### PR TITLE
Support framerates higher than 250 for faster I/O event handling

### DIFF
--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -103,9 +103,13 @@ class Scratch3ProcedureBlocks {
     argumentReporterStringNumber (args, util) {
         const value = util.getParam(args.VALUE);
         if (value === null) {
-            // tw: support legacy block
-            if (String(args.VALUE).toLowerCase() === 'last key pressed') {
+            // tw: support legacy block and screen refresh time
+            const lowercaseValue = String(args.VALUE).toLowerCase();
+            if (lowercaseValue === 'last key pressed') {
                 return util.ioQuery('keyboard', 'getLastKeyPressed');
+            }
+            if (lowercaseValue === 'screen refresh time') {
+                return this.runtime.screenRefreshTime;
             }
             // When the parameter is not found in the most recent procedure
             // call, the default is always 0.

--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -103,13 +103,9 @@ class Scratch3ProcedureBlocks {
     argumentReporterStringNumber (args, util) {
         const value = util.getParam(args.VALUE);
         if (value === null) {
-            // tw: support legacy block and screen refresh time
-            const lowercaseValue = String(args.VALUE).toLowerCase();
-            if (lowercaseValue === 'last key pressed') {
+            // tw: support legacy block
+            if (String(args.VALUE).toLowerCase() === 'last key pressed') {
                 return util.ioQuery('keyboard', 'getLastKeyPressed');
-            }
-            if (lowercaseValue === 'screen refresh time') {
-                return this.runtime.screenRefreshTime;
             }
             // When the parameter is not found in the most recent procedure
             // call, the default is always 0.

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -244,6 +244,7 @@ class Scratch3SensingBlocks {
 
     current (args) {
         const menuOption = Cast.toString(args.CURRENTMENU).toLowerCase();
+        if (menuOption === 'refreshtime') return (this.runtime.screenRefreshTime / 1000);
         const date = new Date();
         switch (menuOption) {
         case 'year': return date.getFullYear();

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -194,6 +194,11 @@ class ScriptTreeGenerator {
                         kind: 'tw.lastKeyPressed'
                     };
                 }
+                if (name.toLowerCase() === 'screen refresh time') {
+                    return {
+                        kind: 'tw.screenRefreshTime'
+                    };
+                }
             }
             if (index === -1) {
                 return {

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -194,11 +194,6 @@ class ScriptTreeGenerator {
                         kind: 'tw.lastKeyPressed'
                     };
                 }
-                if (name.toLowerCase() === 'screen refresh time') {
-                    return {
-                        kind: 'tw.screenRefreshTime'
-                    };
-                }
             }
             if (index === -1) {
                 return {
@@ -588,6 +583,10 @@ class ScriptTreeGenerator {
             case 'second':
                 return {
                     kind: 'sensing.second'
+                };
+            case 'refreshtime':
+                return {
+                    kind: 'sensing.refrehTime'
                 };
             }
             return {

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -586,7 +586,7 @@ class ScriptTreeGenerator {
                 };
             case 'refreshtime':
                 return {
-                    kind: 'sensing.refrehTime'
+                    kind: 'sensing.refreshTime'
                 };
             }
             return {

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -724,6 +724,8 @@ class JSGenerator {
         }
         case 'sensing.second':
             return new TypedInput(`(new Date().getSeconds())`, TYPE_NUMBER);
+        case 'sensing.refreshTime':
+            return new TypedInput('(runtime.screenRefreshTime / 1000)', TYPE_NUMBER);
         case 'sensing.touching':
             return new TypedInput(`target.isTouchingObject(${this.descendInput(node.object).asUnknown()})`, TYPE_BOOLEAN);
         case 'sensing.touchingColor':
@@ -738,9 +740,6 @@ class JSGenerator {
 
         case 'tw.lastKeyPressed':
             return new TypedInput('runtime.ioDevices.keyboard.getLastKeyPressed()', TYPE_STRING);
-
-        case 'tw.screenRefreshTime':
-            return new TypedInput('(runtime.screenRefreshTime / 1000)', TYPE_NUMBER);
 
         case 'var.get':
             return this.descendVariable(node.variable);

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -739,6 +739,9 @@ class JSGenerator {
         case 'tw.lastKeyPressed':
             return new TypedInput('runtime.ioDevices.keyboard.getLastKeyPressed()', TYPE_STRING);
 
+        case 'tw.screenRefreshTime':
+            return new TypedInput('(runtime.screenRefreshTime / 1000)', TYPE_NUMBER);
+
         case 'var.get':
             return this.descendVariable(node.variable);
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -194,12 +194,6 @@ let stepProfilerId = -1;
 let stepThreadsProfilerId = -1;
 
 /**
- * Numeric ID for RenderWebGL.draw in Profiler instances.
- * @type {number}
- */
-let rendererDrawProfilerId = -1;
-
-/**
  * Manages targets, scripts, and the sequencer.
  * @constructor
  */
@@ -2548,24 +2542,24 @@ class Runtime extends EventEmitter {
         // Store threads that completed this iteration for testing and other
         // internal purposes.
         this._lastStepDoneThreads = doneThreads;
-        if (this.renderer) {
-            // @todo: Only render when this.redrawRequested or clones rendered.
-            if (this.profiler !== null) {
-                if (rendererDrawProfilerId === -1) {
-                    rendererDrawProfilerId = this.profiler.idByName('RenderWebGL.draw');
-                }
-                this.profiler.start(rendererDrawProfilerId);
-            }
-            // tw: do not draw if document is hidden or a rAF loop is running
-            // Checking for the animation frame loop is more reliable than using
-            // interpolationEnabled in some edge cases
-            if (!document.hidden && !this.frameLoop._interpolationAnimation) {
-                this.renderer.draw();
-            }
-            if (this.profiler !== null) {
-                this.profiler.stop();
-            }
-        }
+        // if (this.renderer) {
+        //     // @todo: Only render when this.redrawRequested or clones rendered.
+        //     if (this.profiler !== null) {
+        //         if (rendererDrawProfilerId === -1) {
+        //             rendererDrawProfilerId = this.profiler.idByName('RenderWebGL.draw');
+        //         }
+        //         this.profiler.start(rendererDrawProfilerId);
+        //     }
+        //     // tw: do not draw if document is hidden or a rAF loop is running
+        //     // Checking for the animation frame loop is more reliable than using
+        //     // interpolationEnabled in some edge cases
+        //     if (!document.hidden && !this.frameLoop._interpolationAnimation) {
+        //         this.renderer.draw();
+        //     }
+        //     if (this.profiler !== null) {
+        //         this.profiler.stop();
+        //     }
+        // }
 
         if (this._refreshTargets) {
             this.emit(Runtime.TARGETS_UPDATE, false /* Don't emit project changed */);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2622,9 +2622,6 @@ class Runtime extends EventEmitter {
      * @param {number} framerate Target frames per second
      */
     setFramerate (framerate) {
-        // Setting framerate to anything greater than this is unnecessary and can break the sequencer
-        // Additionally, the JS spec says intervals can't run more than once every 4ms (250/s) anyways
-        // if (framerate > 250) framerate = 250;
         // Convert negative framerates to 1FPS
         // Note that 0 is a special value which means "matching device screen refresh rate"
         if (framerate < 0) framerate = 1;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2477,7 +2477,7 @@ class Runtime extends EventEmitter {
     }
 
     _renderInterpolatedPositions () {
-        const frameStarted = this.frameLoop._lastRenderTime;
+        const frameStarted = this.frameLoop._lastStepTime;
         const now = this.frameLoop.now();
         const timeSinceStart = now - frameStarted;
         const progressInFrame = Math.min(1, Math.max(0, timeSinceStart / this.currentStepTime));
@@ -2564,10 +2564,6 @@ class Runtime extends EventEmitter {
             this.profiler.stop();
             this.profiler.reportFrames();
         }
-
-        // if (this.interpolationEnabled) {
-        //     this._lastStepTime = Date.now();
-        // }
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -439,6 +439,14 @@ class Runtime extends EventEmitter {
          */
         this.platform = Object.assign({}, platform);
 
+        /**
+         * Screen refresh time speculated from screen refresh rate, in milliseconds.
+         * Indicates time passed between two screen refreshments.
+         * Based on site isolation status, the resolution could be ~0.1ms or lower.
+         * @type {!number}
+         */
+        this.screenRefreshTime = 0;
+
         this._initScratchLink();
 
         this.resetRunId();
@@ -463,7 +471,6 @@ class Runtime extends EventEmitter {
 
         this.debug = false;
 
-        this._lastStepTime = Date.now();
         this.interpolationEnabled = false;
 
         this._defaultStoredSettings = this._generateAllProjectOptions();
@@ -2470,8 +2477,8 @@ class Runtime extends EventEmitter {
     }
 
     _renderInterpolatedPositions () {
-        const frameStarted = this._lastStepTime;
-        const now = Date.now();
+        const frameStarted = this.frameLoop._lastRenderTime;
+        const now = this.frameLoop.now();
         const timeSinceStart = now - frameStarted;
         const progressInFrame = Math.min(1, Math.max(0, timeSinceStart / this.currentStepTime));
 
@@ -2576,9 +2583,9 @@ class Runtime extends EventEmitter {
             this.profiler.reportFrames();
         }
 
-        if (this.interpolationEnabled) {
-            this._lastStepTime = Date.now();
-        }
+        // if (this.interpolationEnabled) {
+        //     this._lastStepTime = Date.now();
+        // }
     }
 
     /**
@@ -2639,7 +2646,7 @@ class Runtime extends EventEmitter {
     setFramerate (framerate) {
         // Setting framerate to anything greater than this is unnecessary and can break the sequencer
         // Additionally, the JS spec says intervals can't run more than once every 4ms (250/s) anyways
-        if (framerate > 250) framerate = 250;
+        // if (framerate > 250) framerate = 250;
         // Convert negative framerates to 1FPS
         // Note that 0 is a special value which means "matching device screen refresh rate"
         if (framerate < 0) framerate = 1;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2549,24 +2549,6 @@ class Runtime extends EventEmitter {
         // Store threads that completed this iteration for testing and other
         // internal purposes.
         this._lastStepDoneThreads = doneThreads;
-        // if (this.renderer) {
-        //     // @todo: Only render when this.redrawRequested or clones rendered.
-        //     if (this.profiler !== null) {
-        //         if (rendererDrawProfilerId === -1) {
-        //             rendererDrawProfilerId = this.profiler.idByName('RenderWebGL.draw');
-        //         }
-        //         this.profiler.start(rendererDrawProfilerId);
-        //     }
-        //     // tw: do not draw if document is hidden or a rAF loop is running
-        //     // Checking for the animation frame loop is more reliable than using
-        //     // interpolationEnabled in some edge cases
-        //     if (!document.hidden && !this.frameLoop._interpolationAnimation) {
-        //         this.renderer.draw();
-        //     }
-        //     if (this.profiler !== null) {
-        //         this.profiler.stop();
-        //     }
-        // }
 
         if (this._refreshTargets) {
             this.emit(Runtime.TARGETS_UPDATE, false /* Don't emit project changed */);

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -82,6 +82,9 @@ class Sequencer {
         // Whether `stepThreads` has run through a full single tick.
         let ranFirstTick = false;
         const doneThreads = [];
+
+        // tw: If this happens, the runtime is in initialization, do not execute any thread.
+        if (this.runtime.currentStepTime === 0) return [];
         // Conditions for continuing to stepping threads:
         // 1. We must have threads in the list, and some must be active.
         // 2. Time elapsed must be less than WORK_TIME.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -88,7 +88,6 @@ class Sequencer {
         // 3. Either turbo mode, or no redraw has been requested by a primitive.
         while (this.runtime.threads.length > 0 &&
                numActiveThreads > 0 &&
-               this.timer.timeElapsed() < WORK_TIME &&
                (this.runtime.turboMode || !this.runtime.redrawRequested)) {
             if (this.runtime.profiler !== null) {
                 if (stepThreadsInnerProfilerId === -1) {
@@ -164,6 +163,10 @@ class Sequencer {
                 }
                 this.runtime.threads.length = nextActiveThread;
             }
+
+            // tw: Detect timer here so the sequencer won't break when FPS is greater than 1000
+            // and performance.now() is not available.
+            if (this.timer.timeElapsed() < WORK_TIME) break;
         }
 
         this.activeThread = null;

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -166,7 +166,7 @@ class Sequencer {
 
             // tw: Detect timer here so the sequencer won't break when FPS is greater than 1000
             // and performance.now() is not available.
-            if (this.timer.timeElapsed() < WORK_TIME) break;
+            if (this.timer.timeElapsed() >= WORK_TIME) break;
         }
 
         this.activeThread = null;

--- a/src/engine/tw-frame-loop.js
+++ b/src/engine/tw-frame-loop.js
@@ -131,6 +131,7 @@ class FrameLoop {
                 _cancelAnimationFrame,
                 true
             );
+            this.runtime.currentStepTime = 0;
         } else {
             // Interpolation should never be enabled when framerate === 0 as that's just redundant
             this._renderInterval = taskWrapper(

--- a/src/engine/tw-frame-loop.js
+++ b/src/engine/tw-frame-loop.js
@@ -91,7 +91,7 @@ class FrameLoop {
                 if (this.runtime.profiler !== null) {
                     if (rendererDrawProfilerId === -1) {
                         rendererDrawProfilerId =
-                            this.profiler.idByName('RenderWebGL.draw');
+                            this.runtime.profiler.idByName('RenderWebGL.draw');
                     }
                     this.runtime.profiler.start(rendererDrawProfilerId);
                 }

--- a/src/engine/tw-frame-loop.js
+++ b/src/engine/tw-frame-loop.js
@@ -62,16 +62,14 @@ class FrameLoop {
     }
 
     stepCallback () {
-        const now = this.now();
         this.runtime._step();
-        this._lastStepTime = now;
+        this._lastStepTime = this.now();
     }
 
     stepImmediateCallback () {
-        const now = this.now();
-        if (now - this._lastStepTime >= this.runtime.currentStepTime) {
+        if (this.now() - this._lastStepTime >= this.runtime.currentStepTime) {
             this.runtime._step();
-            this._lastStepTime = now;
+            this._lastStepTime = this.now();
         }
     }
 

--- a/src/engine/tw-frame-loop.js
+++ b/src/engine/tw-frame-loop.js
@@ -20,9 +20,9 @@ const _cancelAnimationFrame =
 const taskWrapper = (callback, requestFn, cancelFn, manualInterval) => {
     let id;
     let cancelled = false;
-    const handle = (...args) => {
+    const handle = () => {
         if (manualInterval) id = requestFn(handle);
-        callback(...args);
+        callback();
     };
     const cancel = () => {
         if (!cancelled) cancelFn(id);
@@ -123,10 +123,10 @@ class FrameLoop {
         this.running = true;
         if (this.framerate === 0) {
             this._stepInterval = this._renderInterval = taskWrapper(
-                () => {
+                (() => {
                     this.stepCallback();
                     this.renderCallback();
-                },
+                }),
                 _requestAnimationFrame,
                 _cancelAnimationFrame,
                 true
@@ -139,8 +139,8 @@ class FrameLoop {
                 _cancelAnimationFrame,
                 true
             );
-            if (this.framerate > 250) {
-                // High precision implementation via setImmediate
+            if (this.framerate > 250 && global.setImmediate && global.clearImmediate) {
+                // High precision implementation via setImmediate (polyfilled)
                 // bug: very unfriendly to DevTools
                 this._stepInterval = taskWrapper(
                     this.stepImmediateCallback.bind(this),

--- a/src/engine/tw-frame-loop.js
+++ b/src/engine/tw-frame-loop.js
@@ -80,6 +80,8 @@ class FrameLoop {
                 if (!document.hidden) {
                     this.runtime._renderInterpolatedPositions();
                 }
+                this.runtime.screenRefreshTime = renderTime - this._lastRenderTime; // Screen refresh time (from rate)
+                this._lastRenderTime = renderTime;
             } else if (
                 renderTime - this._lastRenderTime >=
                 this.runtime.currentStepTime
@@ -101,12 +103,12 @@ class FrameLoop {
                 if (this.runtime.profiler !== null) {
                     this.runtime.profiler.stop();
                 }
+                this.runtime.screenRefreshTime = renderTime - this._lastRenderTime; // Screen refresh time (from rate)
+                this._lastRenderTime = renderTime;
+                if (this.framerate === 0) {
+                    this.runtime.currentStepTime = this.runtime.screenRefreshTime;
+                }
             }
-            this.runtime.screenRefreshTime = renderTime - this._lastRenderTime; // Screen refresh time (from rate)
-            if (this.framerate === 0) {
-                this.runtime.currentStepTime = this.runtime.screenRefreshTime;
-            }
-            this._lastRenderTime = renderTime;
         }
     }
 

--- a/src/engine/tw-frame-loop.js
+++ b/src/engine/tw-frame-loop.js
@@ -83,6 +83,7 @@ class FrameLoop {
                 this.runtime.screenRefreshTime = renderTime - this._lastRenderTime; // Screen refresh time (from rate)
                 this._lastRenderTime = renderTime;
             } else if (
+                this.framerate === 0 ||
                 renderTime - this._lastRenderTime >=
                 this.runtime.currentStepTime
             ) {


### PR DESCRIPTION
### Resolves

See `Reason for Changes`.

### Proposed Changes

This Pull Request refactors (entire) frameLoop to allow **meaningful** framerates higher than 250. This is a experimental change, however it won't break anything.

Now framerates higher than 250 will use deprecated `setImmediate` (this is fine because it is polyfilled by https://www.npmjs.com/package/setimmediate) instead of `setTimeout` to call `vm.runtime._step`, allowing the engine to capture multiple `DOM` events before screen drawing.

The `vm.runtime.renderer.draw()` is now synchronized with screen refresh rate while interpolation still works.

Newly added features:

#### `vm.runtime.screenRefreshTime`

Screen refresh time speculated from screen refresh rate, in milliseconds. Indicates time passed between two screen refreshments. Based on site isolation status, the resolution could be ~0.1ms or lower.

#### sensing_current `screen refresh time` (field value `refreshtime`)

Indicates screen refresh time (described above) **in seconds**. This is required for Scratch projects to detect when to draw, for example:

![image](https://github.com/user-attachments/assets/12f4d28f-6053-4c47-a406-00b56de7338f)

(The argument reporter is replaced with `sensing_current` now)

If the program is running on a `60Hz` monitor with `480 FPS`, it will run with **90 rendering frames** (to avoid sudden frame dropping) and **480 logic frames**.

### Reason for Changes

Consider this situation:

1. You are using a 60Hz monitor however the framerate is set to 240 (this actually makes the game smoother).

There are only 60 screen updates every second while `vm.runtime.renderer.draw()` is called 240 times, which means that **180** calls are unnecessary.

2. Some **rhythm games** require higher I/O (keyboard, mouse, etc.) sample rate for inputs.

They could do this by changing framerate, but it is impossible to set framerate (= I/O sample rate) higher than 250.

### Test Coverage

N/A. This is basically browser stuff. However, all tests are passed and it works fine with pen & sprite projects.

### Additional Information

It is recommended to squash merge this Pull Request.