### PR TITLE
fix isRecursiveCall failing on flyout blocks

### DIFF
--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -451,7 +451,8 @@ class Thread {
         let callCount = 5; // Max number of enclosing procedure calls to examine.
         const sp = this.stackFrames.length - 1;
         for (let i = sp - 1; i >= 0; i--) {
-            const block = this.target.blocks.getBlock(this.stackFrames[i].op.id);
+            const block = this.target.blocks.getBlock(this.stackFrames[i].op.id) ||
+                this.target.runtime.flyoutBlocks.getBlock(this.stackFrames[i].op.id);
             if (block.opcode === 'procedures_call' &&
                 block.mutation.proccode === procedureCode) {
                 return true;


### PR DESCRIPTION
### Resolves

![image](https://github.com/user-attachments/assets/a970b440-28a4-4920-8e0d-c670a38b7820)

When in interpreter mode, clicking "b" in the flyout will cause exceptions:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'opcode')
    at a.isRecursiveCall (thread.js:455:23)
    at c.stepToProcedure (sequencer.js:321:36)
    at Object.startProcedure (block-utility.js:154:24)
    at Object.call (scratch3_procedures.js:92:14)
    at push.e.exports (execute.js:531:40)
    at c.stepThread (sequencer.js:216:17)
    at c.stepThreads (sequencer.js:129:26)
    at c.stepThreads (module.js:385:32)
    at Y._step (runtime.js:2537:44)
    at Y._step (userscript.js:237:30)
```

### Proposed Changes

Fixed the issue by adding flyoutBlocks as a fallback.

### Reason for Changes

I don't know.

### Test Coverage

N/A
