### PR TITLE
Make fixUpVariableReferences() fix broadcasts

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -697,7 +697,7 @@ class Target extends EventEmitter {
             return null;
         };
 
-        const allReferences = this.blocks.getAllVariableAndListReferences();
+        const allReferences = this.blocks.getAllVariableAndListReferences(undefined, true);
         const unreferencedLocalVarIds = [];
         if (Object.keys(this.variables).length > 0) {
             for (const localVarId in this.variables) {

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -697,7 +697,8 @@ class Target extends EventEmitter {
             return null;
         };
 
-        const allReferences = this.blocks.getAllVariableAndListReferences(undefined, true);
+        // Get all variables including broadcasts
+        const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
         const unreferencedLocalVarIds = [];
         if (Object.keys(this.variables).length > 0) {
             for (const localVarId in this.variables) {


### PR DESCRIPTION
### Resolves

https://github.com/TurboWarp/packager/issues/733

### Proposed Changes

Make fixUpVariableReferences() fix also broadcasts.

### Reason for Changes

The [issue](https://github.com/TurboWarp/packager/issues/733) seems to arise from the fact, that the broadcasts are not correctly adopted when you import sprites.

### Notes

I really don't understand why the issue doesn't happen to the editor.