### PR TITLE
don't use branchCount for extension substack compilation

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -1414,12 +1414,14 @@ class ScriptTreeGenerator {
 
         const blockInfo = this.getBlockInfo(block.opcode);
         const blockType = (blockInfo && blockInfo.info && blockInfo.info.blockType) || BlockType.COMMAND;
-        const substacks = [];
+        const substacks = {};
         if (blockType === BlockType.CONDITIONAL || blockType === BlockType.LOOP) {
-            const branchCount = blockInfo.info.branchCount;
-            for (let i = 0; i < branchCount; i++) {
-                const inputName = i === 0 ? 'SUBSTACK' : `SUBSTACK${i + 1}`;
-                substacks.push(this.descendSubstack(block, inputName));
+            for (const inputName in block.inputs) {
+                if (!inputName.startsWith('SUBSTACK')) continue;
+                const branchNum = inputName === 'SUBSTACK' ? 1 : +inputName.substring('SUBSTACK'.length);
+                if (!isNaN(branchNum)) {
+                    substacks[branchNum] = this.descendSubstack(block, inputName);
+                }
             }
         }
 

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -773,9 +773,9 @@ class JSGenerator {
                 this.source += `const ${branchVariable} = createBranchInfo(${blockType === BlockType.LOOP});\n`;
                 this.source += `while (${branchVariable}.branch = +(${this.generateCompatibilityLayerCall(node, false, branchVariable)})) {\n`;
                 this.source += `switch (${branchVariable}.branch) {\n`;
-                for (let i = 0; i < node.substacks.length; i++) {
-                    this.source += `case ${i + 1}: {\n`;
-                    this.descendStack(node.substacks[i], new Frame(false));
+                for (const index in node.substacks) {
+                    this.source += `case ${+index}: {\n`;
+                    this.descendStack(node.substacks[index], new Frame(false));
                     this.source += `break;\n`;
                     this.source += `}\n`; // close case
                 }


### PR DESCRIPTION


### Resolves

Resolves [🗨︎(extremely minor parity issue) Compiler uses branchCount for startBranch](https://discord.com/channels/837024174865776680/1195010469077975101)

### Proposed Changes

Makes the compiler use all inputs starting with SUBSTACK for extension C block compilation rather than relying on the block info's branchCount.

### Reason for Changes

This fixes a minor parity issue with the interpreter where if the number of SUBSTACK inputs in a block was more than its branchCount (e.g for blocks with mutators), the extra substacks didn't compile.

### Test Coverage

Haven't touched tests.
