### PR TITLE
Allow `refreshBlocks()` to specify extension

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -277,19 +277,22 @@ class ExtensionManager {
 
     /**
      * Regenerate blockinfo for any loaded extensions
+     * @param {string=} optExtensionId Optional extension ID for refreshing
      * @returns {Promise} resolved once all the extensions have been reinitialized
      */
-    refreshBlocks () {
-        const allPromises = Array.from(this._loadedExtensions.values()).map(serviceName =>
-            dispatch.call(serviceName, 'getInfo')
-                .then(info => {
-                    info = this._prepareExtensionInfo(serviceName, info);
-                    dispatch.call('runtime', '_refreshExtensionPrimitives', info);
-                })
-                .catch(e => {
-                    log.error('Failed to refresh built-in extension primitives', e);
-                })
-        );
+    refreshBlocks (optExtensionId) {
+        const refresh = serviceName => dispatch.call(serviceName, 'getInfo')
+            .then(info => {
+                info = this._prepareExtensionInfo(serviceName, info);
+                dispatch.call('runtime', '_refreshExtensionPrimitives', info);
+            })
+            .catch(e => {
+                log.error('Failed to refresh built-in extension primitives', e);
+            });
+        if (optExtensionId && this._loadedExtensions.has(optExtensionId)) {
+            return refresh(this._loadedExtensions.get(optExtensionId));
+        }
+        const allPromises = Array.from(this._loadedExtensions.values()).map(refresh);
         return Promise.all(allPromises);
     }
 

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -277,7 +277,7 @@ class ExtensionManager {
 
     /**
      * Regenerate blockinfo for any loaded extensions
-     * @param {string=} optExtensionId Optional extension ID for refreshing
+     * @param {string} [optExtensionId] Optional extension ID for refreshing
      * @returns {Promise} resolved once all the extensions have been reinitialized
      */
     refreshBlocks (optExtensionId) {
@@ -289,7 +289,10 @@ class ExtensionManager {
             .catch(e => {
                 log.error('Failed to refresh built-in extension primitives', e);
             });
-        if (optExtensionId && this._loadedExtensions.has(optExtensionId)) {
+        if (optExtensionId) {
+            if (!this._loadedExtensions.has(optExtensionId)) {
+                throw new Error(`Unknown extension: ${optExtensionId}`);
+            }
             return refresh(this._loadedExtensions.get(optExtensionId));
         }
         const allPromises = Array.from(this._loadedExtensions.values()).map(refresh);

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -291,7 +291,7 @@ class ExtensionManager {
             });
         if (optExtensionId) {
             if (!this._loadedExtensions.has(optExtensionId)) {
-                throw new Error(`Unknown extension: ${optExtensionId}`);
+                return Promise.reject(new Error(`Unknown extension: ${optExtensionId}`));
             }
             return refresh(this._loadedExtensions.get(optExtensionId));
         }


### PR DESCRIPTION
### Resolves

The base of dynamic blocks.

### Proposed Changes

Added a optional parameter to `refreshBlocks`, allowing specify which extension to refresh.

### Reason for Changes

Performance considerations. This change was originally made by Gandi IDE, used for dynamic blocks (maybe), and I think we also need one.

### Test Coverage

N/A. No tests for `refreshBlocks` found.
