### PR TITLE
Expose ArgumentTypeMap (iwnafhwtb for runtime)

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -534,6 +534,18 @@ class Runtime extends EventEmitter {
          * Total number of finished or errored scratch-storage load() requests since the runtime was created or cleared.
          */
         this.finishedAssetRequests = 0;
+
+        /**
+         * Export some internal values for extensions.
+         */
+        this.exports = {
+            i_will_not_ask_for_help_when_these_break: () => {
+                console.warn('You are using unsupported APIs. WHEN your code breaks, do not expect help.');
+                return ({
+                    ArgumentTypeMap
+                });
+            }
+        };
     }
 
     /**


### PR DESCRIPTION

### Resolves

Nothing

### Proposed Changes

Exposes ArgumentTypeMap in exports.
I added the same i_will_not_ask_for_help_when_these_break thing for the export.

### Reason for Changes

Allows extensions to add new types or edit existing types while letting the runtime not cry.

### Test Coverage

No tests sorry
