### PR TITLE
Add `branchIconURI`

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1408,13 +1408,13 @@ class Runtime extends EventEmitter {
             if (!blockInfo.disableMonitor && context.inputList.length === 0) {
                 blockJSON.checkboxInFlyout = true;
             }
-        } else if (blockInfo.blockType === BlockType.LOOP) {
+        } else if (blockInfo.blockType === BlockType.LOOP || blockInfo.branchIcon) {
             // Add icon to the bottom right of a loop block
             blockJSON[`lastDummyAlign${outLineNum}`] = 'RIGHT';
             blockJSON[`message${outLineNum}`] = '%1';
             blockJSON[`args${outLineNum}`] = [{
                 type: 'field_image',
-                src: './static/blocks-media/repeat.svg', // TODO: use a constant or make this configurable?
+                src: blockInfo.branchIcon ?? './static/blocks-media/repeat.svg',
                 width: 24,
                 height: 24,
                 alt: '*', // TODO remove this since we don't use collapsed blocks in scratch

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1408,13 +1408,13 @@ class Runtime extends EventEmitter {
             if (!blockInfo.disableMonitor && context.inputList.length === 0) {
                 blockJSON.checkboxInFlyout = true;
             }
-        } else if (blockInfo.blockType === BlockType.LOOP || blockInfo.branchIcon) {
+        } else if (blockInfo.blockType === BlockType.LOOP || blockInfo.branchIconURI) {
             // Add icon to the bottom right of a loop block
             blockJSON[`lastDummyAlign${outLineNum}`] = 'RIGHT';
             blockJSON[`message${outLineNum}`] = '%1';
             blockJSON[`args${outLineNum}`] = [{
                 type: 'field_image',
-                src: blockInfo.branchIcon ?? './static/blocks-media/repeat.svg',
+                src: blockInfo.branchIconURI || './static/blocks-media/repeat.svg',
                 width: 24,
                 height: 24,
                 alt: '*', // TODO remove this since we don't use collapsed blocks in scratch

--- a/test/unit/tw_branch_icon_uri.js
+++ b/test/unit/tw_branch_icon_uri.js
@@ -1,0 +1,39 @@
+const {test} = require('tap');
+const VirtualMachine = require('../../src/virtual-machine');
+const BlockType = require('../../src/extension-support/block-type');
+
+test('branchIconURI', t => {
+    const vm = new VirtualMachine();
+    vm.extensionManager._registerInternalExtension({
+        getInfo: () => ({
+            id: 'testextension',
+            name: 'test',
+            blocks: [
+                {
+                    blockType: BlockType.LOOP,
+                    opcode: 'block1',
+                    text: 'no custom icon'
+                },
+                {
+                    blockType: BlockType.LOOP,
+                    opcode: 'block2',
+                    text: 'LOOP with custom icon',
+                    branchIconURI: 'data:whatever1'
+                },
+                {
+                    blockType: BlockType.CONDITIONAL,
+                    opcode: 'block2',
+                    text: 'CONDITIONAL with custom icon',
+                    branchIconURI: 'data:whatever2'
+                }
+            ]
+        })
+    });
+
+    const blocks = vm.runtime.getBlocksJSON();
+    t.equal(blocks[0].args2[0].src, './static/blocks-media/repeat.svg', 'default custom icon');
+    t.equal(blocks[1].args2[0].src, 'data:whatever1', 'LOOP with custom icon');
+    t.equal(blocks[2].args2[0].src, 'data:whatever2', 'CONDITIONAL with custom icon');
+
+    t.end();
+});


### PR DESCRIPTION
### Proposed Changes

Adds a new option to blocks called `branchIcon`. This option allows you to add a custom branch icon to a block. This does not have to strictly be a `Scratch.BlockType.LOOP` Block, which makes it all the better. Should work flawlessly with data uri's. 

### Reason for Changes

I added this option because it'll be really useful to have custom branch indications, and also use it in normal blocks as well to indicate anything else.

### Test Coverage

Tried building my own gui, but my node version is too new. So I could not test this, but it should still easily work.

**Edit**
 - Tested by @Ashimee and @JeremyGamer13, works perfectly.

### Example

```js
blocks: [
          {
            opcode: "block",
            text: "block: [ARGUMENT]",
            blockType: Scratch.BlockType.LOOP, // Can be any other block, too, which is fire
            branchIcon: // This is the new option I'm adding. You can specify a data uri here.
            arguments: {
              ARGUMENT: {
                type: Scratch.ArgumentType.STRING
              }
            }
          }
        ],
```
### Potential Changes

Might change it from it's `else if` state and separate it to it's own `if` statement if we want to make the `branchIcon` option also work on `Scratch.BlockType.REPORTER` and `Scratch.BlockType.BOOLEAN`, but I might not do this.