### PR TITLE
Add acceptReporters to more inputs.

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -128,10 +128,10 @@ const ArgumentTypeMap = (() => {
 
 const FieldTypeMap = (() => {
     const map = {};
-    map[ArgumentType.ANGLE] = "field_angle";
-    map[ArgumentType.NUMBER] = "field_number";
-    map[ArgumentType.STRING] = "field_input";
-    map[ArgumentType.NOTE] = "field_note";
+    map[ArgumentType.ANGLE] = 'field_angle';
+    map[ArgumentType.NUMBER] = 'field_number';
+    map[ArgumentType.STRING] = 'field_input';
+    map[ArgumentType.NOTE] = 'field_note';
     return map;
 })();
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -126,6 +126,15 @@ const ArgumentTypeMap = (() => {
     return map;
 })();
 
+const FieldTypeMap = (() => {
+    const map = {};
+    map[ArgumentType.ANGLE] = "field_angle";
+    map[ArgumentType.NUMBER] = "field_number";
+    map[ArgumentType.STRING] = "field_input";
+    map[ArgumentType.NOTE] = "field_note";
+    return map;
+})();
+
 /**
  * A pair of functions used to manage the cloud variable limit,
  * to be used when adding (or attempting to add) or removing a cloud variable.
@@ -1635,7 +1644,7 @@ class Runtime extends EventEmitter {
             let fieldName;
             if (argInfo.menu) {
                 const menuInfo = context.categoryInfo.menuInfo[argInfo.menu];
-                if (menuInfo.acceptReporters) {
+                if (menuInfo.acceptReporters || argInfo.acceptReporters) {
                     valueName = placeholder;
                     shadowType = this._makeExtensionMenuId(argInfo.menu, context.categoryInfo.id);
                     fieldName = argInfo.menu;
@@ -1646,6 +1655,11 @@ class Runtime extends EventEmitter {
                     shadowType = null;
                     fieldName = placeholder;
                 }
+            } else if (argInfo.acceptReporters === false && FieldTypeMap[argInfo.type]) {
+                argJSON.type = FieldTypeMap[argInfo.type];
+                valueName = null;
+                shadowType = null;
+                fieldName = placeholder;
             } else {
                 valueName = placeholder;
                 shadowType = (argTypeInfo.shadow && argTypeInfo.shadow.type) || null;


### PR DESCRIPTION
### Proposed Changes

Add an acceptReporters option for argument placeholders.

### Reason for Changes

TurboWarp's argument types currently always allow for reporters to be accepted. Other features, like event-based hats, are exclusively limited to discriminating by fields.

Some features do require the input/customisation of a user, but without it changing in real-time with, for example a variable reporter.

Allowing for fields to be directly inside of blocks would also open up more customisation for extension developers.

It also feels more intuitive for acceptReporters to apply to every type of input, not just menus; we can have menus be only *sometimes* able to accept reporters (kind of like the broadcast menu/field).

### Test Coverage

Haven't touched actual tests.

### Known Problems

- Colours are messed up.
- Isn't compatible with fields aside from the text-based ones.