### PR TITLE
Expose the `Variable` class onto VM exports

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -221,6 +221,7 @@ class VirtualMachine extends EventEmitter {
             Sprite,
             RenderedTarget,
             JSZip,
+            Variable,
 
             i_will_not_ask_for_help_when_these_break: () => {
                 console.warn('You are using unsupported APIs. WHEN your code breaks, do not expect help.');


### PR DESCRIPTION
Exposes the `Variable` class in the VM.

This is mainly for extensions and is harmless.