### PR TITLE
Fix WeDo2.send sends empty message

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -664,7 +664,7 @@ class WeDo2 {
         return this._ble.write(
             BLEService.IO_SERVICE,
             uuid,
-            Base64Util.uint8ArrayToBase64(new Uint8Array(message)),
+            Base64Util.uint8ArrayToBase64(message),
             'base64'
         );
     }

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -664,7 +664,7 @@ class WeDo2 {
         return this._ble.write(
             BLEService.IO_SERVICE,
             uuid,
-            Base64Util.uint8ArrayToBase64(message),
+            Base64Util.uint8ArrayToBase64(new Uint8Array(message)),
             'base64'
         );
     }

--- a/src/util/base64-util.js
+++ b/src/util/base64-util.js
@@ -20,10 +20,13 @@ class Base64Util {
 
     /**
      * Convert a Uint8Array to a base64 encoded string.
-     * @param {Uint8Array} array - the array to convert.
+     * @param {Uint8Array|Array<number>} array - the array to convert.
      * @return {string} - the base64 encoded string.
      */
     static uint8ArrayToBase64 (array) {
+        if (Array.isArray(array)) {
+            array = new Uint8Array(array);
+        }
         let binary = '';
         const len = array.byteLength;
         for (let i = 0; i < len; i++) {

--- a/test/unit/util_base64.js
+++ b/test/unit/util_base64.js
@@ -3,6 +3,7 @@ const Base64Util = require('../../src/util/base64-util');
 
 test('uint8ArrayToBase64', t => {
     t.equal(Base64Util.uint8ArrayToBase64(new Uint8Array([0, 50, 80, 200])), 'ADJQyA==');
+    t.equal(Base64Util.uint8ArrayToBase64([0, 50, 80, 200]), 'ADJQyA==');
     t.end();
 });
 
@@ -29,7 +30,9 @@ test('round trips', t => {
     ];
     for (const uint8array of data) {
         const uint8ToBase64 = Base64Util.uint8ArrayToBase64(uint8array);
+        const arrayToBase64 = Base64Util.uint8ArrayToBase64(Array.from(uint8array));
         const bufferToBase64 = Base64Util.arrayBufferToBase64(uint8array.buffer);
+        t.equal(uint8ToBase64, arrayToBase64);
         t.equal(uint8ToBase64, bufferToBase64);
         const decoded = Base64Util.base64ToUint8Array(uint8ToBase64);
         t.same(uint8array, decoded);


### PR DESCRIPTION
WeDo2.send invokes Base64Util.uint8ArrayToBase64(message). However message.arrayLength === undefined. This causes Base64Util.uint8ArrayToBase64 always returning empty string ''.

### Resolves

WeDo2.send invokes Base64Util.uint8ArrayToBase64(message). However message.arrayLength === undefined. This causes Base64Util.uint8ArrayToBase64 always returning empty string ''.
This causes motors not functioning, and other devices not functioning.

### Proposed Changes

replace Base64Util.uint8ArrayToBase64(message) with Base64Util.uint8ArrayToBase64(new Uint8Array(message))

### Reason for Changes

WeDo2.send invokes Base64Util.uint8ArrayToBase64(message). However message.arrayLength === undefined. This causes Base64Util.uint8ArrayToBase64 always returning empty string ''.
This causes motors not functioning, and other devices not functioning.

### Test Coverage

Wedo 2.0 Block: turn motor on for 1 seconds.
