### PR TITLE
Loosen platform compatibility checks

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -1483,7 +1483,7 @@ const checkPlatformCompatibility = (json, runtime) => {
     }
 
     const projectPlatform = json.meta.platform.name;
-    if (projectPlatform === runtime.platform.name) {
+    if (projectPlatform.includes(runtime.platform.name)) {
         return;
     }
 


### PR DESCRIPTION
### Proposed Changes

This pull request updates the platform checking functionality in TW so that it checks if TW's platform name is included in a given project's platform name.

### Reason for Changes

The current platform checking logic in TW can lead to incompatibility issues with other platforms that include the TW name in their platform name, (e.g. cross-compilers and other addons that are compatible with TW and other Scratch modifications). To address this issue and allow for broader compatibility, the logic has been updated to check if the 'TurboWarp' (`runtime.platform.name`) string is included in the platform name, rather than strictly matching the name exactly. This improves compatibility without compromising the integrity of the platform checking functionality, reminiscent of useragents in the http/https protocol.

### Test Coverage

As this pull request involves a simple change in logic from using `===` to `includes()`, no tests were required to verify the behaviour of the change. This is because the test coverage of this particular area was already sufficient. The `string.includes()` function is standard JavaScript, therefore testing isn't mandatory, nor should be. (...at least I hope so)

### TL;DR
remove annoying pop-up if platform name is not exactly 'TurboWarp' but addon is compatible with it