### PR TITLE
Expose _StackFrame and Thread classes

### DIFF
--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -514,4 +514,5 @@ class Thread {
     }
 }
 
+Thread.exports = {_StackFrame};
 module.exports = Thread;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -27,7 +27,7 @@ const {loadSound} = require('./import/load-sound.js');
 const {serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
 require('canvas-toBlob');
 const {exportCostume} = require('./serialization/tw-costume-import-export');
-const {Thread, _StackFrame} = require('./engine/thread.js');
+const Thread = require('./engine/thread');
 const Base64Util = require('./util/base64-util');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
@@ -220,8 +220,7 @@ class VirtualMachine extends EventEmitter {
             Sprite,
             RenderedTarget,
             JSZip,
-            Thread,
-            _StackFrame
+            Thread
         };
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -27,6 +27,7 @@ const {loadSound} = require('./import/load-sound.js');
 const {serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
 require('canvas-toBlob');
 const {exportCostume} = require('./serialization/tw-costume-import-export');
+const {Thread, _StackFrame} = require('./engine/thread.js');
 const Base64Util = require('./util/base64-util');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
@@ -218,7 +219,9 @@ class VirtualMachine extends EventEmitter {
         this.exports = {
             Sprite,
             RenderedTarget,
-            JSZip
+            JSZip,
+            Thread,
+            _StackFrame
         };
     }
 


### PR DESCRIPTION
Useful for starting threads with data or creating fake threads

### Proposed Changes

This exposes the Thread and _StackFrame classes from the thread.js file.
src/engine/thread.js

### Reason for Changes

Useful for starting threads with preset properties.

