### PR TITLE
Implement compiler output snapshot testing

### DIFF
--- a/snapshot-tests/__snapshots__/order-library-reverse.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/order-library-reverse.sb3.tw-snapshot
@@ -1,0 +1,83 @@
+// TW Snapshot
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-order"];
+const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
+const b2 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+b0.value = 0;
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+b0.value = ((+b0.value || 0) + 1);
+if (((b0.value || 0) === 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, null);
+} else {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 1 != " + ("" + b0.value)),}, b2, false, false, null);
+}
+retire();
+}; })
+
+// Sprite3 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, null);
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+thread.timer = timer();
+var a1 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a1) {
+yield;
+}
+thread.timer = null;
+thread.timer = timer();
+var a2 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a2) {
+yield;
+}
+thread.timer = null;
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-order"];
+const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
+const b2 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+b0.value = 0;
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+b0.value = ((+b0.value || 0) + 1);
+if (((b0.value || 0) === 2)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, null);
+} else {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 2 != " + ("" + b0.value)),}, b2, false, false, null);
+}
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/order-library.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/order-library.sb3.tw-snapshot
@@ -1,0 +1,83 @@
+// TW Snapshot
+
+// Sprite3 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, null);
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+thread.timer = timer();
+var a1 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a1) {
+yield;
+}
+thread.timer = null;
+thread.timer = timer();
+var a2 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a2) {
+yield;
+}
+thread.timer = null;
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-order"];
+const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
+const b2 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+b0.value = 0;
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+b0.value = ((+b0.value || 0) + 1);
+if (((b0.value || 0) === 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, null);
+} else {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 1 != " + ("" + b0.value)),}, b2, false, false, null);
+}
+retire();
+}; })
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-order"];
+const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
+const b2 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+b0.value = 0;
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * (+b1.value || 0));
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+b0.value = ((+b0.value || 0) + 1);
+if (((b0.value || 0) === 2)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, null);
+} else {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 2 != " + ("" + b0.value)),}, b2, false, false, null);
+}
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-NaN.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-NaN.sb3.tw-snapshot
@@ -1,0 +1,58 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 16",}, b0, false, false, null);
+if ((("" + (0 * Infinity)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual((((0 * Infinity) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + ((Math.acos(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual(((((Math.acos(1.01) * 180) / Math.PI) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + ((Math.asin(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual(((((Math.asin(1.01) * 180) / Math.PI) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + (0 / 0)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual((((0 / 0) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + Math.sqrt(-1)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual(((Math.sqrt(-1) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual(((mod(0, 0) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual(((Math.log(-1) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + (Math.log(-1) / Math.LN10)).toLowerCase() === "NaN".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual((((Math.log(-1) / Math.LN10) || 0) * 1), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-add-can-return-nan.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-add-can-return-nan.sb3.tw-snapshot
@@ -1,0 +1,13 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+if (!((Infinity + -Infinity) <= 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-all-at-once.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-all-at-once.sb3.tw-snapshot
@@ -1,0 +1,13 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+if (true) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-broadcast-id-and-name-desync.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-broadcast-id-and-name-desync.sb3.tw-snapshot
@@ -1,0 +1,19 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" }));
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
@@ -1,0 +1,21 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+target.setSize(96);
+b1.value = 0;
+while (!(100 === Math.round(target.size))) {
+b1.value = ((+b1.value || 0) + 1);
+target.setSize(target.size + ((((100 - Math.round(target.size)) || 0) / 10) || 0));
+yield;
+}
+if (((+b1.value || 0) === 20)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-color-input-returns-hex.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-color-input-returns-hex.sb3.tw-snapshot
@@ -1,0 +1,15 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+b1.value = "#22388a";
+if ((("" + b1.value).toLowerCase() === "#22388a".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-comparison-matrix-inline.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-comparison-matrix-inline.sb3.tw-snapshot
@@ -1,0 +1,1774 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, null);
+if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 1: 0 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 2: 0 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 3: 0 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 4: 0 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 5: 0 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 6: 0 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 7: 0 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 8: 0 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 9: 0 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 10: 0 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 11: 0 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 12: 0 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 13: 0 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 14: 0 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 15: 0 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 16: 0 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (0 === -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 17: 0 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (0 > -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 18: 0 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (0 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 19: 0 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 20: 0 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (0 > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 21: 0 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 22: 0 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 23: 0 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 24: 0 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 25: 0 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 26: 0 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 27: 0 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 28: 0 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 29: 0 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 30: 0 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 31: 0 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 32: 0 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 33: 0 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 34: 0 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 35: 0 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 36: 0 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 37: 0 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 38: 0 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 39: 0 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan(0, "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 40: 0 should be < ",}, b0, false, false, null);
+}
+if (!(("" + compareEqual(0, "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 41: 0 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan(0, "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 42: 0 should be > ",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 43: 0.0 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 44: 0.0 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 45: 0.0 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 46: 0.0 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 47: 0.0 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 48: 0.0 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 49: 0.0 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 50: 0.0 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 51: 0.0 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 52: 0.0 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 53: 0.0 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 54: 0.0 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 55: 0.0 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 56: 0.0 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 57: 0.0 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 58: 0.0 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (0 === -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 59: 0.0 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (0 > -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 60: 0.0 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (0 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 61: 0.0 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 62: 0.0 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (0 > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 63: 0.0 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 64: 0.0 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 65: 0.0 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 66: 0.0 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 67: 0.0 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 68: 0.0 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 69: 0.0 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 70: 0.0 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 71: 0.0 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 72: 0.0 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 73: 0.0 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 74: 0.0 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 75: 0.0 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 76: 0.0 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 77: 0.0 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 78: 0.0 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 79: 0.0 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 80: 0.0 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("0.0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 81: 0.0 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("0.0", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 82: 0.0 should be < ",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("0.0", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 83: 0.0 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("0.0", "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 84: 0.0 should be > ",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 85: 1.23 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 86: 1.23 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 87: 1.23 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 88: 1.23 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 89: 1.23 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 90: 1.23 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 91: 1.23 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 92: 1.23 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 93: 1.23 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 94: 1.23 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 95: 1.23 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 96: 1.23 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 97: 1.23 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 98: 1.23 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 99: 1.23 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 100: 1.23 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 101: 1.23 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 102: 1.23 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 103: 1.23 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 104: 1.23 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 105: 1.23 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 106: 1.23 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 107: 1.23 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 108: 1.23 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 109: 1.23 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 110: 1.23 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 111: 1.23 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 112: 1.23 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 113: 1.23 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 114: 1.23 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (1.23 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 115: 1.23 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 116: 1.23 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (1.23 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 117: 1.23 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 118: 1.23 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 119: 1.23 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 120: 1.23 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 121: 1.23 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 122: 1.23 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("1.23".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 123: 1.23 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan(1.23, "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 124: 1.23 should be < ",}, b0, false, false, null);
+}
+if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 125: 1.23 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan(1.23, "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 126: 1.23 should be > ",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 127: .23 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 128: .23 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 129: .23 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 130: .23 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 131: .23 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 132: .23 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 133: .23 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 134: .23 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 135: .23 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 136: .23 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 137: .23 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 138: .23 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 139: .23 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 140: .23 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 141: .23 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 142: .23 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 143: .23 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 144: .23 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 145: .23 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 146: .23 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 147: .23 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 148: .23 should be < true",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 149: .23 should be = true",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 150: .23 should be > true",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 151: .23 should be < false",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 152: .23 should be = false",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 153: .23 should be > false",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 154: .23 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 155: .23 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 156: .23 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (0.23 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 157: .23 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0.23 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 158: .23 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0.23 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 159: .23 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 160: .23 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 161: .23 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 162: .23 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 163: .23 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 164: .23 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + (".23".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 165: .23 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan(".23", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 166: .23 should be < ",}, b0, false, false, null);
+}
+if (!(("" + compareEqual(".23", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 167: .23 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan(".23", "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 168: .23 should be > ",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 169: 0.123 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 170: 0.123 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 171: 0.123 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 172: 0.123 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 173: 0.123 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 174: 0.123 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 175: 0.123 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 176: 0.123 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 177: 0.123 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 178: 0.123 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 179: 0.123 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 180: 0.123 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 181: 0.123 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 182: 0.123 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 183: 0.123 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 184: 0.123 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 185: 0.123 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 186: 0.123 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 187: 0.123 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 188: 0.123 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 189: 0.123 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 190: 0.123 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 191: 0.123 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 192: 0.123 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 193: 0.123 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 194: 0.123 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 195: 0.123 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 196: 0.123 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 197: 0.123 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 198: 0.123 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (0.123 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 199: 0.123 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 200: 0.123 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0.123 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 201: 0.123 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 202: 0.123 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 203: 0.123 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 204: 0.123 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 205: 0.123 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 206: 0.123 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("0.123".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 207: 0.123 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan(0.123, "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 208: 0.123 should be < ",}, b0, false, false, null);
+}
+if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 209: 0.123 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan(0.123, "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 210: 0.123 should be > ",}, b0, false, false, null);
+}
+if (!(("" + (-0 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 211: -0 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (-0 === 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 212: -0 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (-0 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 213: -0 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (-0 < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 214: -0 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (-0 === 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 215: -0 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (-0 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 216: -0 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (-0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 217: -0 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (-0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 218: -0 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (-0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 219: -0 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (-0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 220: -0 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (-0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 221: -0 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (-0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 222: -0 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (-0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 223: -0 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (-0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 224: -0 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (-0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 225: -0 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (-0 < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 226: -0 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (-0 === -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 227: -0 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (-0 > -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 228: -0 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (-0 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 229: -0 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (-0 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 230: -0 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (-0 > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 231: -0 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 232: -0 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 233: -0 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 234: -0 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 235: -0 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 236: -0 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 237: -0 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 238: -0 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 239: -0 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 240: -0 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (-0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 241: -0 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (-0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 242: -0 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (-0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 243: -0 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 244: -0 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 245: -0 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 246: -0 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 247: -0 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 248: -0 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("-0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 249: -0 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("-0", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 250: -0 should be < ",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("-0", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 251: -0 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("-0", "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 252: -0 should be > ",}, b0, false, false, null);
+}
+if (!(("" + (-1 < 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 253: -1 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 254: -1 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (-1 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 255: -1 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (-1 < 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 256: -1 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 257: -1 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (-1 > 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 258: -1 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (-1 < 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 259: -1 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (-1 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 260: -1 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (-1 > 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 261: -1 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (-1 < 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 262: -1 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (-1 === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 263: -1 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (-1 > 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 264: -1 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (-1 < 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 265: -1 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (-1 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 266: -1 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (-1 > 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 267: -1 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (-1 < -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 268: -1 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (-1 === -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 269: -1 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (-1 > -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 270: -1 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (-1 < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 271: -1 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (-1 === -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 272: -1 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (-1 > -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 273: -1 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 274: -1 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 275: -1 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 276: -1 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 277: -1 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 278: -1 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 279: -1 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 280: -1 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 281: -1 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 282: -1 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (-1 < Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 283: -1 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (-1 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 284: -1 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (-1 > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 285: -1 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 286: -1 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 287: -1 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 288: -1 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 289: -1 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 290: -1 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("-1".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 291: -1 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan(-1, "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 292: -1 should be < ",}, b0, false, false, null);
+}
+if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 293: -1 should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan(-1, "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 294: -1 should be > ",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 295: true should be < 0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 296: true should be = 0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 297: true should be > 0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 298: true should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 299: true should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 300: true should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 301: true should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 302: true should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 303: true should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 304: true should be < .23",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 305: true should be = .23",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 306: true should be > .23",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 307: true should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 308: true should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 309: true should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 310: true should be < -0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 311: true should be = -0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 312: true should be > -0",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 313: true should be < -1",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 314: true should be = -1",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 315: true should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 316: true should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 317: true should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 318: true should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 319: true should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 320: true should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 321: true should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 322: true should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 323: true should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 324: true should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 325: true should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 326: true should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 327: true should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 328: true should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 329: true should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 330: true should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 331: true should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 332: true should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 333: true should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 334: true should be < ",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 335: true should be = ",}, b0, false, false, null);
+}
+if (!(("" + ("true".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 336: true should be > ",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 337: false should be < 0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 338: false should be = 0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 339: false should be > 0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 340: false should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 341: false should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 342: false should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 343: false should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 344: false should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 345: false should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 346: false should be < .23",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 347: false should be = .23",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 348: false should be > .23",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 349: false should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 350: false should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 351: false should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 352: false should be < -0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 353: false should be = -0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 354: false should be > -0",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 355: false should be < -1",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 356: false should be = -1",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 357: false should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 358: false should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 359: false should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 360: false should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 361: false should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 362: false should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 363: false should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 364: false should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 365: false should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 366: false should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 367: false should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 368: false should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 369: false should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 370: false should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 371: false should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 372: false should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 373: false should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 374: false should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 375: false should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 376: false should be < ",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 377: false should be = ",}, b0, false, false, null);
+}
+if (!(("" + ("false".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 378: false should be > ",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 379: NaN should be < 0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 380: NaN should be = 0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 381: NaN should be > 0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 382: NaN should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 383: NaN should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 384: NaN should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 385: NaN should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 386: NaN should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 387: NaN should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 388: NaN should be < .23",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 389: NaN should be = .23",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 390: NaN should be > .23",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 391: NaN should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 392: NaN should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 393: NaN should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 394: NaN should be < -0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 395: NaN should be = -0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 396: NaN should be > -0",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 397: NaN should be < -1",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 398: NaN should be = -1",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 399: NaN should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 400: NaN should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 401: NaN should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 402: NaN should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 403: NaN should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 404: NaN should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 405: NaN should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 406: NaN should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 407: NaN should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 408: NaN should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 409: NaN should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 410: NaN should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 411: NaN should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 412: NaN should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 413: NaN should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 414: NaN should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 415: NaN should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 416: NaN should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 417: NaN should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 418: NaN should be < ",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 419: NaN should be = ",}, b0, false, false, null);
+}
+if (!(("" + ("NaN".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 420: NaN should be > ",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 421: Infinity should be < 0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 422: Infinity should be = 0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 423: Infinity should be > 0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 424: Infinity should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 425: Infinity should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 426: Infinity should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 427: Infinity should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 428: Infinity should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 429: Infinity should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 430: Infinity should be < .23",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === 0.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 431: Infinity should be = .23",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > 0.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 432: Infinity should be > .23",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 433: Infinity should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 434: Infinity should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 435: Infinity should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 436: Infinity should be < -0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === -0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 437: Infinity should be = -0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > -0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 438: Infinity should be > -0",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 439: Infinity should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 440: Infinity should be = -1",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 441: Infinity should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 442: Infinity should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 443: Infinity should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 444: Infinity should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 445: Infinity should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 446: Infinity should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 447: Infinity should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 448: Infinity should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 449: Infinity should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 450: Infinity should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + (Infinity < Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 451: Infinity should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 452: Infinity should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + (Infinity > Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 453: Infinity should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 454: Infinity should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 455: Infinity should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 456: Infinity should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 457: Infinity should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 458: Infinity should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("Infinity".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 459: Infinity should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan(Infinity, "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 460: Infinity should be < ",}, b0, false, false, null);
+}
+if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 461: Infinity should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan(Infinity, "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 462: Infinity should be > ",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 463: banana should be < 0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 464: banana should be = 0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 465: banana should be > 0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 466: banana should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 467: banana should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 468: banana should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 469: banana should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 470: banana should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 471: banana should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 472: banana should be < .23",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 473: banana should be = .23",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 474: banana should be > .23",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 475: banana should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 476: banana should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 477: banana should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 478: banana should be < -0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 479: banana should be = -0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 480: banana should be > -0",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 481: banana should be < -1",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 482: banana should be = -1",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 483: banana should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 484: banana should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 485: banana should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 486: banana should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 487: banana should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 488: banana should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 489: banana should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 490: banana should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 491: banana should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 492: banana should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 493: banana should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 494: banana should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 495: banana should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 496: banana should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 497: banana should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 498: banana should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 499: banana should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 500: banana should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 501: banana should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 502: banana should be < ",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 503: banana should be = ",}, b0, false, false, null);
+}
+if (!(("" + ("banana".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 504: banana should be > ",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 505: 🎉 should be < 0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 506: 🎉 should be = 0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 507: 🎉 should be > 0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 508: 🎉 should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 509: 🎉 should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 510: 🎉 should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 511: 🎉 should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 512: 🎉 should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 513: 🎉 should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 514: 🎉 should be < .23",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 515: 🎉 should be = .23",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 516: 🎉 should be > .23",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 517: 🎉 should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 518: 🎉 should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 519: 🎉 should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 520: 🎉 should be < -0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 521: 🎉 should be = -0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 522: 🎉 should be > -0",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 523: 🎉 should be < -1",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 524: 🎉 should be = -1",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 525: 🎉 should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 526: 🎉 should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 527: 🎉 should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 528: 🎉 should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 529: 🎉 should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 530: 🎉 should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 531: 🎉 should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 532: 🎉 should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 533: 🎉 should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 534: 🎉 should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 535: 🎉 should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 536: 🎉 should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 537: 🎉 should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 538: 🎉 should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 539: 🎉 should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 540: 🎉 should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 541: 🎉 should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 542: 🎉 should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 543: 🎉 should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 544: 🎉 should be < ",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 545: 🎉 should be = ",}, b0, false, false, null);
+}
+if (!(("" + ("🎉".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 546: 🎉 should be > ",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", 0)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 547:  should be < 0",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("", 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 548:  should be = 0",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", 0)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 549:  should be > 0",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", "0.0")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 550:  should be < 0.0",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("", "0.0")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 551:  should be = 0.0",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", "0.0")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 552:  should be > 0.0",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", 1.23)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 553:  should be < 1.23",}, b0, false, false, null);
+}
+if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 554:  should be = 1.23",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", 1.23)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 555:  should be > 1.23",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", ".23")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 556:  should be < .23",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("", ".23")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 557:  should be = .23",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", ".23")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 558:  should be > .23",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", 0.123)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 559:  should be < 0.123",}, b0, false, false, null);
+}
+if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 560:  should be = 0.123",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", 0.123)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 561:  should be > 0.123",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", "-0")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 562:  should be < -0",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("", "-0")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 563:  should be = -0",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", "-0")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 564:  should be > -0",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", -1)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 565:  should be < -1",}, b0, false, false, null);
+}
+if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 566:  should be = -1",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", -1)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 567:  should be > -1",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 568:  should be < true",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 569:  should be = true",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 570:  should be > true",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 571:  should be < false",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 572:  should be = false",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 573:  should be > false",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 574:  should be < NaN",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 575:  should be = NaN",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 576:  should be > NaN",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", Infinity)).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 577:  should be < Infinity",}, b0, false, false, null);
+}
+if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 578:  should be = Infinity",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", Infinity)).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 579:  should be > Infinity",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 580:  should be < banana",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 581:  should be = banana",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 582:  should be > banana",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 583:  should be < 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 584:  should be = 🎉",}, b0, false, false, null);
+}
+if (!(("" + ("".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 585:  should be > 🎉",}, b0, false, false, null);
+}
+if (!(("" + compareLessThan("", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 586:  should be < ",}, b0, false, false, null);
+}
+if (!(("" + compareEqual("", "")).toLowerCase() === "true".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 587:  should be = ",}, b0, false, false, null);
+}
+if (!(("" + compareGreaterThan("", "")).toLowerCase() === "false".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail 588:  should be > ",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-comparison-matrix-runtime.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-comparison-matrix-runtime.sb3.tw-snapshot
@@ -1,0 +1,128 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, null);
+yield* thread.procedures["Wrun test"]();
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 run test
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["mfV;yS}9e:%h5UZ)QyiY"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b2 = stage.variables["n^wm8jw#b24sggt.S^tD"];
+const b3 = stage.variables["_]6^lq+-%H0{ov`tKt7$"];
+const b4 = stage.variables["3lyKRepBc$tx)EWlpr!y"];
+const b5 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ_run_test () {
+thread.procedures["Wsetup values"]();
+b0.value = 0;
+b1.value = 0;
+for (var a0 = b2.value.length; a0 >= 0.5; a0--) {
+b1.value = ((+b1.value || 0) + 1);
+b3.value = 0;
+for (var a1 = b2.value.length; a1 >= 0.5; a1--) {
+b3.value = ((+b3.value || 0) + 1);
+b0.value = ((+b0.value || 0) + 1);
+if (!compareEqual(compareGreaterThan(listGet(b2.value, b1.value), (b2.value[((b3.value || 0) | 0) - 1] ?? "")), (b4.value[((b0.value || 0) | 0) - 1] ?? ""))) {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be > " + ("" + listGet(b2.value, b3.value))))),}, b5, true, false, null);
+}
+b0.value = ((+b0.value || 0) + 1);
+if (!compareEqual(compareEqual(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[((b0.value || 0) | 0) - 1] ?? ""))) {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be = " + ("" + listGet(b2.value, b3.value))))),}, b5, true, false, null);
+}
+b0.value = ((+b0.value || 0) + 1);
+if (!compareEqual(compareLessThan(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[((b0.value || 0) | 0) - 1] ?? ""))) {
+yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be < " + ("" + listGet(b2.value, b3.value))))),}, b5, true, true, null);
+if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+}
+}
+}
+}; })
+
+// Sprite1 setup values
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["n^wm8jw#b24sggt.S^tD"];
+return function funXYZ_setup_values () {
+b0.value = [];
+b0.value.push(0);
+b0._monitorUpToDate = false;
+b0.value.push(1);
+b0._monitorUpToDate = false;
+b0.value.push(2);
+b0._monitorUpToDate = false;
+b0.value.push(-1);
+b0._monitorUpToDate = false;
+b0.value.push(-2);
+b0._monitorUpToDate = false;
+b0.value.push("0.0");
+b0._monitorUpToDate = false;
+b0.value.push("-0.");
+b0._monitorUpToDate = false;
+b0.value.push("-0.0");
+b0._monitorUpToDate = false;
+b0.value.push(".123");
+b0._monitorUpToDate = false;
+b0.value.push("-.123");
+b0._monitorUpToDate = false;
+b0.value.push("1.");
+b0._monitorUpToDate = false;
+b0.value.push((0 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((1 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((2 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((-1 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((-2 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((0.123 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((-0.123 + 0));
+b0._monitorUpToDate = false;
+b0.value.push((1 + 0));
+b0._monitorUpToDate = false;
+b0.value.push("1e99");
+b0._monitorUpToDate = false;
+b0.value.push((1e+99 + 0));
+b0._monitorUpToDate = false;
+b0.value.push(Infinity);
+b0._monitorUpToDate = false;
+b0.value.push(-Infinity);
+b0._monitorUpToDate = false;
+b0.value.push("-infinitY");
+b0._monitorUpToDate = false;
+b0.value.push((1 / 0));
+b0._monitorUpToDate = false;
+b0.value.push((-1 / 0));
+b0._monitorUpToDate = false;
+b0.value.push((0 / 0));
+b0._monitorUpToDate = false;
+b0.value.push(NaN);
+b0._monitorUpToDate = false;
+b0.value.push("nan");
+b0._monitorUpToDate = false;
+b0.value.push("-NaN");
+b0._monitorUpToDate = false;
+b0.value.push("true");
+b0._monitorUpToDate = false;
+b0.value.push("false");
+b0._monitorUpToDate = false;
+b0.value.push(!false);
+b0._monitorUpToDate = false;
+b0.value.push(!!false);
+b0._monitorUpToDate = false;
+b0.value.push("");
+b0._monitorUpToDate = false;
+b0.value.push("Banana");
+b0._monitorUpToDate = false;
+b0.value.push(" ");
+b0._monitorUpToDate = false;
+b0.value.push("🎉");
+b0._monitorUpToDate = false;
+}; })

--- a/snapshot-tests/__snapshots__/tw-coordinate-precision.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-coordinate-precision.sb3.tw-snapshot
@@ -1,0 +1,35 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = runtime.getSpriteTargetByName("Sprite1");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, null);
+target.setXY(1e-9, target.y);
+if ((limitPrecision(target.x) === 1e-9)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass much above x does not round",}, b0, false, false, null);
+}
+if (((b1 ? b1.x : 0) === 1e-9)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass initial 'of' test",}, b0, false, false, null);
+}
+target.setXY(target.x + 0, target.y);
+runtime.ext_scratch3_motion._moveSteps(0, target);
+target.setXY(target.x + -9e-10, target.y);
+if (((b1 ? b1.x : 0) === 1.0000000000000007e-10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 'of' never rounds - positive x",}, b0, false, false, null);
+}
+if ((limitPrecision(target.x) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass x slightly above 0 rounds",}, b0, false, false, null);
+}
+target.setXY(target.x + -9e-10, target.y);
+target.setXY(target.x, target.y + 0);
+if (((b1 ? b1.x : 0) === -7.999999999999999e-10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 'of' never rounds and change x - negative x",}, b0, false, false, null);
+}
+if ((limitPrecision(target.x) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass x slightly below 0 rounds",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-forkphorus-515-boolean-number-comparison.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-forkphorus-515-boolean-number-comparison.sb3.tw-snapshot
@@ -1,0 +1,22 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 4",}, b0, false, false, null);
+if (compareGreaterThan(("something".toLowerCase() === "something".toLowerCase()), ("0" + ""))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareLessThan(("something".toLowerCase() === "else".toLowerCase()), ("1" + ""))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareGreaterThan(("something".toLowerCase() === "something".toLowerCase()), (0 + 0))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareLessThan(("something".toLowerCase() === "else".toLowerCase()), (1 + 0))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
@@ -1,0 +1,27 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = runtime.getOpcodeFunction("motion_pointtowards");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 4",}, b0, false, false, null);
+target.setDirection(95);
+if ((target.direction === 95)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 1",}, b0, false, false, null);
+}
+target.setDirection(((1 / 0) || 0));
+if ((target.direction === 95)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, null);
+}
+target.setDirection(((0 / 0) || 0));
+if ((target.direction === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"TOWARDS":"Sprite2",}, b1, false, false, null);
+if ((target.direction === 90)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-forkphorus-515-random-with-invalid-number-with-period.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-forkphorus-515-random-with-invalid-number-with-period.sb3.tw-snapshot
@@ -1,0 +1,31 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, null);
+b1.value = runtime.ext_scratch3_operators._random(("an invalid number" + "."), 1);
+if ((b1.value > 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareLessThan(b1.value, 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + b1.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+b1.value = runtime.ext_scratch3_operators._random(1, ("an invalid number" + "."));
+if ((b1.value > 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareLessThan(b1.value, 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if ((("" + b1.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
@@ -1,0 +1,22 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = target.variables["gTtSj;o_E;Snkn620KF."];
+const b2 = target.variables["zShM`!CD?d_|Z,]5X}N6"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, null);
+b1.value = 2;
+if (((+b1.value || 0) === 2)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass variable",}, b0, false, false, null);
+}
+b2.value = [];
+b2.value.push(3);
+b2._monitorUpToDate = false;
+if (((+(b2.value[(1 | 0) - 1] ?? "") || 0) === 3)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass list",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
@@ -1,0 +1,76 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("sound_setvolumeto");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b2 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"VOLUME":0,}, b0, false, false, null);
+b1.value = 0;
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b2, false, false, null);
+yield* thread.procedures["Wno refresh"]();
+yield* thread.procedures["Wruns below with no refresh"]();
+if (compareEqual(b1.value, 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, null);
+runtime.stopAll();
+retire(); return;
+retire();
+}; })
+
+// Sprite1 no refresh
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("music_restForBeats");
+const b1 = runtime.getOpcodeFunction("music_playDrumForBeats");
+return function* genXYZ_no_refresh () {
+for (var a0 = 30; a0 >= 0.5; a0--) {
+thread.timer = timer();
+var a1 = Math.max(0, 1000 * 0);
+runtime.requestRedraw();
+while (thread.timer.timeElapsed() < a1) {
+if (isStuck()) yield;
+}
+thread.timer = null;
+yield* executeInCompatibilityLayer({"BEATS":0,}, b0, true, false, null);
+yield* executeInCompatibilityLayer({"DRUM":1,"BEATS":0,}, b1, true, false, null);
+runtime.ext_scratch3_motion._moveSteps(0, target);
+}
+}; })
+
+// Sprite1 runs below with no refresh
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+return function* genXYZ_runs_below_with_no_r () {
+yield* thread.procedures["Whas refresh"]();
+}; })
+
+// Sprite1 has refresh
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("music_restForBeats");
+const b1 = runtime.getOpcodeFunction("music_playDrumForBeats");
+return function* genXYZ_has_refresh () {
+for (var a0 = 30; a0 >= 0.5; a0--) {
+thread.timer = timer();
+var a1 = Math.max(0, 1000 * 0);
+runtime.requestRedraw();
+while (thread.timer.timeElapsed() < a1) {
+if (isStuck()) yield;
+}
+thread.timer = null;
+yield* executeInCompatibilityLayer({"BEATS":0,}, b0, true, false, null);
+yield* executeInCompatibilityLayer({"DRUM":1,"BEATS":0,}, b1, true, false, null);
+runtime.ext_scratch3_motion._moveSteps(0, target);
+}
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+while (true) {
+b0.value = ((+b0.value || 0) + 1);
+yield;
+}
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-list-any.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-list-any.sb3.tw-snapshot
@@ -1,0 +1,37 @@
+// TW Snapshot
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["eFlmP1{XC+I1:h0Yln.K"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 7",}, b0, false, false, null);
+b1.value = [];
+listInsert(b1, "any", "a");
+listInsert(b1, "any", "b");
+listInsert(b1, "any", "c");
+if ((b1.value.length === 3)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (listContains(b1, "a")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (listContains(b1, "b")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (listContains(b1, "c")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (listContains(b1, listGet(b1.value, "any"))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+listDelete(b1, "any");
+if ((b1.value.length === 2)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+if (compareEqual(listGet(b1.value, "*"), "")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-obsolete-blocks.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-obsolete-blocks.sb3.tw-snapshot
@@ -1,0 +1,32 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b2 = runtime.getOpcodeFunction("sensing_userid");
+const b3 = runtime.getOpcodeFunction("motion_xscroll");
+const b4 = runtime.getOpcodeFunction("motion_yscroll");
+const b5 = runtime.getOpcodeFunction("motion_scroll_right");
+const b6 = runtime.getOpcodeFunction("motion_scroll_up");
+const b7 = runtime.getOpcodeFunction("motion_align_scene");
+const b8 = runtime.getOpcodeFunction("looks_setstretchto");
+const b9 = runtime.getOpcodeFunction("looks_changestretchby");
+const b10 = runtime.getOpcodeFunction("looks_hideallsprites");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+b1.value = (yield* executeInCompatibilityLayer({}, b2, false, false, null));
+b1.value = (yield* executeInCompatibilityLayer({}, b3, false, false, null));
+b1.value = (yield* executeInCompatibilityLayer({}, b4, false, false, null));
+yield* executeInCompatibilityLayer({"DISTANCE":10,}, b5, false, false, null);
+yield* executeInCompatibilityLayer({"DISTANCE":10,}, b6, false, false, null);
+yield* executeInCompatibilityLayer({"ALIGNMENT":"bottom-left",}, b7, false, false, null);
+yield* executeInCompatibilityLayer({"STRETCH":100,}, b8, false, false, null);
+yield* executeInCompatibilityLayer({"STRETCH":100,}, b8, false, false, null);
+yield* executeInCompatibilityLayer({"CHANGE":10,}, b9, false, false, null);
+yield* executeInCompatibilityLayer({"CHANGE":10,}, b9, false, false, null);
+yield* executeInCompatibilityLayer({}, b10, false, false, null);
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-one-divide-negative-zero.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-one-divide-negative-zero.sb3.tw-snapshot
@@ -1,0 +1,13 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+if ((((1 / -0) || 0) === -Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-preciseProjectTimer-drift-453118719.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-preciseProjectTimer-drift-453118719.sb3.tw-snapshot
@@ -1,0 +1,26 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["PsY$$vp$IVH;dDAr[q2h"];
+const b1 = runtime.getOpcodeFunction("looks_say");
+const b2 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
+return function* genXYZ () {
+b0.value = 0;
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b1, false, false, null);
+for (var a0 = 30; a0 >= 0.5; a0--) {
+b2.value = runtime.ioDevices.clock.projectTimer();
+thread.timer = timer();
+var a1 = Math.max(0, 1000 * 0);
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a1) {
+yield;
+}
+thread.timer = null;
+yield;
+}
+b0.value = 1;
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-prefers-first-occurence-of-procedure-387608267.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-prefers-first-occurence-of-procedure-387608267.sb3.tw-snapshot
@@ -1,0 +1,18 @@
+// TW Snapshot
+
+// Player script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+yield* thread.procedures["ZSet Costume"]();
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Player Set Costume
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ_Set_Costume () {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}; })

--- a/snapshot-tests/__snapshots__/tw-procedure-arguments-with-same-name.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-procedure-arguments-with-same-name.sb3.tw-snapshot
@@ -1,0 +1,30 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, null);
+yield* thread.procedures["Znumber or text %s %s"]("bad","ok");
+yield* thread.procedures["Zboolean %b %b"]("false",!false);
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 number or text %s %s
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ_number_or_text__ (p0,p1) {
+if ((("" + p1).toLowerCase() === "ok".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+}; })
+
+// Sprite1 boolean %b %b
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ_boolean__ (p0,p1) {
+if (toBoolean(p1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+}; })

--- a/snapshot-tests/__snapshots__/tw-procedure-call-resets-variable-input-types-430811055.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-procedure-call-resets-variable-input-types-430811055.sb3.tw-snapshot
@@ -1,0 +1,23 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+b1.value = "";
+thread.procedures["Zdo something"]();
+if (!compareEqual(b1.value, "")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 do something
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function funXYZ_do_something () {
+b0.value = "help";
+}; })

--- a/snapshot-tests/__snapshots__/tw-procedure-prototype-exists-but-not-definition-549160843.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-procedure-prototype-exists-but-not-definition-549160843.sb3.tw-snapshot
@@ -1,0 +1,10 @@
+// TW Snapshot
+
+// Apple script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, null);
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
@@ -1,0 +1,51 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["JbF5exWEi*m?-UEmkASS"];
+const b1 = stage.variables["[G/@.KGc-4y[(GZ(bt7o"];
+const b2 = runtime.getOpcodeFunction("looks_say");
+const b3 = runtime.getOpcodeFunction("sound_seteffectto");
+return function* genXYZ () {
+while (true) {
+if (compareEqual(b0.value, b1.value)) {
+} else {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, null);
+b1.value = b0.value;
+yield* executeInCompatibilityLayer({"VALUE":b0.value,"EFFECT":"pitch",}, b3, false, true, null);
+if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+}
+yield;
+}
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["[G/@.KGc-4y[(GZ(bt7o"];
+const b1 = runtime.getOpcodeFunction("looks_say");
+const b2 = stage.variables["JbF5exWEi*m?-UEmkASS"];
+return function* genXYZ () {
+b0.value = 0;
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b1, false, false, null);
+for (var a0 = 15; a0 >= 0.5; a0--) {
+if (((+b2.value || 0) === 200)) {
+b2.value = 50;
+} else {
+b2.value = 200;
+}
+thread.timer = timer();
+var a1 = Math.max(0, 1000 * 0);
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a1) {
+yield;
+}
+thread.timer = null;
+yield;
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, null);
+runtime.stopAll();
+retire(); return;
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-restart-broadcast-threads.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-restart-broadcast-threads.sb3.tw-snapshot
@@ -1,0 +1,33 @@
+// TW Snapshot
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+b1.value = 0;
+startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
+startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * 0);
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+if (((+b1.value || 0) === 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+b0.value = ((+b0.value || 0) + 1);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-safe-procedure-argument-casting.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-safe-procedure-argument-casting.sb3.tw-snapshot
@@ -1,0 +1,24 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, null);
+thread.procedures["Zswitch %s"]("1");
+if ((((target.currentCostume + 1) === 2) && ((+target.getCostumes()[target.currentCostume].name || 0) === 1))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+thread.procedures["Zswitch %s"]("2");
+if ((((target.currentCostume + 1) === 1) && ((+target.getCostumes()[target.currentCostume].name || 0) === 2))) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 switch %s
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+return function funXYZ_switch_ (p0) {
+runtime.ext_scratch3_looks._setCostume(target, p0);
+}; })

--- a/snapshot-tests/__snapshots__/tw-sensing-of.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-sensing-of.sb3.tw-snapshot
@@ -1,0 +1,113 @@
+// TW Snapshot
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage && stage.lookupVariableByNameAndType("Stage variable", "", true);
+const b2 = runtime.getSpriteTargetByName("Test sprite");
+const b3 = b2 && b2.lookupVariableByNameAndType("Private variable", "", true);
+const b4 = stage && stage.lookupVariableByNameAndType("This variable used to exist", "", true);
+const b5 = stage.variables["GTmK+*w8mNQP,z`4WG8#"];
+const b6 = runtime.getSpriteTargetByName("Sprite that doesn't exist");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 32",}, b0, false, false, null);
+if (((stage.currentCostume + 1) === 2)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass backdrop #",}, b0, false, false, null);
+}
+if ((stage.getCostumes()[stage.currentCostume].name.toLowerCase() === "Backdrop name test".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass backdrop name",}, b0, false, false, null);
+}
+if (((stage ? stage.volume : 0) === 45)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass stage volume",}, b0, false, false, null);
+}
+if ((("" + (b1 ? b1.value : 0)).toLowerCase() === "Variable in stage".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass stage variable",}, b0, false, false, null);
+}
+if (((b2 ? b2.x : 0) === 19)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass x",}, b0, false, false, null);
+}
+if (((b2 ? b2.y : 0) === 20)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass y",}, b0, false, false, null);
+}
+if (((b2 ? b2.direction : 0) === 89)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass direction",}, b0, false, false, null);
+}
+if (((b2 ? b2.currentCostume + 1 : 0) === 3)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass costume #",}, b0, false, false, null);
+}
+if ((("" + (b2 ? b2.getCostumes()[b2.currentCostume].name : 0)).toLowerCase() === "Costume name test".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass costume name",}, b0, false, false, null);
+}
+if (((b2 ? b2.size : 0) === 76.01)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass size",}, b0, false, false, null);
+}
+if (((b2 ? b2.volume : 0) === 14.3)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass volume",}, b0, false, false, null);
+}
+if ((("" + (b3 ? b3.value : 0)).toLowerCase() === "Private variable value".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass private variable",}, b0, false, false, null);
+}
+if (compareEqual((b4 ? b4.value : 0), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent variable",}, b0, false, false, null);
+}
+b5.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b5.value, PROPERTY: "backdrop #" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop name" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop name",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "volume" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "Stage variable" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE stage variable",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "x position" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE x",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "y position" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE y",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "direction" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE direction",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "costume #" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE costume #",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "costume name" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE costume name",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "size" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE size",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "volume" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, null);
+}
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "Private variable" }), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE private variable",}, b0, false, false, null);
+}
+if (((b6 ? b6.x : 0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, null);
+}
+if (((b6 ? b6.y : 0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop name",}, b0, false, false, null);
+}
+if (((b6 ? b6.direction : 0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, null);
+}
+if (((b6 ? b6.currentCostume + 1 : 0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE stage variable",}, b0, false, false, null);
+}
+if (compareEqual((b6 ? b6.getCostumes()[b6.currentCostume].name : 0), 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE x",}, b0, false, false, null);
+}
+if (((b6 ? b6.size : 0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE y",}, b0, false, false, null);
+}
+if (((b6 ? b6.volume : 0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass NE direction",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-stage-cannot-move-layers.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-stage-cannot-move-layers.sb3.tw-snapshot
@@ -1,0 +1,46 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+b1.value = "Initial";
+thread.timer = timer();
+var a0 = Math.max(0, 1000 * 0);
+runtime.requestRedraw();
+yield;
+while (thread.timer.timeElapsed() < a0) {
+yield;
+}
+thread.timer = null;
+yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test 1" }));
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+if ((("" + b0.value).toLowerCase() === "Initial".toLowerCase())) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b1, false, false, null);
+}
+retire();
+}; })
+
+// Stage script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+return function* genXYZ () {
+retire();
+}; })
+
+// Stage script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = target.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function* genXYZ () {
+b0.value = "Stage callback";
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-subtract-can-return-nan.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-subtract-can-return-nan.sb3.tw-snapshot
@@ -1,0 +1,13 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+if (!((Infinity - Infinity) <= 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-tangent.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-tangent.sb3.tw-snapshot
@@ -1,0 +1,55 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b0, false, false, null);
+if ((tan(0) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 0",}, b0, false, false, null);
+}
+if ((tan(90) === Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 90",}, b0, false, false, null);
+}
+if ((tan(180) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 180",}, b0, false, false, null);
+}
+if ((tan(270) === -Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 270",}, b0, false, false, null);
+}
+if ((tan(360) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 360",}, b0, false, false, null);
+}
+if ((tan(450) === Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 450",}, b0, false, false, null);
+}
+if ((tan(540) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 540",}, b0, false, false, null);
+}
+if ((tan(630) === -Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 630",}, b0, false, false, null);
+}
+if ((tan(720) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 720",}, b0, false, false, null);
+}
+if ((tan(810) === Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 810",}, b0, false, false, null);
+}
+if ((tan(-90) === -Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass -90",}, b0, false, false, null);
+}
+if ((tan(-180) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass -180",}, b0, false, false, null);
+}
+if ((tan(-270) === Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass -270",}, b0, false, false, null);
+}
+if ((tan(-360) === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass -360",}, b0, false, false, null);
+}
+if ((tan(-450) === -Infinity)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass -450",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-unsafe-equals.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-unsafe-equals.sb3.tw-snapshot
@@ -1,0 +1,85 @@
+// TW Snapshot
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables[",OktMIwz{~bdgWnPEa8u"];
+const b2 = stage.variables["yfy(G`K5K^fJcXAfiN4i"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 14",}, b0, false, false, null);
+if ((10 === 10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 1",}, b0, false, false, null);
+}
+if ((10 === 10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, null);
+}
+b1.value = 10;
+if (((+b1.value || 0) === 10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, null);
+}
+if (compareEqual(b1.value, "010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, null);
+}
+if (compareEqual(b1.value, "0000000010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 5",}, b0, false, false, null);
+}
+for (var a0 = 1; a0 >= 0.5; a0--) {
+if (((+b1.value || 0) === 10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 6",}, b0, false, false, null);
+}
+if (compareEqual(b1.value, "010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 7",}, b0, false, false, null);
+}
+if (compareEqual(b1.value, "0000000010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 8",}, b0, false, true, null);
+if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+}
+yield;
+}
+b2.value = "010";
+if (((+b2.value || 0) === 10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 9",}, b0, false, false, null);
+}
+if (compareEqual(b2.value, "010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 10",}, b0, false, false, null);
+}
+if (compareEqual(b2.value, "0000000010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 11",}, b0, false, false, null);
+}
+for (var a1 = 1; a1 >= 0.5; a1--) {
+if (((+b2.value || 0) === 10)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 12",}, b0, false, false, null);
+}
+if (compareEqual(b2.value, "010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 13",}, b0, false, false, null);
+}
+if (compareEqual(b2.value, "0000000010")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass 14",}, b0, false, true, null);
+if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+}
+yield;
+}
+if ((0 === 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+if ((1 === 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+if ((0 === 1)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+if (compareEqual(" ", 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+if (compareEqual(0, " ")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+if (compareEqual("", 0)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+if (compareEqual(0, "")) {
+yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, null);
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-warp-repeat-until-timer-greater-than.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-warp-repeat-until-timer-greater-than.sb3.tw-snapshot
@@ -1,0 +1,26 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+yield* thread.procedures["Wrun without screen refresh"]();
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 run without screen refresh
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["F?*}X,`9XBpN_[piGRrz"];
+const b1 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ_run_without_screen_r () {
+b0.value = (((daysSince2000() * 86400) || 0) + 3);
+runtime.ioDevices.clock.resetProjectTimer();
+while (!((runtime.ioDevices.clock.projectTimer() > 0.1) || compareGreaterThan((daysSince2000() * 86400), b0.value))) {
+if (isStuck()) yield;
+}
+if (compareLessThan((daysSince2000() * 86400), b0.value)) {
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b1, true, false, null);
+}
+}; })

--- a/snapshot-tests/__snapshots__/tw-when-backdrop-switches-to-next-backdrop.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-when-backdrop-switches-to-next-backdrop.sb3.tw-snapshot
@@ -1,0 +1,18 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, null);
+runtime.ext_scratch3_looks._setBackdrop(stage, stage.currentCostume + 1, true);
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-when-backdrop-switches-to-switch-backdrop-to.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-when-backdrop-switches-to-switch-backdrop-to.sb3.tw-snapshot
@@ -1,0 +1,18 @@
+// TW Snapshot
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite1 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, null);
+runtime.ext_scratch3_looks._setBackdrop(stage, "backdrop2");
+retire();
+}; })

--- a/snapshot-tests/__snapshots__/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
+++ b/snapshot-tests/__snapshots__/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
@@ -1,0 +1,31 @@
+// TW Snapshot
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = runtime.getOpcodeFunction("looks_say");
+const b1 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
+const b2 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
+return function* genXYZ () {
+yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, null);
+b1.value = 0;
+b2.value = "";
+while (!compareGreaterThan(b2.value, "")) {
+startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "step" });
+yield;
+}
+yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, null);
+yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, null);
+retire();
+}; })
+
+// Sprite2 script
+(function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
+const b0 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
+const b1 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
+return function* genXYZ () {
+b0.value = ((+b0.value || 0) + 1);
+if (((b0.value || 0) === 5)) {
+b1.value = "end";
+}
+retire();
+}; })

--- a/snapshot-tests/index.js
+++ b/snapshot-tests/index.js
@@ -1,0 +1,100 @@
+const Snapshot = require('./snapshots.js');
+
+/* eslint-disable no-console */
+
+const RESET = `\u001b[0m`;
+const BOLD = '\u001b[1m';
+const RED = '\u001b[31m';
+const BLUE = `\u001b[34m`;
+const GREEN = '\u001b[32m';
+const GRAY = '\u001b[90m';
+
+const PASSED = 'PASSED';
+const FAILED = 'FAILED';
+const UPDATED = 'UPDATED';
+
+const isUpdatingSnapshots = process.argv.includes('--update');
+
+const runSnapshotTest = async test => {
+    try {
+        const generatedSnapshot = await Snapshot.generateActualSnapshot(test);
+        const expectedSnapshot = Snapshot.getExpectedSnapshot(test);
+        const matches = generatedSnapshot === expectedSnapshot;
+
+        const prefix = `### ${test}: `;
+
+        if (isUpdatingSnapshots) {
+            if (matches) {
+                console.log(`${BOLD}${GREEN}${prefix}already matches${RESET}`);
+                return PASSED;
+            }
+            console.log(`${BOLD}${BLUE}### ${test}: updating${RESET}`);
+            Snapshot.saveSnapshot(test, generatedSnapshot);
+            return UPDATED;
+        }
+
+        if (matches) {
+            console.log(`${BOLD}${GREEN}### ${test}: matches${RESET}`);
+            return PASSED;
+        }
+
+        if (expectedSnapshot === null) {
+            console.log(`${BOLD}${BLUE}### ${test}: missing data, saving generated snapshot${RESET}`);
+            Snapshot.saveSnapshot(test, generatedSnapshot);
+            return UPDATED;
+        }
+
+        console.log(`${BOLD}${RED}### ${test}: DOES NOT MATCH${RESET}`);
+        console.log(`${RED}EXPECTED:\n${expectedSnapshot}${RESET}`);
+        console.log(`${BLUE}GOT:\n${generatedSnapshot}${RESET}`);
+    } catch (e) {
+        console.log(`${BOLD}${RED}### ${test}: ERROR${RESET}`);
+        console.log(`${RED}${e}${RESET}`);
+    }
+
+    console.log('');
+    return FAILED;
+};
+
+const run = async () => {
+    console.log(`Running ${Snapshot.tests.length} snapshot tests.`);
+
+    const fileToResult = {};
+    for (const test of Snapshot.tests) {
+        fileToResult[test] = await runSnapshotTest(test);
+    }
+
+    const getTestsByResult = r => Object.entries(fileToResult)
+        .filter(i => i[1] === r)
+        .map(i => i[0]);
+
+    const passed = getTestsByResult(PASSED);
+    const failed = getTestsByResult(FAILED);
+    const updated = getTestsByResult(UPDATED);
+
+    console.log('');
+    console.log(`${BOLD} === SUMMARY ===${RESET}`);
+    if (passed.length) {
+        console.log(`${BOLD}${GREEN}PASSED ${passed.length}${RESET}${GRAY} ${passed.join(', ')}${RESET}`);
+    }
+    if (failed.length) {
+        console.log(`${BOLD}${RED}FAILED ${failed.length}${RESET}${GRAY} ${failed.join(', ')}${RESET}`);
+    }
+    if (updated.length) {
+        console.log(`${BOLD}${BLUE}UPDATED ${updated.length}${RESET}${GRAY} ${updated.join(', ')}${RESET}`);
+    }
+
+    if (failed.length) {
+        console.log('');
+        console.log(`If the compiler's behavior has changed, this failure is expected.`);
+        console.log(`Update snapshots with ${BOLD}node snapshot-tests --update${RESET}`);
+        console.log(`Review the diff in version control, then commit the updated snapshot files.`);
+        process.exit(1);
+    }
+};
+
+run()
+    .catch(err => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/snapshot-tests/snapshots.js
+++ b/snapshot-tests/snapshots.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const fs = require('fs');
+const VM = require('../src/virtual-machine');
+const JSGenerator = require('../src/compiler/jsgen');
+
+const executeDir = path.resolve(__dirname, '../test/fixtures/execute');
+// sb2 project loading results in random IDs each time, so for now we only snapshot sb3 files
+const testProjects = fs.readdirSync(executeDir).filter(uri => uri.endsWith('.sb3'));
+
+const snapshotDir = path.resolve(__dirname, '__snapshots__');
+fs.mkdirSync(snapshotDir, {
+    recursive: true
+});
+
+const getProjectData = file => fs.readFileSync(path.join(executeDir, file));
+
+const getSnapshotPath = file => path.join(snapshotDir, `${file}.tw-snapshot`);
+
+const generateActualSnapshot = async file => {
+    const vm = new VM();
+    await vm.loadProject(getProjectData(file));
+
+    /*
+        Example source (manually formatted):
+        (function factory32(thread) {
+            const target = thread.target;
+            const runtime = target.runtime;
+            const stage = runtime.getTargetForStage();
+            return function* gen30_whatever () {
+                // ...
+            };
+        }; })
+    */
+    const normalizeJS = source => source
+        .replace(/^\(function factory\d+/, '(function factoryXYZ')
+        .replace(/return function\* gen\d+/, 'return function* genXYZ')
+        .replace(/return function fun\d+/, 'return function funXYZ');
+
+    const generatedJS = [];
+    JSGenerator.testingApparatus = {
+        report: (jsgen, factorySource) => {
+            const targetName = jsgen.target.getName();
+            const scriptName = jsgen.script.procedureCode || 'script';
+            const js = normalizeJS(factorySource);
+            generatedJS.push(`// ${targetName} ${scriptName}\n${js}`);
+        }
+    };
+
+    vm.runtime.precompile();
+
+    return `// TW Snapshot\n\n${generatedJS.join('\n\n')}\n`;
+};
+
+const getExpectedSnapshot = test => {
+    try {
+        return fs.readFileSync(getSnapshotPath(test), 'utf-8');
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            return null;
+        }
+        throw e;
+    }
+};
+
+const saveSnapshot = (test, data) => {
+    fs.writeFileSync(getSnapshotPath(test), data);
+};
+
+module.exports = {
+    tests: testProjects,
+    generateActualSnapshot,
+    getExpectedSnapshot,
+    saveSnapshot
+};

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -1310,8 +1310,15 @@ class JSGenerator {
             log.info(`JS: ${this.target.getName()}: compiled ${this.script.procedureCode || 'script'}`, factory);
         }
 
+        if (JSGenerator.testingApparatus) {
+            JSGenerator.testingApparatus.report(this, factory);
+        }
+
         return fn;
     }
 }
+
+// Test hook used by automated snapshot testing.
+JSGenerator.testingApparatus = null;
 
 module.exports = JSGenerator;

--- a/test/integration/tw-snapshots.js
+++ b/test/integration/tw-snapshots.js
@@ -1,0 +1,20 @@
+const {test} = require('tap');
+const Snapshots = require('../../snapshot-tests/snapshots');
+
+for (const testName of Snapshots.tests) {
+    test(testName, async t => {
+        const expected = Snapshots.getExpectedSnapshot(testName);
+        if (expected) {
+            const actual = await Snapshots.generateActualSnapshot(testName);
+            if (actual === expected) {
+                t.pass('matches');
+            } else {
+                // This assertion will always fail, but tap will print a readable diff
+                t.equal(expected, actual, 'did not match; you may have to run: node snapshot-tests --update');
+            }
+        } else {
+            t.fail('missing snapshot, please run: node snapshot-tests --update');
+        }
+        t.end();
+    });
+}


### PR DESCRIPTION
If the compiler's type analysis becomes smarter, being able to show that its output matches what is expected
will become more important. Snapshot testing is how we will solve that.

Take the existing sb3 test projects (sb2 project loading is not deterministic), compile them, then see if the compiler's output matches the previous known value. CI will fail if the compiler's output unexpectedly changes. If you intentionally change the compiler's output or add a test project, run the script that generates new snapshots `node snapshot-tests --update`. The tests will fail until you do that.
