### PR TITLE
Use URI encoding instead of base64 for addon blocks icon

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2553,7 +2553,7 @@ class Runtime extends EventEmitter {
                     color1: '#29beb8',
                     color2: '#3aa8a4',
                     color3: '#3aa8a4',
-                    menuIconURI: `data:image/svg+xml;base64,${btoa(ICON)}`,
+                    menuIconURI: `data:image/svg+xml;,${encodeURIComponent(ICON)}`,
                     blocks: [],
                     customFieldTypes: {},
                     menus: []


### PR DESCRIPTION
Fixes test errors from #106 