### PR TITLE
Return original message if translation request fails

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -278,7 +278,7 @@ class Scratch3TranslateBlocks {
             })
             .catch(err => {
                 log.warn(`error fetching translate result! ${err}`);
-                return '';
+                return args.WORDS;
             });
         return translatePromise;
     }

--- a/src/util/fetch-with-timeout.js
+++ b/src/util/fetch-with-timeout.js
@@ -15,6 +15,9 @@ const fetchWithTimeout = (resource, init, timeout) => {
         fetch(resource, Object.assign({signal}, init)).then(response => {
             clearTimeout(timeoutID);
             return response;
+        }, error => {
+            clearTimeout(timeoutID);
+            throw error;
         }),
         new Promise((resolve, reject) => {
             timeoutID = setTimeout(() => {

--- a/test/unit/tw_translate.js
+++ b/test/unit/tw_translate.js
@@ -1,0 +1,23 @@
+const {test} = require('tap');
+const Scratch3TranslateBlocks = require('../../src/extensions/scratch3_translate/index');
+
+global.navigator = {
+    language: 'en'
+};
+
+// Translate tries to access AbortController from window, but does not require it to exist.
+global.window = {};
+
+test('translate returns original string on network error', t => {
+    t.plan(1);
+
+    // Simulate the network being down or filtered
+    global.fetch = () => Promise.reject(new Error('Simulated network error'));
+
+    const extension = new Scratch3TranslateBlocks();
+    extension.getTranslate({WORDS: 'My message 123123', LANGUAGE: 'es'})
+        .then(message => {
+            t.equal(message, 'My message 123123');
+            t.end();
+        });
+});


### PR DESCRIPTION
For games that put their entire interface through translate blocks, this allows them to be usable when no internet connection is present.

Has convenient side effect of breaking some online detectors.
