### PR TITLE
Add boolean argument support to ScratchX compatibility layer

### DIFF
--- a/src/extension-support/tw-scratchx-compatibility-layer.js
+++ b/src/extension-support/tw-scratchx-compatibility-layer.js
@@ -79,6 +79,11 @@ const parseScratchXArgument = (argument, defaultValue) => {
         const split = argument.split(/\.|:/);
         const menuName = split[1];
         result.menu = menuName;
+    } else if (argument === 'b') {
+        result.type = ArgumentType.BOOLEAN;
+        if (!hasDefaultValue) {
+            result.defaultValue = '';
+        }
     } else {
         throw new Error(`Unknown ScratchX argument type: ${argument}`);
     }

--- a/src/extension-support/tw-scratchx-compatibility-layer.js
+++ b/src/extension-support/tw-scratchx-compatibility-layer.js
@@ -60,11 +60,12 @@ const isScratchCompatibleValue = v => typeof v === 'string' || typeof v === 'num
 const parseScratchXArgument = (argument, defaultValue) => {
     const result = {};
     const hasDefaultValue = isScratchCompatibleValue(defaultValue);
+
     // defaultValue is ignored for booleans in Scratch 3
     if (hasDefaultValue && argument !== 'b') {
         result.defaultValue = defaultValue;
     }
-    // TODO: ScratchX docs don't mention support for boolean arguments?
+
     if (argument === 's') {
         result.type = ArgumentType.STRING;
         if (!hasDefaultValue) {

--- a/src/extension-support/tw-scratchx-compatibility-layer.js
+++ b/src/extension-support/tw-scratchx-compatibility-layer.js
@@ -60,7 +60,8 @@ const isScratchCompatibleValue = v => typeof v === 'string' || typeof v === 'num
 const parseScratchXArgument = (argument, defaultValue) => {
     const result = {};
     const hasDefaultValue = isScratchCompatibleValue(defaultValue);
-    if (hasDefaultValue) {
+    // defaultValue is ignored for booleans in Scratch 3
+    if (hasDefaultValue && argument !== 'b') {
         result.defaultValue = defaultValue;
     }
     // TODO: ScratchX docs don't mention support for boolean arguments?
@@ -81,9 +82,6 @@ const parseScratchXArgument = (argument, defaultValue) => {
         result.menu = menuName;
     } else if (argument === 'b') {
         result.type = ArgumentType.BOOLEAN;
-        if (!hasDefaultValue) {
-            result.defaultValue = '';
-        }
     } else {
         throw new Error(`Unknown ScratchX argument type: ${argument}`);
     }

--- a/test/unit/tw_scratchx.js
+++ b/test/unit/tw_scratchx.js
@@ -74,7 +74,7 @@ test('complex extension', async t => {
         return 'This value should be ignored.';
     };
 
-    const touching = sprite => sprite === 'Sprite9';
+    const touching = (sprite, bool) => sprite === 'Sprite9' && bool === true;
 
     const converted = convert(
         'My Extension',
@@ -235,11 +235,17 @@ test('complex extension', async t => {
     }), 'scratchxscratchxscratchx');
 
     t.equal(converted.touching({
-        0: 'Sprite1'
+        0: 'Sprite1',
+        1: true
     }), false);
     t.equal(converted.touching({
-        0: 'Sprite9'
+        0: 'Sprite9',
+        1: true
     }), true);
+    t.equal(converted.touching({
+        0: 'Sprite9',
+        1: false
+    }), false);
 
     t.end();
 });

--- a/test/unit/tw_scratchx.js
+++ b/test/unit/tw_scratchx.js
@@ -87,7 +87,7 @@ test('complex extension', async t => {
                 ['r', 'multiply %n by %n and append %s', 'multiplyAndAppend'],
                 ['R', 'repeat %m.myMenu %n', 'repeat', ''],
                 ['-'],
-                ['b', 'touching %s', 'touching', 'Sprite1']
+                ['b', 'touching %s %b', 'touching', 'Sprite1', 'ignored']
             ],
             menus: {
                 myMenu: ['abc', 'def', 123, true, false],
@@ -178,12 +178,15 @@ test('complex extension', async t => {
         '---',
         {
             opcode: 'touching',
-            text: 'touching [0]',
+            text: 'touching [0] [1]',
             blockType: 'Boolean',
             arguments: [
                 {
                     type: 'string',
                     defaultValue: 'Sprite1'
+                },
+                {
+                    type: 'Boolean'
                 }
             ]
         }


### PR DESCRIPTION
I noticed this ``// TODO: ScratchX docs don't mention support for boolean arguments?``.
I've been recently messing around with ScratchX extensions and noticed it uses "b" for the Boolean argument type.
This should get added for better ScratchX extension support.