### PR TITLE
Pen: "Stage selected: less pen blocks" label on the stage

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -298,6 +298,16 @@ class Scratch3PenBlocks {
             }),
             blockIconURI: blockIconURI,
             blocks: [
+                // tw: additional message when on the stage for clarity
+                {
+                    blockType: BlockType.LABEL,
+                    text: formatMessage({
+                        id: 'tw.pen.stageSelected',
+                        default: 'Stage selected: less pen blocks',
+                        description: 'Label that appears in the Pen category when the stage is selected'
+                    }),
+                    filter: [TargetType.STAGE]
+                },
                 {
                     opcode: 'clear',
                     blockType: BlockType.COMMAND,


### PR DESCRIPTION
### Proposed Changes

Adds a label to the Pen category when on the stage:
![image](https://github.com/TurboWarp/scratch-vm/assets/68464103/6fbab754-ed96-4a13-924c-76d55035aea1)

### Reason for Changes

The motion category already does a similar thing ("Stage selected: no motion blocks"), so this is for parity. Some people have gotten confused about this: https://www.reddit.com/r/turbowarp/comments/1adxxff/why_is_there_only_the_erase_block_in_pen_how_do_i/
And TurboWarp/scratch-blocks#9 got merged, so I assume minor tweaks like this can get accepted. (Though this one adds a string.)

### Test Coverage

Haven't touched tests.
