### PR TITLE
Create classes for IR stack blocks and inputs

### DIFF
--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -176,7 +176,7 @@ const ReporterOpcode = {
     SENSING_KEY_DOWN: "keyboard.pressed",
     SENSING_MOUSE_DOWN: "mouse.down",
     SENSING_MOUSE_X: "mouse.x",
-    SENSING_MOUSE_Y: "mosue.y",
+    SENSING_MOUSE_Y: "mouse.y",
     SENSING_OF: "sensing.of",
     SENSING_TIMER_GET: "timer.get",
     SENSING_TOUCHING_COLOR: "sensing.touchingColor",

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -14,7 +14,7 @@ const ValueType = {
     BOOLEAN: 3,
     UNKNOWN: 4,
     NUMBER_OR_NAN: 5,
-}
+};
 
 /**
  * Enum for the opcodes of the stackable blocks used in the IR AST.

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -108,7 +108,7 @@ const BlockOpcode = {
  * @enum {string}
  */
 const ReporterOpcode = {
-    CONSTANT: "contant",
+    CONSTANT: "constant",
 
     LOOKS_BACKDROP_NUMBER: "looks.backdropNumber",
     LOOKS_BACKDROP_NAME: "looks.backdropName",

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -21,7 +21,7 @@ const ValueType = {
  * @readonly
  * @enum {string}
  */
-const BlockOpcode = {
+const StackOpcode = {
     NOP: "noop",
 
     ADDON_CALL: "addons.call",
@@ -107,7 +107,7 @@ const BlockOpcode = {
  * @readonly
  * @enum {string}
  */
-const ReporterOpcode = {
+const InputOpcode = {
     CONSTANT: "constant",
 
     COMPATIBILITY_LAYER: "compat",
@@ -190,7 +190,7 @@ const ReporterOpcode = {
 };
 
 module.exports = {
-    BlockOpcode,
-    ReporterOpcode,
+    StackOpcode,
+    InputOpcode,
     ValueType,
 };

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -1,0 +1,189 @@
+/**
+ * @fileoverview Common enums shared amongst parts of the compiler.
+ */
+
+
+/**
+ * Enum for the type of the value that is returned by reporter blocks and stored in constants.
+ * @readonly
+ * @enum {number}
+ */
+export const ValueType = {
+    NUMBER: 1,
+    STRING: 2,
+    BOOLEAN: 3,
+    UNKNOWN: 4,
+    NUMBER_OR_NAN: 5,
+}
+
+/**
+ * Enum for the opcodes of the stackable blocks used in the IR AST.
+ * @readonly
+ * @enum {string}
+ */
+export const BlockOpcode = {
+    NOP: "noop",
+
+    CONTROL_IF_ELSE: "control.if",
+    CONTROL_CLONE_CREATE: "control.createClone",
+    CONTROL_CLONE_DELETE: "control.deleteClone",
+    CONTROL_WHILE: "control.while",
+    CONTROL_FOR: "control.for",
+    CONTROL_REPEAT: "control.repeat",
+    CONTROL_STOP_ALL: "control.stopAll",
+    CONTROL_STOP_OTHERS: "control.stopOthers",
+    CONTROL_STOP_SCRIPT: "control.stopScript",
+    CONTROL_WAIT: "control.wait",
+    CONTROL_WAIT_UNTIL: "control.waitUntil",
+    CONTROL_WHILE: "control.while",
+
+    LIST_ADD: "list.add",
+    LIST_INSERT: "list.instert",
+    LIST_REPLACE: "list.replace",
+    LIST_DELETE_ALL: "list.deleteAll",
+    LIST_DELETE: "list.delete",
+    LIST_SHOW: "list.show",
+    LIST_HIDE: "list.hide",
+
+    VAR_SET: "var.set",
+    VAR_SHOW: "var.show",
+    VAR_HIDE: "var.hide",
+
+    EVENT_BROADCAST: "event.broadcast",
+    EVENT_BROADCAST_AND_WAIT: "event.broadcastAndWait",
+
+    LOOKS_EFFECT_SET: "looks.setEffect",
+    LOOKS_EFFECT_CHANGE: "looks.changeEffect",
+    LOOKS_EFFECT_CLEAR: "looks.clearEffects",
+    LOOKS_SIZE_CHANGE: "looks.changeSize",
+    LOOKS_SIZE_SET: "looks.setSize",
+    LOOKS_LAYER_FORWARD: "looks.forwardLayers",
+    LOOKS_LAYER_BACKWARD: "looks.backwardLayers",
+    LOOKS_LAYER_FRONT: "looks.goToFront",
+    LOOKS_LAYER_BACK: "looks.goToBack",
+    LOOKS_HIDE: "looks.hide",
+    LOOKS_SHOW: "looks.show",
+    LOOKS_BACKDROP_NEXT: "looks.nextBackdrop",
+    LOOKS_BACKDROP_SET: "looks.switchBackdrop",
+    LOOKS_COSTUME_NEXT: "looks.nextCostume",
+    LOOKS_COSTUME_SET: "looks.switchCostume",
+
+    MOTION_X_SET: "motion.setX",
+    MOTION_X_CHANGE: "motion.changeX",
+    MOTION_Y_SET: "motion.setY",
+    MOTION_Y_CHANGE: "motion.changeY",
+    MOTION_XY_SET: "motion.setXY",
+    MOTION_IF_ON_EDGE_BOUNCE: "motion.ifOnEdgeBounce",
+    MOTION_STEP: "motion.step",
+    MOTION_ROTATION_STYLE_SET: "motion.setRotationStyle",
+    MOTION_DIRECTION_SET: "motion.setDirection",
+
+    PEN_UP: "pen.up",
+    PEN_DOWN: "pen.down",
+    PEN_CLEAR: "pen.clear",
+    PEN_COLOR_PARAM_SET: "pen.setParam",
+    PEN_COLOR_PARAM_CHANGE: "pen.changeParam",
+    PEN_COLOR_HUE_CHANGE_LEGASY: "pen.legacyChangeHue",
+    PEN_COLOR_HUE_SET_LEGASY: "pen_setPenHueToNumber",
+    PEN_COLOR_SHADE_CHANGE_LEGASY: "pen.legacyChangeShade",
+    PEN_COLOR_SHADE_SET_LEGASY: "pen.legacySetShade",
+    PEN_COLOR_SET: "pen.setColor",
+    PEN_SIZE_SET: "pen.setSize",
+    PEN_SIZE_CHANGE: "pen.changeSize",
+    PEN_STAMP: "pen.stamp",
+
+    SENSING_TIMER_RESET: "timer.reset",
+
+    PROCEDURE_CALL: "procedures.call",
+
+    TW_ADDON_CALL: "addons.call",
+    TW_DEBUGGER: "tw.debugger",
+    TW_VISUAL_REPORT: "visualReport",
+    TW_COMPATIBILITY_LAYER: "compat"
+};
+
+/**
+ * Enum for the opcodes of the reporter blocks used in the IR AST.
+ * @readonly
+ * @enum {string}
+ */
+export const ReporterOpcode = {
+    CONSTANT: "contant",
+
+    LOOKS_BACKDROP_NUMBER: "looks.backdropNumber",
+    LOOKS_BACKDROP_NAME: "looks.backdropName",
+    LOOKS_COSTUME_NUMBER: "looks.costumeNumber",
+    LOOKS_COSTUME_NAME: "looks.costumeName",
+    LOOKS_SIZE_GET: "looks.size",
+
+    VAR_GET: "var.get",
+
+    LIST_GET: "list.get",
+    LIST_LENGTH: "list.length",
+    LIST_CONTAINS: "list.contains",
+    LIST_INDEX_OF: "list.indexOf",
+    LIST_CONTENTS: "list.contents",
+
+    MOTION_X_GET: "motion.x",
+    MOTION_Y_GET: "motion.y",
+    MOTION_DIRECTION_GET: "motion.direction",
+
+    OP_ADD: "op.add",
+    OP_AND: "op.and",
+    OP_CONTAINS: "op.contains",
+    OP_DIVIDE: "op.divide",
+    OP_EQUALS: "op.equals",
+    OP_GREATER: "op.greater",
+    OP_LESS: "op.less",
+    OP_JOIN: "op.join",
+    OP_LENGTH: "op.length",
+    OP_LETTER_OF: "op.letterOf",
+    OP_ABS: "op.abs",
+    OP_FLOOR: "op.floor",
+    OP_CEILING: "op.ceiling",
+    OP_SQRT: "op.sqrt",
+    OP_SIN: "op.sin",
+    OP_COS: "op.cos",
+    OP_TAN: "op.tan",
+    OP_ASIN: "op.asin",
+    OP_ACOS: "op.acos",
+    OP_ATAN: "op.atan",
+    OP_LOG_E: "op.ln",
+    OP_LOG_10: "op.log",
+    OP_POW_E: "op.e^",
+    OP_POW_10: "op.10^",
+    OP_MOD: "op.mod",
+    OP_MULTIPLY: "op.multiply",
+    OP_NOT: "op.not",
+    OP_OR: "op.or",
+    OP_RANDOM: "op.random",
+    OP_ROUND: "op.round",
+    OP_SUBTRACT: "op.subtract",
+
+    SENSING_ANSWER: "sensing.answer",
+    SENSING_COLOR_TOUCHING_COLOR: "sensing.colorTouchingColor",
+    SENSING_TIME_YEAR: "sensing.year",
+    SENSING_TIME_MONTH: "sensing.month",
+    SENSING_TIME_DATE: "sensing.date",
+    SENSING_TIME_WEEKDAY: "sensing.dayofweek",
+    SENSING_TIME_HOUR: "sensing.hour",
+    SENSING_TIME_MINUTE: "sensing.minute",
+    SENSING_TIME_SECOND: "sensing.second",
+    SENSING_TIME_DAYS_SINCE_2000: "sensing.daysSince2000",
+    SENSING_DISTANCE: "sensing.distance",
+    SENSING_KEY_DOWN: "keyboard.pressed",
+    SENSING_MOUSE_DOWN: "mouse.down",
+    SENSING_MOUSE_X: "mouse.x",
+    SENSING_MOUSE_Y: "mosue.y",
+    SENSING_OF: "sensing.of",
+    SENSING_TIMER_GET: "timer.get",
+    SENSING_TOUCHING_COLOR: "sensing.touchingColor",
+    SENSING_TOUCHING_OBJECT: "sensing.touching",
+    SENSING_USERNAME: "sensing.username",
+
+    PROCEDURE_ARG_ROUND: "args.stringNumber",
+    PROCEDURE_ARG_BOOLEAN: "args.boolean",
+
+    TW_KEY_LAST_PRESSED: "tw.lastKeyPressed",
+    TW_COMPATIBILITY_LAYER: "compat"
+};

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -8,7 +8,7 @@
  * @readonly
  * @enum {number}
  */
-export const ValueType = {
+const ValueType = {
     NUMBER: 1,
     STRING: 2,
     BOOLEAN: 3,
@@ -21,7 +21,7 @@ export const ValueType = {
  * @readonly
  * @enum {string}
  */
-export const BlockOpcode = {
+const BlockOpcode = {
     NOP: "noop",
 
     CONTROL_IF_ELSE: "control.if",
@@ -107,7 +107,7 @@ export const BlockOpcode = {
  * @readonly
  * @enum {string}
  */
-export const ReporterOpcode = {
+const ReporterOpcode = {
     CONSTANT: "contant",
 
     LOOKS_BACKDROP_NUMBER: "looks.backdropNumber",
@@ -186,4 +186,10 @@ export const ReporterOpcode = {
 
     TW_KEY_LAST_PRESSED: "tw.lastKeyPressed",
     TW_COMPATIBILITY_LAYER: "compat"
+};
+
+module.exports = {
+    BlockOpcode,
+    ReporterOpcode,
+    ValueType,
 };

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -24,6 +24,11 @@ const ValueType = {
 const BlockOpcode = {
     NOP: "noop",
 
+    ADDON_CALL: "addons.call",
+    DEBUGGER: "tw.debugger",
+    VISUAL_REPORT: "visualReport",
+    COMPATIBILITY_LAYER: "compat",
+
     CONTROL_IF_ELSE: "control.if",
     CONTROL_CLONE_CREATE: "control.createClone",
     CONTROL_CLONE_DELETE: "control.deleteClone",
@@ -83,10 +88,10 @@ const BlockOpcode = {
     PEN_CLEAR: "pen.clear",
     PEN_COLOR_PARAM_SET: "pen.setParam",
     PEN_COLOR_PARAM_CHANGE: "pen.changeParam",
-    PEN_COLOR_HUE_CHANGE_LEGASY: "pen.legacyChangeHue",
-    PEN_COLOR_HUE_SET_LEGASY: "pen_setPenHueToNumber",
-    PEN_COLOR_SHADE_CHANGE_LEGASY: "pen.legacyChangeShade",
-    PEN_COLOR_SHADE_SET_LEGASY: "pen.legacySetShade",
+    PEN_COLOR_HUE_CHANGE_LEGACY: "pen.legacyChangeHue",
+    PEN_COLOR_HUE_SET_LEGACY: "pen_setPenHueToNumber",
+    PEN_COLOR_SHADE_CHANGE_LEGACY: "pen.legacyChangeShade",
+    PEN_COLOR_SHADE_SET_LEGACY: "pen.legacySetShade",
     PEN_COLOR_SET: "pen.setColor",
     PEN_SIZE_SET: "pen.setSize",
     PEN_SIZE_CHANGE: "pen.changeSize",
@@ -94,12 +99,7 @@ const BlockOpcode = {
 
     SENSING_TIMER_RESET: "timer.reset",
 
-    PROCEDURE_CALL: "procedures.call",
-
-    TW_ADDON_CALL: "addons.call",
-    TW_DEBUGGER: "tw.debugger",
-    TW_VISUAL_REPORT: "visualReport",
-    TW_COMPATIBILITY_LAYER: "compat"
+    PROCEDURE_CALL: "procedures.call"
 };
 
 /**
@@ -109,6 +109,8 @@ const BlockOpcode = {
  */
 const ReporterOpcode = {
     CONSTANT: "constant",
+
+    COMPATIBILITY_LAYER: "compat",
 
     LOOKS_BACKDROP_NUMBER: "looks.backdropNumber",
     LOOKS_BACKDROP_NAME: "looks.backdropName",
@@ -181,11 +183,10 @@ const ReporterOpcode = {
     SENSING_TOUCHING_OBJECT: "sensing.touching",
     SENSING_USERNAME: "sensing.username",
 
-    PROCEDURE_ARG_ROUND: "args.stringNumber",
+    PROCEDURE_ARG_STRING_NUMBER: "args.stringNumber",
     PROCEDURE_ARG_BOOLEAN: "args.boolean",
 
-    TW_KEY_LAST_PRESSED: "tw.lastKeyPressed",
-    TW_COMPATIBILITY_LAYER: "compat"
+    TW_KEY_LAST_PRESSED: "tw.lastKeyPressed"
 };
 
 module.exports = {

--- a/src/compiler/intermediate.js
+++ b/src/compiler/intermediate.js
@@ -3,11 +3,56 @@
  */
 
 /**
+ * Describes a 'stackable' block (eg. show)
+ */
+ class IntermediateStack {
+    /**
+     * @param {import("./enums").StackOpcode} opcode 
+     * @param {Object} inputs 
+     */
+    constructor(opcode, inputs = {}) {
+        /**
+         * The type of the stackable block.
+         * @type {import("./enums").StackOpcode}
+         */
+        this.opcode = opcode;
+
+        /**
+         * The 
+         * @type {Object} 
+         */
+        this.inputs = inputs;
+    }
+}
+
+/**
+ * Describes an input to a block.
+ * This could be a constant, variable or math operation.
+ */
+class IntermediateInput {
+    /**
+     * @param {import("./enums").InputOpcode} opcode 
+     * @param {Object} inputs 
+     */
+    constructor(opcode, inputs = {}) {
+        /**
+         * @type {import("./enums").InputOpcode}
+         */
+        this.opcode = opcode;
+
+        /**
+         * @type {Object}
+         */
+        this.inputs = inputs;
+    }
+}
+
+/**
  * An IntermediateScript describes a single script.
  * Scripts do not necessarily have hats.
  */
 class IntermediateScript {
-    constructor () {
+    constructor() {
         /**
          * The ID of the top block of this script.
          * @type {string}
@@ -16,7 +61,7 @@ class IntermediateScript {
 
         /**
          * List of nodes that make up this script.
-         * @type {Array|null}
+         * @type {IntermediateStack[]}
          */
         this.stack = null;
 
@@ -76,7 +121,7 @@ class IntermediateScript {
  * An IntermediateRepresentation contains scripts.
  */
 class IntermediateRepresentation {
-    constructor () {
+    constructor() {
         /**
          * The entry point of this IR.
          * @type {IntermediateScript}
@@ -92,6 +137,8 @@ class IntermediateRepresentation {
 }
 
 module.exports = {
+    IntermediateStack,
+    IntermediateInput,
     IntermediateScript,
     IntermediateRepresentation
 };

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -138,7 +138,7 @@ class ScriptTreeGenerator {
         if (!input) {
             log.warn(`IR: ${parentBlock.opcode}: missing input ${inputName}`, parentBlock);
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: 0
             };
         }
@@ -147,7 +147,7 @@ class ScriptTreeGenerator {
         if (!block) {
             log.warn(`IR: ${parentBlock.opcode}: could not find input ${inputName} with ID ${inputId}`);
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: 0
             };
         }

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -202,7 +202,7 @@ class ScriptTreeGenerator {
                 };
             }
             return {
-                kind: ReporterOpcode.PROCEDURE_ARG_ROUND,
+                kind: ReporterOpcode.PROCEDURE_ARG_STRING_NUMBER,
                 index: index
             };
         }
@@ -1112,7 +1112,7 @@ class ScriptTreeGenerator {
             const procedureCode = block.mutation.proccode;
             if (procedureCode === 'tw:debugger;') {
                 return {
-                    kind: BlockOpcode.TW_DEBUGGER
+                    kind: BlockOpcode.DEBUGGER
                 };
             }
             const paramNamesIdsAndDefaults = this.blocks.getProcedureParamNamesIdsAndDefaults(procedureCode);
@@ -1141,7 +1141,7 @@ class ScriptTreeGenerator {
                     args[paramNames[i]] = value;
                 }
                 return {
-                    kind: BlockOpcode.TW_ADDON_CALL,
+                    kind: BlockOpcode.ADDON_CALL,
                     code: procedureCode,
                     arguments: args,
                     blockId: block.id
@@ -1232,7 +1232,7 @@ class ScriptTreeGenerator {
                 try {
                     const inputNode = this.descendInput(block);
                     return {
-                        kind: BlockOpcode.TW_VISUAL_REPORT,
+                        kind: BlockOpcode.VISUAL_REPORT,
                         input: inputNode
                     };
                 } catch (e) {
@@ -1388,7 +1388,7 @@ class ScriptTreeGenerator {
             fields[name] = block.fields[name].value;
         }
         return {
-            kind: BlockOpcode.TW_COMPATIBILITY_LAYER,
+            kind: BlockOpcode.COMPATIBILITY_LAYER,
             opcode: block.opcode,
             inputs,
             fields

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -1054,12 +1054,12 @@ class ScriptTreeGenerator {
             };
         case 'pen_changePenHueBy':
             return {
-                kind: BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGASY,
+                kind: BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGACY,
                 hue: this.descendInputOfBlock(block, 'HUE')
             };
         case 'pen_changePenShadeBy':
             return {
-                kind: BlockOpcode.PEN_COLOR_SHADE_CHANGE_LEGASY,
+                kind: BlockOpcode.PEN_COLOR_SHADE_CHANGE_LEGACY,
                 shade: this.descendInputOfBlock(block, 'SHADE')
             };
         case 'pen_penDown':
@@ -1083,12 +1083,12 @@ class ScriptTreeGenerator {
             };
         case 'pen_setPenHueToNumber':
             return {
-                kind: BlockOpcode.PEN_COLOR_HUE_SET_LEGASY,
+                kind: BlockOpcode.PEN_COLOR_HUE_SET_LEGACY,
                 hue: this.descendInputOfBlock(block, 'HUE')
             };
         case 'pen_setPenShadeToNumber':
             return {
-                kind: BlockOpcode.PEN_COLOR_SHADE_SET_LEGASY,
+                kind: BlockOpcode.PEN_COLOR_SHADE_SET_LEGACY,
                 shade: this.descendInputOfBlock(block, 'SHADE')
             };
         case 'pen_setPenSizeTo':

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -223,7 +223,7 @@ class ScriptTreeGenerator {
                 };
             }
             return {
-                kind: ReporterOpcode.BOOLEAN,
+                kind: ReporterOpcode.PROCEDURE_ARG_BOOLEAN,
                 index: index
             };
         }
@@ -597,7 +597,7 @@ class ScriptTreeGenerator {
             };
         case 'sensing_mousedown':
             return {
-                kind: ReporterOpcode.SENSING_MOUSE_DOWNm
+                kind: ReporterOpcode.SENSING_MOUSE_DOWN,
             };
         case 'sensing_mousex':
             return {
@@ -970,7 +970,7 @@ class ScriptTreeGenerator {
             };
         case 'looks_switchcostumeto':
             return {
-                kind: BlockOpcode.LOOKS_COSTUME_NEXT,
+                kind: BlockOpcode.LOOKS_COSTUME_SET,
                 costume: this.descendInputOfBlock(block, 'COSTUME')
             };
 

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -5,6 +5,7 @@ const Variable = require('../engine/variable');
 const log = require('../util/log');
 const {IntermediateScript, IntermediateRepresentation} = require('./intermediate');
 const compatBlocks = require('./compat-blocks');
+const {BlockOpcode, ReporterOpcode} = require('./enums.js')
 
 /**
  * @fileoverview Generate intermediate representations from Scratch blocks.
@@ -164,7 +165,7 @@ class ScriptTreeGenerator {
         switch (block.opcode) {
         case 'colour_picker':
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: block.fields.COLOUR.value
             };
         case 'math_angle':
@@ -173,12 +174,12 @@ class ScriptTreeGenerator {
         case 'math_positive_number':
         case 'math_whole_number':
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: block.fields.NUM.value
             };
         case 'text':
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: block.fields.TEXT.value
             };
 
@@ -190,18 +191,18 @@ class ScriptTreeGenerator {
                 // Legacy support
                 if (name.toLowerCase() === 'last key pressed') {
                     return {
-                        kind: 'tw.lastKeyPressed'
+                        kind: ReporterOpcode.TW_KEY_LAST_PRESSED,
                     };
                 }
             }
             if (index === -1) {
                 return {
-                    kind: 'constant',
+                    kind: ReporterOpcode.CONSTANT,
                     value: 0
                 };
             }
             return {
-                kind: 'args.stringNumber',
+                kind: ReporterOpcode.PROCEDURE_ARG_ROUND,
                 index: index
             };
         }
@@ -212,52 +213,52 @@ class ScriptTreeGenerator {
             if (index === -1) {
                 if (name.toLowerCase() === 'is compiled?' || name.toLowerCase() === 'is turbowarp?') {
                     return {
-                        kind: 'constant',
+                        kind: ReporterOpcode.CONSTANT,
                         value: true
                     };
                 }
                 return {
-                    kind: 'constant',
+                    kind: ReporterOpcode.CONSTANT,
                     value: 0
                 };
             }
             return {
-                kind: 'args.boolean',
+                kind: ReporterOpcode.BOOLEAN,
                 index: index
             };
         }
 
         case 'data_variable':
             return {
-                kind: 'var.get',
+                kind: ReporterOpcode.VAR_GET,
                 variable: this.descendVariable(block, 'VARIABLE', SCALAR_TYPE)
             };
         case 'data_itemoflist':
             return {
-                kind: 'list.get',
+                kind: ReporterOpcode.LIST_GET,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 index: this.descendInputOfBlock(block, 'INDEX')
             };
         case 'data_lengthoflist':
             return {
-                kind: 'list.length',
+                kind: ReporterOpcode.LIST_LENGTH,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE)
             };
         case 'data_listcontainsitem':
             return {
-                kind: 'list.contains',
+                kind: ReporterOpcode.LIST_CONTAINS,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 item: this.descendInputOfBlock(block, 'ITEM')
             };
         case 'data_itemnumoflist':
             return {
-                kind: 'list.indexOf',
+                kind: ReporterOpcode.LIST_INDEX_OF,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 item: this.descendInputOfBlock(block, 'ITEM')
             };
         case 'data_listcontents':
             return {
-                kind: 'list.contents',
+                kind: ReporterOpcode.LIST_CONTENTS,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE)
             };
 
@@ -267,7 +268,7 @@ class ScriptTreeGenerator {
             // TODO: empty string probably isn't the correct fallback
             const broadcastName = broadcastVariable ? broadcastVariable.name : '';
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: broadcastName
             };
         }
@@ -275,95 +276,95 @@ class ScriptTreeGenerator {
         case 'looks_backdropnumbername':
             if (block.fields.NUMBER_NAME.value === 'number') {
                 return {
-                    kind: 'looks.backdropNumber'
+                    kind: ReporterOpcode.LOOKS_BACKDROP_NUMBER
                 };
             }
             return {
-                kind: 'looks.backdropName'
+                kind: ReporterOpcode.LOOKS_BACKDROP_NAME
             };
         case 'looks_costumenumbername':
             if (block.fields.NUMBER_NAME.value === 'number') {
                 return {
-                    kind: 'looks.costumeNumber'
+                    kind: ReporterOpcode.LOOKS_COSTUME_NUMBER
                 };
             }
             return {
-                kind: 'looks.costumeName'
+                kind: ReporterOpcode.LOOKS_COSTUME_NAME
             };
         case 'looks_size':
             return {
-                kind: 'looks.size'
+                kind: ReporterOpcode.LOOKS_SIZE_GET,
             };
 
         case 'motion_direction':
             return {
-                kind: 'motion.direction'
+                kind: ReporterOpcode.MOTION_DIRECTION_GET,
             };
         case 'motion_xposition':
             return {
-                kind: 'motion.x'
+                kind: ReporterOpcode.MOTION_X_GET,
             };
         case 'motion_yposition':
             return {
-                kind: 'motion.y'
+                kind: ReporterOpcode.MOTION_Y_GET,
             };
 
         case 'operator_add':
             return {
-                kind: 'op.add',
+                kind: ReporterOpcode.OP_ADD,
                 left: this.descendInputOfBlock(block, 'NUM1'),
                 right: this.descendInputOfBlock(block, 'NUM2')
             };
         case 'operator_and':
             return {
-                kind: 'op.and',
+                kind: ReporterOpcode.OP_AND,
                 left: this.descendInputOfBlock(block, 'OPERAND1'),
                 right: this.descendInputOfBlock(block, 'OPERAND2')
             };
         case 'operator_contains':
             return {
-                kind: 'op.contains',
+                kind: ReporterOpcode.OP_CONTAINS,
                 string: this.descendInputOfBlock(block, 'STRING1'),
                 contains: this.descendInputOfBlock(block, 'STRING2')
             };
         case 'operator_divide':
             return {
-                kind: 'op.divide',
+                kind: ReporterOpcode.OP_DIVIDE,
                 left: this.descendInputOfBlock(block, 'NUM1'),
                 right: this.descendInputOfBlock(block, 'NUM2')
             };
         case 'operator_equals':
             return {
-                kind: 'op.equals',
+                kind: ReporterOpcode.OP_EQUALS,
                 left: this.descendInputOfBlock(block, 'OPERAND1'),
                 right: this.descendInputOfBlock(block, 'OPERAND2')
             };
         case 'operator_gt':
             return {
-                kind: 'op.greater',
+                kind: ReporterOpcode.OP_GREATER,
                 left: this.descendInputOfBlock(block, 'OPERAND1'),
                 right: this.descendInputOfBlock(block, 'OPERAND2')
             };
         case 'operator_join':
             return {
-                kind: 'op.join',
+                kind: ReporterOpcode.OP_JOIN,
                 left: this.descendInputOfBlock(block, 'STRING1'),
                 right: this.descendInputOfBlock(block, 'STRING2')
             };
         case 'operator_length':
             return {
-                kind: 'op.length',
+                kind: ReporterOpcode.OP_LENGTH,
                 string: this.descendInputOfBlock(block, 'STRING')
             };
         case 'operator_letter_of':
             return {
-                kind: 'op.letterOf',
+                kind: ReporterOpcode.OP_LETTER_OF,
                 letter: this.descendInputOfBlock(block, 'LETTER'),
                 string: this.descendInputOfBlock(block, 'STRING')
             };
         case 'operator_lt':
             return {
-                kind: 'op.less',
+                kind: ReporterOpcode.OP_LESS,
                 left: this.descendInputOfBlock(block, 'OPERAND1'),
                 right: this.descendInputOfBlock(block, 'OPERAND2')
             };
@@ -372,87 +373,87 @@ class ScriptTreeGenerator {
             const operator = block.fields.OPERATOR.value.toLowerCase();
             switch (operator) {
             case 'abs': return {
-                kind: 'op.abs',
+                kind: ReporterOpcode.OP_ABS,
                 value
             };
             case 'floor': return {
-                kind: 'op.floor',
+                kind: ReporterOpcode.OP_FLOOR,
                 value
             };
             case 'ceiling': return {
-                kind: 'op.ceiling',
+                kind: ReporterOpcode.OP_CEILING,
                 value
             };
             case 'sqrt': return {
-                kind: 'op.sqrt',
+                kind: ReporterOpcode.OP_SQRT,
                 value
             };
             case 'sin': return {
-                kind: 'op.sin',
+                kind: ReporterOpcode.OP_SIN,
                 value
             };
             case 'cos': return {
-                kind: 'op.cos',
+                kind: ReporterOpcode.OP_COS,
                 value
             };
             case 'tan': return {
-                kind: 'op.tan',
+                kind: ReporterOpcode.OP_TAN,
                 value
             };
             case 'asin': return {
-                kind: 'op.asin',
+                kind: ReporterOpcode.OP_ASIN,
                 value
             };
             case 'acos': return {
-                kind: 'op.acos',
+                kind: ReporterOpcode.OP_ACOS,
                 value
             };
             case 'atan': return {
-                kind: 'op.atan',
+                kind: ReporterOpcode.OP_ATAN,
                 value
             };
             case 'ln': return {
-                kind: 'op.ln',
+                kind: ReporterOpcode.OP_LOG_E,
                 value
             };
             case 'log': return {
-                kind: 'op.log',
+                kind: ReporterOpcode.OP_LOG_10,
                 value
             };
             case 'e ^': return {
-                kind: 'op.e^',
+                kind: ReporterOpcode.OP_POW_E,
                 value
             };
             case '10 ^': return {
-                kind: 'op.10^',
+                kind: ReporterOpcode.OP_POW_10,
                 value
             };
             default: return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: 0
             };
             }
         }
         case 'operator_mod':
             return {
-                kind: 'op.mod',
+                kind: ReporterOpcode.OP_MOD,
                 left: this.descendInputOfBlock(block, 'NUM1'),
                 right: this.descendInputOfBlock(block, 'NUM2')
             };
         case 'operator_multiply':
             return {
-                kind: 'op.multiply',
+                kind: ReporterOpcode.OP_MULTIPLY,
                 left: this.descendInputOfBlock(block, 'NUM1'),
                 right: this.descendInputOfBlock(block, 'NUM2')
             };
         case 'operator_not':
             return {
-                kind: 'op.not',
+                kind: ReporterOpcode.OP_NOT,
                 operand: this.descendInputOfBlock(block, 'OPERAND')
             };
         case 'operator_or':
             return {
-                kind: 'op.or',
+                kind: ReporterOpcode.OP_OR,
                 left: this.descendInputOfBlock(block, 'OPERAND1'),
                 right: this.descendInputOfBlock(block, 'OPERAND2')
             };
@@ -461,7 +462,7 @@ class ScriptTreeGenerator {
             const to = this.descendInputOfBlock(block, 'TO');
             // If both values are known at compile time, we can do some optimizations.
             // TODO: move optimizations to jsgen?
-            if (from.kind === 'constant' && to.kind === 'constant') {
+            if (from.kind === ReporterOpcode.CONSTANT && to.kind === ReporterOpcode.CONSTANT) {
                 const sFrom = from.value;
                 const sTo = to.value;
                 const nFrom = Cast.toNumber(sFrom);
@@ -470,14 +471,14 @@ class ScriptTreeGenerator {
                 // todo: this probably never happens so consider removing
                 if (nFrom === nTo) {
                     return {
-                        kind: 'constant',
+                        kind: ReporterOpcode.CONSTANT,
                         value: nFrom
                     };
                 }
                 // If both are ints, hint this to the compiler
                 if (Cast.isInt(sFrom) && Cast.isInt(sTo)) {
                     return {
-                        kind: 'op.random',
+                        kind: ReporterOpcode.OP_RANDOM,
                         low: nFrom <= nTo ? from : to,
                         high: nFrom <= nTo ? to : from,
                         useInts: true,
@@ -486,27 +487,27 @@ class ScriptTreeGenerator {
                 }
                 // Otherwise hint that these are floats
                 return {
-                    kind: 'op.random',
+                    kind: ReporterOpcode.OP_RANDOM,
                     low: nFrom <= nTo ? from : to,
                     high: nFrom <= nTo ? to : from,
                     useInts: false,
                     useFloats: true
                 };
-            } else if (from.kind === 'constant') {
+            } else if (from.kind === ReporterOpcode.CONSTANT) {
                 // If only one value is known at compile-time, we can still attempt some optimizations.
                 if (!Cast.isInt(Cast.toNumber(from.value))) {
                     return {
-                        kind: 'op.random',
+                        kind: ReporterOpcode.OP_RANDOM,
                         low: from,
                         high: to,
                         useInts: false,
                         useFloats: true
                     };
                 }
-            } else if (to.kind === 'constant') {
+            } else if (to.kind === ReporterOpcode.CONSTANT) {
                 if (!Cast.isInt(Cast.toNumber(to.value))) {
                     return {
-                        kind: 'op.random',
+                        kind: ReporterOpcode.OP_RANDOM,
                         low: from,
                         high: to,
                         useInts: false,
@@ -516,7 +517,7 @@ class ScriptTreeGenerator {
             }
             // No optimizations possible
             return {
-                kind: 'op.random',
+                kind: ReporterOpcode.OP_RANDOM,
                 low: from,
                 high: to,
                 useInts: false,
@@ -525,23 +526,23 @@ class ScriptTreeGenerator {
         }
         case 'operator_round':
             return {
-                kind: 'op.round',
+                kind: ReporterOpcode.OP_ROUND,
                 value: this.descendInputOfBlock(block, 'NUM')
             };
         case 'operator_subtract':
             return {
-                kind: 'op.subtract',
+                kind: ReporterOpcode.OP_SUBTRACT,
                 left: this.descendInputOfBlock(block, 'NUM1'),
                 right: this.descendInputOfBlock(block, 'NUM2')
             };
 
         case 'sensing_answer':
             return {
-                kind: 'sensing.answer'
+                kind: ReporterOpcode.SENSING_ANSWER,
             };
         case 'sensing_coloristouchingcolor':
             return {
-                kind: 'sensing.colorTouchingColor',
+                kind: ReporterOpcode.SENSING_COLOR_TOUCHING_COLOR,
                 target: this.descendInputOfBlock(block, 'COLOR2'),
                 mask: this.descendInputOfBlock(block, 'COLOR')
             };
@@ -549,99 +550,99 @@ class ScriptTreeGenerator {
             switch (block.fields.CURRENTMENU.value.toLowerCase()) {
             case 'year':
                 return {
-                    kind: 'sensing.year'
+                    kind: ReporterOpcode.SENSING_TIME_YEAR,
                 };
             case 'month':
                 return {
-                    kind: 'sensing.month'
+                    kind: ReporterOpcode.SENSING_TIME_MONTH,
                 };
             case 'date':
                 return {
-                    kind: 'sensing.date'
+                    kind: ReporterOpcode.SENSING_TIME_DATE,
                 };
             case 'dayofweek':
                 return {
-                    kind: 'sensing.dayofweek'
+                    kind: ReporterOpcode.SENSING_TIME_WEEKDAY,
                 };
             case 'hour':
                 return {
-                    kind: 'sensing.hour'
+                    kind: ReporterOpcode.SENSING_TIME_HOUR,
                 };
             case 'minute':
                 return {
-                    kind: 'sensing.minute'
+                    kind: ReporterOpcode.SENSING_TIME_MINUTE,
                 };
             case 'second':
                 return {
-                    kind: 'sensing.second'
+                    kind: ReporterOpcode.SENSING_TIME_SECOND,
                 };
             }
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: 0
             };
         case 'sensing_dayssince2000':
             return {
-                kind: 'sensing.daysSince2000'
+                kind: ReporterOpcode.SENSING_TIME_DAYS_SINCE_2000,
             };
         case 'sensing_distanceto':
             return {
-                kind: 'sensing.distance',
+                kind: ReporterOpcode.SENSING_DISTANCE,
                 target: this.descendInputOfBlock(block, 'DISTANCETOMENU')
             };
         case 'sensing_keypressed':
             return {
-                kind: 'keyboard.pressed',
+                kind: ReporterOpcode.SENSING_KEY_DOWN,
                 key: this.descendInputOfBlock(block, 'KEY_OPTION')
             };
         case 'sensing_mousedown':
             return {
-                kind: 'mouse.down'
+                kind: ReporterOpcode.SENSING_MOUSE_DOWNm
             };
         case 'sensing_mousex':
             return {
-                kind: 'mouse.x'
+                kind: ReporterOpcode.SENSING_MOUSE_X,
             };
         case 'sensing_mousey':
             return {
-                kind: 'mouse.y'
+                kind: ReporterOpcode.SENSING_MOUSE_Y,
             };
         case 'sensing_of':
             return {
-                kind: 'sensing.of',
+                kind: ReporterOpcode.SENSING_OF,
                 property: block.fields.PROPERTY.value,
                 object: this.descendInputOfBlock(block, 'OBJECT')
             };
         case 'sensing_timer':
             this.usesTimer = true;
             return {
-                kind: 'timer.get'
+                kind: ReporterOpcode.SENSING_TIMER_GET,
             };
         case 'sensing_touchingcolor':
             return {
-                kind: 'sensing.touchingColor',
+                kind: ReporterOpcode.SENSING_TOUCHING_COLOR,
                 color: this.descendInputOfBlock(block, 'COLOR')
             };
         case 'sensing_touchingobject':
             return {
-                kind: 'sensing.touching',
+                kind: ReporterOpcode.SENSING_TOUCHING_OBJECT,
                 object: this.descendInputOfBlock(block, 'TOUCHINGOBJECTMENU')
             };
         case 'sensing_username':
             return {
-                kind: 'sensing.username'
+                kind: ReporterOpcode.SENSING_USERNAME,
             };
 
         case 'sound_sounds_menu':
             // This menu is special compared to other menus -- it actually has an opcode function.
             return {
-                kind: 'constant',
+                kind: ReporterOpcode.CONSTANT,
                 value: block.fields.SOUND_MENU.value
             };
 
         case 'tw_getLastKeyPressed':
             return {
-                kind: 'tw.lastKeyPressed'
+                kind: ReporterOpcode.TW_KEY_LAST_PRESSED,
             };
 
         default: {
@@ -666,7 +667,7 @@ class ScriptTreeGenerator {
             const fields = Object.keys(block.fields);
             if (inputs.length === 0 && fields.length === 1) {
                 return {
-                    kind: 'constant',
+                    kind: ReporterOpcode.CONSTANT,
                     value: block.fields[fields[0]].value
                 };
             }
@@ -688,9 +689,9 @@ class ScriptTreeGenerator {
         case 'control_all_at_once':
             // In Scratch 3, this block behaves like "if 1 = 1"
             return {
-                kind: 'control.if',
+                kind: BlockOpcode.CONTROL_IF_ELSE,
                 condition: {
-                    kind: 'constant',
+                    kind: ReporterOpcode.CONSTANT,
                     value: true
                 },
                 whenTrue: this.descendSubstack(block, 'SUBSTACK'),
@@ -698,20 +699,20 @@ class ScriptTreeGenerator {
             };
         case 'control_create_clone_of':
             return {
-                kind: 'control.createClone',
+                kind: BlockOpcode.CONTROL_CLONE_CREATE,
                 target: this.descendInputOfBlock(block, 'CLONE_OPTION')
             };
         case 'control_delete_this_clone':
             this.script.yields = true;
             return {
-                kind: 'control.deleteClone'
+                kind: BlockOpcode.CONTROL_CLONE_DELETE
             };
         case 'control_forever':
             this.analyzeLoop();
             return {
-                kind: 'control.while',
+                kind: BlockOpcode.CONTROL_WHILE,
                 condition: {
-                    kind: 'constant',
+                    kind: ReporterOpcode.CONSTANT,
                     value: true
                 },
                 do: this.descendSubstack(block, 'SUBSTACK')
@@ -719,21 +720,21 @@ class ScriptTreeGenerator {
         case 'control_for_each':
             this.analyzeLoop();
             return {
-                kind: 'control.for',
+                kind: BlockOpcode.CONTROL_FOR,
                 variable: this.descendVariable(block, 'VARIABLE', SCALAR_TYPE),
                 count: this.descendInputOfBlock(block, 'VALUE'),
                 do: this.descendSubstack(block, 'SUBSTACK')
             };
         case 'control_if':
             return {
-                kind: 'control.if',
+                kind: BlockOpcode.CONTROL_IF_ELSE,
                 condition: this.descendInputOfBlock(block, 'CONDITION'),
                 whenTrue: this.descendSubstack(block, 'SUBSTACK'),
                 whenFalse: []
             };
         case 'control_if_else':
             return {
-                kind: 'control.if',
+                kind: BlockOpcode.CONTROL_IF_ELSE,
                 condition: this.descendInputOfBlock(block, 'CONDITION'),
                 whenTrue: this.descendSubstack(block, 'SUBSTACK'),
                 whenFalse: this.descendSubstack(block, 'SUBSTACK2')
@@ -741,7 +742,7 @@ class ScriptTreeGenerator {
         case 'control_repeat':
             this.analyzeLoop();
             return {
-                kind: 'control.repeat',
+                kind: BlockOpcode.CONTROL_REPEAT,
                 times: this.descendInputOfBlock(block, 'TIMES'),
                 do: this.descendSubstack(block, 'SUBSTACK')
             };
@@ -756,9 +757,9 @@ class ScriptTreeGenerator {
                 this.script.yields = true;
             }
             return {
-                kind: 'control.while',
+                kind: BlockOpcode.CONTROL_WHILE,
                 condition: {
-                    kind: 'op.not',
+                    kind: ReporterOpcode.OP_NOT,
                     operand: condition
                 },
                 do: this.descendSubstack(block, 'SUBSTACK'),
@@ -770,37 +771,37 @@ class ScriptTreeGenerator {
             if (level === 'all') {
                 this.script.yields = true;
                 return {
-                    kind: 'control.stopAll'
+                    kind: BlockOpcode.CONTROL_STOP_ALL
                 };
             } else if (level === 'other scripts in sprite' || level === 'other scripts in stage') {
                 return {
-                    kind: 'control.stopOthers'
+                    kind: BlockOpcode.CONTROL_STOP_OTHERS
                 };
             } else if (level === 'this script') {
                 return {
-                    kind: 'control.stopScript'
+                    kind: BlockOpcode.CONTROL_STOP_SCRIPT
                 };
             }
             return {
-                kind: 'noop'
+                kind: BlockOpcode.NOP
             };
         }
         case 'control_wait':
             this.script.yields = true;
             return {
-                kind: 'control.wait',
+                kind: BlockOpcode.CONTROL_WAIT,
                 seconds: this.descendInputOfBlock(block, 'DURATION')
             };
         case 'control_wait_until':
             this.script.yields = true;
             return {
-                kind: 'control.waitUntil',
+                kind: BlockOpcode.CONTROL_WAIT_UNTIL,
                 condition: this.descendInputOfBlock(block, 'CONDITION')
             };
         case 'control_while':
             this.analyzeLoop();
             return {
-                kind: 'control.while',
+                kind: BlockOpcode.CONTROL_WHILE,
                 condition: this.descendInputOfBlock(block, 'CONDITION'),
                 do: this.descendSubstack(block, 'SUBSTACK'),
                 // We should consider analyzing this like we do for control_repeat_until
@@ -809,19 +810,19 @@ class ScriptTreeGenerator {
 
         case 'data_addtolist':
             return {
-                kind: 'list.add',
+                kind: BlockOpcode.LIST_ADD,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 item: this.descendInputOfBlock(block, 'ITEM')
             };
         case 'data_changevariableby': {
             const variable = this.descendVariable(block, 'VARIABLE', SCALAR_TYPE);
             return {
-                kind: 'var.set',
+                kind: BlockOpcode.VAR_SET,
                 variable,
                 value: {
-                    kind: 'op.add',
+                    kind: ReporterOpcode.OP_ADD,
                     left: {
-                        kind: 'var.get',
+                        kind: ReporterOpcode.VAR_GET,
                         variable
                     },
                     right: this.descendInputOfBlock(block, 'VALUE')
@@ -830,212 +831,212 @@ class ScriptTreeGenerator {
         }
         case 'data_deletealloflist':
             return {
-                kind: 'list.deleteAll',
+                kind: BlockOpcode.LIST_DELETE_ALL,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE)
             };
         case 'data_deleteoflist': {
             const index = this.descendInputOfBlock(block, 'INDEX');
-            if (index.kind === 'constant' && index.value === 'all') {
+            if (index.kind === ReporterOpcode.CONSTANT && index.value === 'all') {
                 return {
-                    kind: 'list.deleteAll',
+                    kind: BlockOpcode.LIST_DELETE_ALL,
                     list: this.descendVariable(block, 'LIST', LIST_TYPE)
                 };
             }
             return {
-                kind: 'list.delete',
+                kind: BlockOpcode.LIST_DELETE,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 index: index
             };
         }
         case 'data_hidelist':
             return {
-                kind: 'list.hide',
+                kind: BlockOpcode.LIST_HIDE,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE)
             };
         case 'data_hidevariable':
             return {
-                kind: 'var.hide',
+                kind: BlockOpcode.VAR_HIDE,
                 variable: this.descendVariable(block, 'VARIABLE', SCALAR_TYPE)
             };
         case 'data_insertatlist':
             return {
-                kind: 'list.insert',
+                kind: BlockOpcode.LIST_INSERT,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 index: this.descendInputOfBlock(block, 'INDEX'),
                 item: this.descendInputOfBlock(block, 'ITEM')
             };
         case 'data_replaceitemoflist':
             return {
-                kind: 'list.replace',
+                kind: BlockOpcode.LIST_REPLACE,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE),
                 index: this.descendInputOfBlock(block, 'INDEX'),
                 item: this.descendInputOfBlock(block, 'ITEM')
             };
         case 'data_setvariableto':
             return {
-                kind: 'var.set',
+                kind: BlockOpcode.VAR_SET,
                 variable: this.descendVariable(block, 'VARIABLE', SCALAR_TYPE),
                 value: this.descendInputOfBlock(block, 'VALUE')
             };
         case 'data_showlist':
             return {
-                kind: 'list.show',
+                kind: BlockOpcode.LIST_SHOW,
                 list: this.descendVariable(block, 'LIST', LIST_TYPE)
             };
         case 'data_showvariable':
             return {
-                kind: 'var.show',
+                kind: BlockOpcode.VAR_SHOW,
                 variable: this.descendVariable(block, 'VARIABLE', SCALAR_TYPE)
             };
 
         case 'event_broadcast':
             return {
-                kind: 'event.broadcast',
+                kind: BlockOpcode.EVENT_BROADCAST,
                 broadcast: this.descendInputOfBlock(block, 'BROADCAST_INPUT')
             };
         case 'event_broadcastandwait':
             this.script.yields = true;
             return {
-                kind: 'event.broadcastAndWait',
+                kind: BlockOpcode.EVENT_BROADCAST_AND_WAIT,
                 broadcast: this.descendInputOfBlock(block, 'BROADCAST_INPUT')
             };
 
         case 'looks_changeeffectby':
             return {
-                kind: 'looks.changeEffect',
+                kind: BlockOpcode.LOOKS_EFFECT_CHANGE,
                 effect: block.fields.EFFECT.value.toLowerCase(),
                 value: this.descendInputOfBlock(block, 'CHANGE')
             };
         case 'looks_changesizeby':
             return {
-                kind: 'looks.changeSize',
+                kind: BlockOpcode.LOOKS_SIZE_CHANGE,
                 size: this.descendInputOfBlock(block, 'CHANGE')
             };
         case 'looks_cleargraphiceffects':
             return {
-                kind: 'looks.clearEffects'
+                kind: BlockOpcode.LOOKS_EFFECT_CLEAR,
             };
         case 'looks_goforwardbackwardlayers':
             if (block.fields.FORWARD_BACKWARD.value === 'forward') {
                 return {
-                    kind: 'looks.forwardLayers',
+                    kind: BlockOpcode.LOOKS_LAYER_FORWARD,
                     layers: this.descendInputOfBlock(block, 'NUM')
                 };
             }
             return {
-                kind: 'looks.backwardLayers',
+                kind: BlockOpcode.LOOKS_LAYER_BACKWARD,
                 layers: this.descendInputOfBlock(block, 'NUM')
             };
         case 'looks_gotofrontback':
             if (block.fields.FRONT_BACK.value === 'front') {
                 return {
-                    kind: 'looks.goToFront'
+                    kind: BlockOpcode.LOOKS_LAYER_FRONT
                 };
             }
             return {
-                kind: 'looks.goToBack'
+                kind: BlockOpcode.LOOKS_LAYER_BACK
             };
         case 'looks_hide':
             return {
-                kind: 'looks.hide'
+                kind: BlockOpcode.LOOKS_HIDE
             };
         case 'looks_nextbackdrop':
             return {
-                kind: 'looks.nextBackdrop'
+                kind: BlockOpcode.LOOKS_BACKDROP_NEXT
             };
         case 'looks_nextcostume':
             return {
-                kind: 'looks.nextCostume'
+                kind: BlockOpcode.LOOKS_COSTUME_NEXT
             };
         case 'looks_seteffectto':
             return {
-                kind: 'looks.setEffect',
+                kind: BlockOpcode.LOOKS_EFFECT_SET,
                 effect: block.fields.EFFECT.value.toLowerCase(),
                 value: this.descendInputOfBlock(block, 'VALUE')
             };
         case 'looks_setsizeto':
             return {
-                kind: 'looks.setSize',
+                kind: BlockOpcode.LOOKS_SIZE_SET,
                 size: this.descendInputOfBlock(block, 'SIZE')
             };
         case 'looks_show':
             return {
-                kind: 'looks.show'
+                kind: BlockOpcode.LOOKS_SHOW
             };
         case 'looks_switchbackdropto':
             return {
-                kind: 'looks.switchBackdrop',
+                kind: BlockOpcode.LOOKS_BACKDROP_SET,
                 backdrop: this.descendInputOfBlock(block, 'BACKDROP')
             };
         case 'looks_switchcostumeto':
             return {
-                kind: 'looks.switchCostume',
+                kind: BlockOpcode.LOOKS_COSTUME_NEXT,
                 costume: this.descendInputOfBlock(block, 'COSTUME')
             };
 
         case 'motion_changexby':
             return {
-                kind: 'motion.changeX',
+                kind: BlockOpcode.MOTION_X_CHANGE,
                 dx: this.descendInputOfBlock(block, 'DX')
             };
         case 'motion_changeyby':
             return {
-                kind: 'motion.changeY',
+                kind: BlockOpcode.MOTION_Y_CHANGE,
                 dy: this.descendInputOfBlock(block, 'DY')
             };
         case 'motion_gotoxy':
             return {
-                kind: 'motion.setXY',
+                kind: BlockOpcode.MOTION_XY_SET,
                 x: this.descendInputOfBlock(block, 'X'),
                 y: this.descendInputOfBlock(block, 'Y')
             };
         case 'motion_ifonedgebounce':
             return {
-                kind: 'motion.ifOnEdgeBounce'
+                kind: BlockOpcode.MOTION_IF_ON_EDGE_BOUNCE,
             };
         case 'motion_movesteps':
             return {
-                kind: 'motion.step',
+                kind: BlockOpcode.MOTION_STEP,
                 steps: this.descendInputOfBlock(block, 'STEPS')
             };
         case 'motion_pointindirection':
             return {
-                kind: 'motion.setDirection',
+                kind: BlockOpcode.MOTION_DIRECTION_SET,
                 direction: this.descendInputOfBlock(block, 'DIRECTION')
             };
         case 'motion_setrotationstyle':
             return {
-                kind: 'motion.setRotationStyle',
+                kind: BlockOpcode.MOTION_ROTATION_STYLE_SET,
                 style: block.fields.STYLE.value
             };
         case 'motion_setx':
             return {
-                kind: 'motion.setX',
+                kind: BlockOpcode.MOTION_X_SET,
                 x: this.descendInputOfBlock(block, 'X')
             };
         case 'motion_sety':
             return {
-                kind: 'motion.setY',
+                kind: BlockOpcode.MOTION_Y_SET,
                 y: this.descendInputOfBlock(block, 'Y')
             };
         case 'motion_turnleft':
             return {
-                kind: 'motion.setDirection',
+                kind: BlockOpcode.MOTION_DIRECTION_SET,
                 direction: {
-                    kind: 'op.subtract',
+                    kind: ReporterOpcode.OP_SUBTRACT,
                     left: {
-                        kind: 'motion.direction'
+                        kind: ReporterOpcode.MOTION_DIRECTION_GET,
                     },
                     right: this.descendInputOfBlock(block, 'DEGREES')
                 }
             };
         case 'motion_turnright':
             return {
-                kind: 'motion.setDirection',
+                kind: BlockOpcode.MOTION_DIRECTION_SET,
                 direction: {
-                    kind: 'op.add',
+                    kind: ReporterOpcode.OP_ADD,
                     left: {
-                        kind: 'motion.direction'
+                        kind: ReporterOpcode.MOTION_DIRECTION_GET,
                     },
                     right: this.descendInputOfBlock(block, 'DEGREES')
                 }
@@ -1043,66 +1044,66 @@ class ScriptTreeGenerator {
 
         case 'pen_clear':
             return {
-                kind: 'pen.clear'
+                kind: BlockOpcode.PEN_CLEAR
             };
         case 'pen_changePenColorParamBy':
             return {
-                kind: 'pen.changeParam',
+                kind: BlockOpcode.PEN_COLOR_PARAM_CHANGE,
                 param: this.descendInputOfBlock(block, 'COLOR_PARAM'),
                 value: this.descendInputOfBlock(block, 'VALUE')
             };
         case 'pen_changePenHueBy':
             return {
-                kind: 'pen.legacyChangeHue',
+                kind: BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGASY,
                 hue: this.descendInputOfBlock(block, 'HUE')
             };
         case 'pen_changePenShadeBy':
             return {
-                kind: 'pen.legacyChangeShade',
+                kind: BlockOpcode.PEN_COLOR_SHADE_CHANGE_LEGASY,
                 shade: this.descendInputOfBlock(block, 'SHADE')
             };
         case 'pen_penDown':
             return {
-                kind: 'pen.down'
+                kind: BlockOpcode.PEN_DOWN
             };
         case 'pen_penUp':
             return {
-                kind: 'pen.up'
+                kind: BlockOpcode.PEN_UP
             };
         case 'pen_setPenColorParamTo':
             return {
-                kind: 'pen.setParam',
+                kind: BlockOpcode.PEN_COLOR_PARAM_SET,
                 param: this.descendInputOfBlock(block, 'COLOR_PARAM'),
                 value: this.descendInputOfBlock(block, 'VALUE')
             };
         case 'pen_setPenColorToColor':
             return {
-                kind: 'pen.setColor',
+                kind: BlockOpcode.PEN_COLOR_SET,
                 color: this.descendInputOfBlock(block, 'COLOR')
             };
         case 'pen_setPenHueToNumber':
             return {
-                kind: 'pen.legacySetHue',
+                kind: BlockOpcode.PEN_COLOR_HUE_SET_LEGASY,
                 hue: this.descendInputOfBlock(block, 'HUE')
             };
         case 'pen_setPenShadeToNumber':
             return {
-                kind: 'pen.legacySetShade',
+                kind: BlockOpcode.PEN_COLOR_SHADE_SET_LEGASY,
                 shade: this.descendInputOfBlock(block, 'SHADE')
             };
         case 'pen_setPenSizeTo':
             return {
-                kind: 'pen.setSize',
+                kind: BlockOpcode.PEN_SIZE_SET,
                 size: this.descendInputOfBlock(block, 'SIZE')
             };
         case 'pen_changePenSizeBy':
             return {
-                kind: 'pen.changeSize',
+                kind: BlockOpcode.PEN_SIZE_CHANGE,
                 size: this.descendInputOfBlock(block, 'SIZE')
             };
         case 'pen_stamp':
             return {
-                kind: 'pen.stamp'
+                kind: BlockOpcode.PEN_STAMP
             };
 
         case 'procedures_call': {
@@ -1111,13 +1112,13 @@ class ScriptTreeGenerator {
             const procedureCode = block.mutation.proccode;
             if (procedureCode === 'tw:debugger;') {
                 return {
-                    kind: 'tw.debugger'
+                    kind: BlockOpcode.TW_DEBUGGER
                 };
             }
             const paramNamesIdsAndDefaults = this.blocks.getProcedureParamNamesIdsAndDefaults(procedureCode);
             if (paramNamesIdsAndDefaults === null) {
                 return {
-                    kind: 'noop'
+                    kind: BlockOpcode.NOP
                 };
             }
 
@@ -1133,14 +1134,14 @@ class ScriptTreeGenerator {
                         value = this.descendInputOfBlock(block, paramIds[i]);
                     } else {
                         value = {
-                            kind: 'constant',
+                            kind: ReporterOpcode.CONSTANT,
                             value: paramDefaults[i]
                         };
                     }
                     args[paramNames[i]] = value;
                 }
                 return {
-                    kind: 'addons.call',
+                    kind: BlockOpcode.TW_ADDON_CALL,
                     code: procedureCode,
                     arguments: args,
                     blockId: block.id
@@ -1151,7 +1152,7 @@ class ScriptTreeGenerator {
             const definitionBlock = this.blocks.getBlock(definitionId);
             if (!definitionBlock) {
                 return {
-                    kind: 'noop'
+                    kind: BlockOpcode.NOP
                 };
             }
             const innerDefinition = this.blocks.getBlock(definitionBlock.inputs.custom_block.block);
@@ -1188,7 +1189,7 @@ class ScriptTreeGenerator {
                     value = this.descendInputOfBlock(block, paramIds[i]);
                 } else {
                     value = {
-                        kind: 'constant',
+                        kind: ReporterOpcode.CONSTANT,
                         value: paramDefaults[i]
                     };
                 }
@@ -1196,7 +1197,7 @@ class ScriptTreeGenerator {
             }
 
             return {
-                kind: 'procedures.call',
+                kind: BlockOpcode.PROCEDURE_CALL,
                 code: procedureCode,
                 variant,
                 arguments: args
@@ -1205,7 +1206,7 @@ class ScriptTreeGenerator {
 
         case 'sensing_resettimer':
             return {
-                kind: 'timer.reset'
+                kind: BlockOpcode.SENSING_TIMER_RESET
             };
 
         default: {
@@ -1231,7 +1232,7 @@ class ScriptTreeGenerator {
                 try {
                     const inputNode = this.descendInput(block);
                     return {
-                        kind: 'visualReport',
+                        kind: BlockOpcode.TW_VISUAL_REPORT,
                         input: inputNode
                     };
                 } catch (e) {
@@ -1387,7 +1388,7 @@ class ScriptTreeGenerator {
             fields[name] = block.fields[name].value;
         }
         return {
-            kind: 'compat',
+            kind: BlockOpcode.TW_COMPATIBILITY_LAYER,
             opcode: block.opcode,
             inputs,
             fields

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -425,10 +425,10 @@ class JSGenerator {
         switch (node.kind) {
         case ReporterOpcode.PROCEDURE_ARG_BOOLEAN:
             return new TypedInput(`toBoolean(p${node.index})`, ValueType.BOOLEAN);
-        case ReporterOpcode.PROCEDURE_ARG_ROUND:
+        case ReporterOpcode.PROCEDURE_ARG_STRING_NUMBER:
             return new TypedInput(`p${node.index}`, ValueType.UNKNOWN);
 
-        case ReporterOpcode.TW_COMPATIBILITY_LAYER:
+        case ReporterOpcode.COMPATIBILITY_LAYER:
             // Compatibility layer inputs never use flags.
             return new TypedInput(`(${this.generateCompatibilityLayerCall(node, false)})`, ValueType.UNKNOWN);
 
@@ -707,7 +707,7 @@ class JSGenerator {
      */
     descendStackedBlock (node) {
         switch (node.kind) {
-        case BlockOpcode.TW_ADDON_CALL: {
+        case BlockOpcode.ADDON_CALL: {
             const inputs = this.descendInputRecord(node.arguments);
             const blockFunction = `runtime.getAddonBlock("${sanitize(node.code)}").callback`;
             const blockId = `"${sanitize(node.blockId)}"`;
@@ -715,7 +715,7 @@ class JSGenerator {
             break;
         }
 
-        case BlockOpcode.TW_COMPATIBILITY_LAYER: {
+        case BlockOpcode.COMPATIBILITY_LAYER: {
             // If the last command in a loop returns a promise, immediately continue to the next iteration.
             // If you don't do this, the loop effectively yields twice per iteration and will run at half-speed.
             const isLastInLoop = this.isLastBlockInLoop();
@@ -1044,7 +1044,7 @@ class JSGenerator {
             this.source += 'runtime.ioDevices.clock.resetProjectTimer();\n';
             break;
 
-        case BlockOpcode.TW_DEBUGGER:
+        case BlockOpcode.DEBUGGER:
             this.source += 'debugger;\n';
             break;
 
@@ -1065,7 +1065,7 @@ class JSGenerator {
             this.source += `runtime.monitorBlocks.changeBlock({ id: "${sanitize(node.variable.id)}", element: "checkbox", value: true }, runtime);\n`;
             break;
 
-        case BlockOpcode.TW_VISUAL_REPORT: {
+        case BlockOpcode.VISUAL_REPORT: {
             const value = this.localVariables.next();
             this.source += `const ${value} = ${this.descendInput(node.input).asUnknown()};`;
             // blocks like legacy no-ops can return a literal `undefined`

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -979,16 +979,16 @@ class JSGenerator {
         case BlockOpcode.PEN_SIZE_CHANGE:
             this.source += `${PEN_EXT}._changePenSizeBy(${this.descendInput(node.size).asNumber()}, target);\n`;
             break;
-        case BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGASY:
+        case BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGACY:
             this.source += `${PEN_EXT}._changePenHueBy(${this.descendInput(node.hue).asNumber()}, target);\n`;
             break;
-        case BlockOpcode.PEN_COLOR_SHADE_CHANGE_LEGASY:
+        case BlockOpcode.PEN_COLOR_SHADE_CHANGE_LEGACY:
             this.source += `${PEN_EXT}._changePenShadeBy(${this.descendInput(node.shade).asNumber()}, target);\n`;
             break;
-        case BlockOpcode.PEN_COLOR_HUE_SET_LEGASY:
+        case BlockOpcode.PEN_COLOR_HUE_SET_LEGACY:
             this.source += `${PEN_EXT}._setPenHueToNumber(${this.descendInput(node.hue).asNumber()}, target);\n`;
             break;
-        case BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGASY:
+        case BlockOpcode.PEN_COLOR_HUE_CHANGE_LEGACY:
             this.source += `${PEN_EXT}._setPenShadeToNumber(${this.descendInput(node.shade).asNumber()}, target);\n`;
             break;
         case BlockOpcode.PEN_COLOR_SET:


### PR DESCRIPTION
Creates two new classes `IntermediateStack` and `IntermediateInput` to replace `Node`. Right now these two classes almost the same, they contain an opcode and an object of inputs that contains all the values the `Node` type used to contain (other than `kind`). 

In the next PR type information will be attached to `IntermediateInput` (so it can replace jsgen's `TypedInput`, `VariableInput` and `ConstantInput`) and eventually more complex type analysis info will be attached to `IntermediateStack` so they should be two separate classes.

Additionally, renamed the enums to `StackOpcode` and `InputOpcode` to better reflect their purpose.