### PR TITLE
Optimize NaN-to-Number Comparisons

### DIFF
--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -541,6 +541,14 @@ class JSGenerator {
         case 'op.greater': {
             const left = this.descendInput(node.left);
             const right = this.descendInput(node.right);
+            // When the left operand is a number and the right operand is a number or NaN, we can use >
+            if (left.isAlwaysNumber() && right.isAlwaysNumberOrNaN()) {
+                return new TypedInput(`(${left.asNumber()} > ${right.asNumberOrNaN()})`, TYPE_BOOLEAN);
+            }
+            // When the left operand is a number or NaN and the right operand is a number, we can negate <=
+            if (left.isAlwaysNumberOrNaN() && right.isAlwaysNumber()) {
+                return new TypedInput(`!(${left.asNumberOrNaN()} <= ${right.asNumber()})`, TYPE_BOOLEAN);
+            }
             // When both operands are known to never be numbers, only use string comparison to avoid all number parsing.
             if (left.isNeverNumber() || right.isNeverNumber()) {
                 return new TypedInput(`(${left.asString()}.toLowerCase() > ${right.asString()}.toLowerCase())`, TYPE_BOOLEAN);
@@ -559,11 +567,19 @@ class JSGenerator {
         case 'op.less': {
             const left = this.descendInput(node.left);
             const right = this.descendInput(node.right);
+            // When the left operand is a number or NaN and the right operand is a number, we can use <
+            if (left.isAlwaysNumberOrNaN() && right.isAlwaysNumber()) {
+                return new TypedInput(`(${left.asNumberOrNaN()} < ${right.asNumber()})`, TYPE_BOOLEAN);
+            }
+            // When the left operand is a number and the right operand is a number or NaN, we can negate >=
+            if (left.isAlwaysNumber() && right.isAlwaysNumberOrNaN()) {
+                return new TypedInput(`!(${left.asNumber()} >= ${right.asNumberOrNaN()})`, TYPE_BOOLEAN);
+            }
             // When both operands are known to never be numbers, only use string comparison to avoid all number parsing.
             if (left.isNeverNumber() || right.isNeverNumber()) {
                 return new TypedInput(`(${left.asString()}.toLowerCase() < ${right.asString()}.toLowerCase())`, TYPE_BOOLEAN);
             }
-            // When both operands are known to be numbers, we can use >
+            // When both operands are known to be numbers, we can use <
             if (left.isAlwaysNumber() && right.isAlwaysNumber()) {
                 return new TypedInput(`(${left.asNumber()} < ${right.asNumber()})`, TYPE_BOOLEAN);
             }

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -553,10 +553,6 @@ class JSGenerator {
             if (left.isNeverNumber() || right.isNeverNumber()) {
                 return new TypedInput(`(${left.asString()}.toLowerCase() > ${right.asString()}.toLowerCase())`, TYPE_BOOLEAN);
             }
-            // When both operands are known to be numbers, we can use >
-            if (left.isAlwaysNumber() && right.isAlwaysNumber()) {
-                return new TypedInput(`(${left.asNumber()} > ${right.asNumber()})`, TYPE_BOOLEAN);
-            }
             // No compile-time optimizations possible - use fallback method.
             return new TypedInput(`compareGreaterThan(${left.asUnknown()}, ${right.asUnknown()})`, TYPE_BOOLEAN);
         }
@@ -578,10 +574,6 @@ class JSGenerator {
             // When both operands are known to never be numbers, only use string comparison to avoid all number parsing.
             if (left.isNeverNumber() || right.isNeverNumber()) {
                 return new TypedInput(`(${left.asString()}.toLowerCase() < ${right.asString()}.toLowerCase())`, TYPE_BOOLEAN);
-            }
-            // When both operands are known to be numbers, we can use <
-            if (left.isAlwaysNumber() && right.isAlwaysNumber()) {
-                return new TypedInput(`(${left.asNumber()} < ${right.asNumber()})`, TYPE_BOOLEAN);
             }
             // No compile-time optimizations possible - use fallback method.
             return new TypedInput(`compareLessThan(${left.asUnknown()}, ${right.asUnknown()})`, TYPE_BOOLEAN);


### PR DESCRIPTION
### Resolves

https://github.com/TurboWarp/scratch-vm/issues/72

### Proposed Changes

Optimizes Number-or-NaN to Number comparisons for greater and less than, by removing functions calls and either using operators normally when possible, or negating greater-equal or less-than-equal operators to effectively "switch the sides" that the NaN is on to make the operation remain correct.

### Reason for Changes

When these are not done then the `compareLessThan` and `compareGreaterThan` functions are used when they can be avoided, going to their slow counterparts if the operand in question actually is NaN.

### Test Coverage

Setting a variable to 0 / 0, then comparing it to a variety of values, including itself, and all permutations of constants, along with testing if these results matched up with those when disabling the compiler.