### PR TITLE
Allow re-evaluation of specific arguments (compiler)

### DIFF
--- a/src/compiler/compat-block-utility.js
+++ b/src/compiler/compat-block-utility.js
@@ -33,6 +33,7 @@ class CompatibilityLayerBlockUtility extends BlockUtility {
         this.thread = thread;
         this.sequencer = thread.target.runtime.sequencer;
         this._startedBranch = null;
+        this._forceRevaluationOfArguments = false;
         thread.stack[0] = fakeBlockId;
         thread.compatibilityStackFrame = stackFrame;
     }

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -173,7 +173,9 @@ const executeInCompatibilityLayer = function*(inputs, blockFunction, isWarp, use
             }
             for (const inputName of reEvaluate) {
                 if (!inputNames.has(inputName)) continue;
-                const inputValue = yield* (inputs[inputName]());
+                const inputValue = (
+                    typeof inputs[inputName] === 'function'
+                 ) ? (yield* (inputs[inputName]())) : inputs[inputName];
                 inputCache[inputName] = inputValue;
                 if (callInputs) callInputs[inputName] = inputValue;
             }

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -157,7 +157,11 @@ const executeInCompatibilityLayer = function*(inputs, blockFunction, isWarp, use
     const executeBlock = function*() {
         let callInputs, reEvaluate = new Set();
         if (firstRun || blockUtility._forceRevaluationOfArguments) {
-            firstRun = false;
+            if (firstRun) {
+                blockUtility._forceRevaluationOfArguments = false;
+                reEvaluate = inputNames;
+                firstRun = false;
+            }
             if (blockUtility._forceRevaluationOfArguments) {
                 if (Array.isArray(blockUtility._forceRevaluationOfArguments)) {
                     reEvaluate = new Set(blockUtility._forceRevaluationOfArguments);
@@ -168,6 +172,7 @@ const executeInCompatibilityLayer = function*(inputs, blockFunction, isWarp, use
                 callInputs = {};
             }
             for (const inputName of reEvaluate) {
+                if (!inputNames.has(inputName)) continue;
                 const inputValue = yield* (inputs[inputName]());
                 inputCache[inputName] = inputValue;
                 if (callInputs) callInputs[inputName] = inputValue;

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -1333,7 +1333,7 @@ class JSGenerator {
         for (const inputName of Object.keys(node.inputs)) {
             const input = node.inputs[inputName];
             const compiledInput = this.descendInput(input).asSafe();
-            result += `"${sanitize(inputName)}":${compiledInput},`;
+            result += `"${sanitize(inputName)}":(function*(){ return( ${compiledInput} ); }),`;
         }
         for (const fieldName of Object.keys(node.fields)) {
             const field = node.fields[fieldName];
@@ -1445,7 +1445,8 @@ JSGenerator.unstable_exports = {
     ConstantInput,
     VariableInput,
     Frame,
-    sanitize
+    sanitize,
+    jsexecute
 };
 
 // Test hook used by automated snapshot testing.


### PR DESCRIPTION

### Resolves

A bunch of stuff on discord.

### Proposed Changes

This lets you pick arguments to re-evaluate using a "hidden" method.

This keeps the old compiler behaviour of keeping the old argument values on yield, but
this lets you use the interpreter behaviour of re-evaluating the arguments on yield. (more selective though)

### Reason for Changes

Makes extension development that requires re-evaluation of arguments much easier.

### Test Coverage

No tests sadly.
