### PR TITLE
Prepare project's JSON for extension

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -658,6 +658,9 @@ class VirtualMachine extends EventEmitter {
         // Clear the current runtime
         this.clear();
 
+        //  Get loading JSON for extensions
+        this.firstJSON = projectJSON;
+
         if (typeof performance !== 'undefined') {
             performance.mark('scratch-vm-deserialize-start');
         }


### PR DESCRIPTION
### Proposed Changes

Changed the deserializeProject method in virtual-machine.js to allow extensions to read the project's JSON when loaded with the project.

### Reason for Changes

Used to obtain the complete project JSON when the extension is loaded for use by the extension and expand the functionality of the extension.

### Test Coverage

![image](https://github.com/TurboWarp/scratch-vm/assets/70421730/c74f2e16-9518-48d8-856a-a0bd5c30f41e)
