### PR TITLE
Create extension script event

### DIFF
--- a/src/extension-support/tw-iframe-extension-worker.js
+++ b/src/extension-support/tw-iframe-extension-worker.js
@@ -55,6 +55,7 @@ class IframeExtensionWorker {
         ], {
             type: 'text/html; charset=utf-8'
         });
+        vm.emit('CREATE_EXTENSION_SCRIPT', this.iframe, blob);
         this.iframe.src = URL.createObjectURL(blob);
     }
 

--- a/src/extension-support/tw-unsandboxed-extension-runner.js
+++ b/src/extension-support/tw-unsandboxed-extension-runner.js
@@ -160,6 +160,7 @@ const loadUnsandboxedExtension = (extensionURL, vm) => new Promise((resolve, rej
         reject(new Error(`Error in unsandboxed script ${extensionURL}. Check the console for more information.`));
     };
     script.src = extensionURL;
+    vm.emit('CREATE_EXTENSION_SCRIPT', script);
     document.body.appendChild(script);
 }).then(objects => {
     teardownUnsandboxedExtensionAPI();


### PR DESCRIPTION
idk how garbo wants me to fix the vm missing error.

### Resolves

One of my proposed changes in the discord.

### Proposed Changes

Emits a event when a extension script is created.

### Reason for Changes

I wanted access to be able to modify some script stuff and the loading api so that we can modify it externally but i dont think you would do that so i did this.
aso you wanted to see some code so
```js
// simple example that adds a comment to the top of the extension
vm.on('CREATE_EXTENSION_SCRIPT', script => {
  if (script.tagName === 'script') {
    script.src = `data:application/javascript;base64,${btoa(`// example
    ${atob(script.substr(script.indexOf(',')))}`)}`
  }
});
```
I have actually needed this before so its not useless

### Test Coverage

No test coverage sorry :(
