### PR TITLE
 Add BlockType.INLINE support #2

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -664,7 +664,7 @@ class ScriptTreeGenerator {
                 const blockInfo = this.getBlockInfo(block.opcode);
                 if (blockInfo) {
                     const type = blockInfo.info.blockType;
-                    if (type === BlockType.REPORTER || type === BlockType.BOOLEAN) {
+                    if (type === BlockType.REPORTER || type === BlockType.BOOLEAN || type === BlockType.INLINE) {
                         return this.descendCompatLayer(block);
                     }
                 }
@@ -1416,7 +1416,7 @@ class ScriptTreeGenerator {
         const blockInfo = this.getBlockInfo(block.opcode);
         const blockType = (blockInfo && blockInfo.info && blockInfo.info.blockType) || BlockType.COMMAND;
         const substacks = {};
-        if (blockType === BlockType.CONDITIONAL || blockType === BlockType.LOOP) {
+        if (blockType === BlockType.CONDITIONAL || blockType === BlockType.LOOP || blockType === BlockType.INLINE) {
             for (const inputName in block.inputs) {
                 if (!inputName.startsWith('SUBSTACK')) continue;
                 const branchNum = inputName === 'SUBSTACK' ? 1 : +inputName.substring('SUBSTACK'.length);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1427,7 +1427,7 @@ class Runtime extends EventEmitter {
                 blockJSON.nextStatement = null; // null = available connection; undefined = terminal
             }
             break;
-       case BlockType.INLINE:
+        case BlockType.INLINE:
             blockJSON.output = null;
             blockInfo.disableMonitor = true;
             blockInfo.branchCount = blockInfo.branchCount || 1;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1427,6 +1427,12 @@ class Runtime extends EventEmitter {
                 blockJSON.nextStatement = null; // null = available connection; undefined = terminal
             }
             break;
+       case BlockType.INLINE:
+            blockJSON.output = null;
+            blockInfo.disableMonitor = true;
+            blockInfo.branchCount = blockInfo.branchCount || 1;
+            blockJSON.outputShape = ScratchBlocksConstants.OUTPUT_SHAPE_SQUARE;
+            break;
         }
 
         const blockText = Array.isArray(blockInfo.text) ? blockInfo.text : [blockInfo.text];

--- a/src/extension-support/block-type.js
+++ b/src/extension-support/block-type.js
@@ -54,7 +54,13 @@ const BlockType = {
     /**
      * Arbitrary scratch-blocks XML.
      */
-    XML: 'xml'
+    XML: 'xml',
+
+    /**
+     * Specialized reporter block that allows for the insertion and evaluation
+     * of a substack.
+     */
+    INLINE: 'inline'
 };
 
 module.exports = BlockType;


### PR DESCRIPTION


I deleted my head repo a while ago so I am remaking this pr (https://github.com/TurboWarp/scratch-vm/pull/217)

### Resolves

Nothing is resolved this is just a new feature.

### Proposed Changes

Adds `BlockType.INLINE` support in full (so compiler support)
This takes the second approach of https://github.com/TurboWarp/scratch-vm/pull/187#issuecomment-1909147877
And this PR can be used as a replacement for https://github.com/TurboWarp/scratch-vm/pull/187 itself.

### Reason for Changes

The need for ugly inline patches and hacky thread stuff.

### Test Coverage

No tests but I did try with a extension.
```js
(function(Scratch) {
  class InlineBlockTest {
    getInfo() {
      return {
        id: 'InlineBlockTest',
        name: 'Test: Inline Block',
        blocks: [{
          blockType: Scratch.BlockType.INLINE,
          opcode: 'block',
          text: 'inline',
        }]
      }
    }
    async block(_, util) {
      await (Promise.resolve());
      util.startBranch(1, true); // Loop does not actually work like "loop"
      return 'test';
    }
  }
  Scratch.extensions.register(new InlineBlockTest);
})(Scratch);
```
