### PR TITLE
Add compatibility layer for extensions relying on old compiler

### DIFF
--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -103,6 +103,7 @@ const StackOpcode = {
     DEBUGGER: 'tw.debugger',
     VISUAL_REPORT: 'visualReport',
     COMPATIBILITY_LAYER: 'compat',
+    OLD_COMPILER_COMPATIBILITY_LAYER: 'oldCompiler',
 
     HAT_EDGE: 'hat.edge',
     HAT_PREDICATE: 'hat.predicate',
@@ -201,6 +202,7 @@ const InputOpcode = {
     CAST_COLOR: 'cast.toColor',
 
     COMPATIBILITY_LAYER: 'compat',
+    OLD_COMPILER_COMPATIBILITY_LAYER: 'oldCompiler',
 
     LOOKS_BACKDROP_NUMBER: 'looks.backdropNumber',
     LOOKS_BACKDROP_NAME: 'looks.backdropName',

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -607,6 +607,13 @@ class ScriptTreeGenerator {
      * @returns {IntermediateStackBlock} Compiled node for this block.
      */
     descendStackedBlock (block) {
+        if (this.oldCompilerStub) {
+            const oldCompilerResult = this.oldCompilerStub.descendStackedBlockFromNewCompiler(block);
+            if (oldCompilerResult) {
+                return oldCompilerResult;
+            }
+        }
+
         switch (block.opcode) {
         case 'control_all_at_once':
             // In Scratch 3, this block behaves like "if 1 = 1"

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -98,7 +98,11 @@ class ScriptTreeGenerator {
             }
         }
 
-        this.oldCompilerStub = new oldCompilerCompatiblity.ScriptTreeGeneratorStub(this);
+        this.oldCompilerStub = (
+            oldCompilerCompatiblity.enabled ?
+                new oldCompilerCompatiblity.ScriptTreeGeneratorStub(this) :
+                null
+        );
     }
 
     setProcedureVariant (procedureVariant) {
@@ -202,6 +206,13 @@ class ScriptTreeGenerator {
      * @returns {IntermediateInput} Compiled input node for this input.
      */
     descendInput (block, preserveStrings = false) {
+        if (this.oldCompilerStub) {
+            const oldCompilerResult = this.oldCompilerStub.descendInputFromNewCompiler(block);
+            if (oldCompilerResult) {
+                return oldCompilerResult;
+            }
+        }
+
         switch (block.opcode) {
         case 'colour_picker':
             return this.createConstantInput(block.fields.COLOUR.value, true);
@@ -566,14 +577,7 @@ class ScriptTreeGenerator {
                 if (compatBlocks.inputs.includes(block.opcode)) {
                     return this.descendCompatLayerInput(block);
                 }
-
-                // It might be an extension block using patches for the old compiler.
-                const oldCompilerResult = this.oldCompilerStub.descendInputFromNewCompiler(block);
-                if (oldCompilerResult) {
-                    return oldCompilerResult;
-                }
-
-                // It might be an extension block using the default compatibility layer.
+                // It might be an extension block.
                 const blockInfo = this.getBlockInfo(block.opcode);
                 if (blockInfo) {
                     const type = blockInfo.info.blockType;
@@ -603,6 +607,13 @@ class ScriptTreeGenerator {
      * @returns {IntermediateStackBlock} Compiled node for this block.
      */
     descendStackedBlock (block) {
+        if (this.oldCompilerStub) {
+            const oldCompilerResult = this.oldCompilerStub.descendStackedBlockFromNewCompiler(block);
+            if (oldCompilerResult) {
+                return oldCompilerResult;
+            }
+        }
+
         switch (block.opcode) {
         case 'control_all_at_once':
             // In Scratch 3, this block behaves like "if 1 = 1"
@@ -944,14 +955,7 @@ class ScriptTreeGenerator {
                 if (compatBlocks.stacked.includes(block.opcode)) {
                     return this.descendCompatLayerStack(block);
                 }
-
-                // It might be an extension block using patches for the old compiler.
-                const oldCompilerResult = this.oldCompilerStub.descendStackedBlockFromNewCompiler(block);
-                if (oldCompilerResult) {
-                    return oldCompilerResult;
-                }
-
-                // It might be an extension block using the default compatibility layer.
+                // It might be an extension block.
                 const blockInfo = this.getBlockInfo(block.opcode);
                 if (blockInfo) {
                     const type = blockInfo.info.blockType;

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -14,6 +14,7 @@ const {
     IntermediateScript,
     IntermediateRepresentation
 } = require('./intermediate');
+const oldCompilerCompatiblity = require('./old-compiler-compatibility.js');
 
 /**
  * @fileoverview Generate intermediate representations from Scratch blocks.
@@ -96,6 +97,12 @@ class ScriptTreeGenerator {
                 }
             }
         }
+
+        this.oldCompilerStub = (
+            oldCompilerCompatiblity.enabled ?
+                new oldCompilerCompatiblity.ScriptTreeGeneratorStub(this) :
+                null
+        );
     }
 
     setProcedureVariant (procedureVariant) {
@@ -199,6 +206,13 @@ class ScriptTreeGenerator {
      * @returns {IntermediateInput} Compiled input node for this input.
      */
     descendInput (block, preserveStrings = false) {
+        if (this.oldCompilerStub) {
+            const oldCompilerResult = this.oldCompilerStub.descendInputFromNewCompiler(block);
+            if (oldCompilerResult) {
+                return oldCompilerResult;
+            }
+        }
+
         switch (block.opcode) {
         case 'colour_picker':
             return this.createConstantInput(block.fields.COLOUR.value, true);

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -98,11 +98,7 @@ class ScriptTreeGenerator {
             }
         }
 
-        this.oldCompilerStub = (
-            oldCompilerCompatiblity.enabled ?
-                new oldCompilerCompatiblity.ScriptTreeGeneratorStub(this) :
-                null
-        );
+        this.oldCompilerStub = new oldCompilerCompatiblity.ScriptTreeGeneratorStub(this);
     }
 
     setProcedureVariant (procedureVariant) {
@@ -206,13 +202,6 @@ class ScriptTreeGenerator {
      * @returns {IntermediateInput} Compiled input node for this input.
      */
     descendInput (block, preserveStrings = false) {
-        if (this.oldCompilerStub) {
-            const oldCompilerResult = this.oldCompilerStub.descendInputFromNewCompiler(block);
-            if (oldCompilerResult) {
-                return oldCompilerResult;
-            }
-        }
-
         switch (block.opcode) {
         case 'colour_picker':
             return this.createConstantInput(block.fields.COLOUR.value, true);
@@ -577,7 +566,14 @@ class ScriptTreeGenerator {
                 if (compatBlocks.inputs.includes(block.opcode)) {
                     return this.descendCompatLayerInput(block);
                 }
-                // It might be an extension block.
+
+                // It might be an extension block using patches for the old compiler.
+                const oldCompilerResult = this.oldCompilerStub.descendInputFromNewCompiler(block);
+                if (oldCompilerResult) {
+                    return oldCompilerResult;
+                }
+
+                // It might be an extension block using the default compatibility layer.
                 const blockInfo = this.getBlockInfo(block.opcode);
                 if (blockInfo) {
                     const type = blockInfo.info.blockType;
@@ -607,13 +603,6 @@ class ScriptTreeGenerator {
      * @returns {IntermediateStackBlock} Compiled node for this block.
      */
     descendStackedBlock (block) {
-        if (this.oldCompilerStub) {
-            const oldCompilerResult = this.oldCompilerStub.descendStackedBlockFromNewCompiler(block);
-            if (oldCompilerResult) {
-                return oldCompilerResult;
-            }
-        }
-
         switch (block.opcode) {
         case 'control_all_at_once':
             // In Scratch 3, this block behaves like "if 1 = 1"
@@ -955,7 +944,14 @@ class ScriptTreeGenerator {
                 if (compatBlocks.stacked.includes(block.opcode)) {
                     return this.descendCompatLayerStack(block);
                 }
-                // It might be an extension block.
+
+                // It might be an extension block using patches for the old compiler.
+                const oldCompilerResult = this.oldCompilerStub.descendStackedBlockFromNewCompiler(block);
+                if (oldCompilerResult) {
+                    return oldCompilerResult;
+                }
+
+                // It might be an extension block using the default compatibility layer.
                 const blockInfo = this.getBlockInfo(block.opcode);
                 if (blockInfo) {
                     const type = blockInfo.info.blockType;

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -6,6 +6,7 @@ const VariablePool = require('./variable-pool');
 const jsexecute = require('./jsexecute');
 const environment = require('./environment');
 const {StackOpcode, InputOpcode, InputType} = require('./enums.js');
+const oldCompilerCompatibility = require('./old-compiler-compatibility.js');
 
 // These imports are used by jsdoc comments but eslint doesn't know that
 /* eslint-disable no-unused-vars */
@@ -124,6 +125,8 @@ class JSGenerator {
         this.isInHat = false;
 
         this.debug = this.target.runtime.debug;
+
+        this.oldCompilerStub = new oldCompilerCompatibility.JSGeneratorStub(this);
     }
 
     /**
@@ -197,6 +200,9 @@ class JSGenerator {
         case InputOpcode.COMPATIBILITY_LAYER:
             // Compatibility layer inputs never use flags.
             return `(${this.generateCompatibilityLayerCall(node, false)})`;
+
+        case InputOpcode.OLD_COMPILER_COMPATIBILITY_LAYER:
+            return this.oldCompilerStub.descendInputFromNewCompiler(block);
 
         case InputOpcode.CONSTANT:
             if (block.isAlwaysType(InputType.NUMBER)) {

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -546,6 +546,9 @@ class JSGenerator {
             break;
         }
 
+        case InputOpcode.OLD_COMPILER_COMPATIBILITY_LAYER:
+            return this.oldCompilerStub.descendStackedBlockFromNewCompiler(block);
+
         case StackOpcode.HAT_EDGE:
             this.isInHat = true;
             this.source += '{\n';

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -1,0 +1,217 @@
+const {InputOpcode, InputType} = require('./enums');
+const {IntermediateInput} = require('./intermediate');
+
+class IRGeneratorStub {
+}
+
+class ScriptTreeGeneratorStub {
+    constructor (real) {
+        /**
+         * The real script generator.
+         * @type {import("./irgen").ScriptTreeGenerator}
+         */
+        this.real = real;
+
+        this.fakeThis = {
+            descendInputOfBlock: this.descendInputOfBlockFromOldCompiler.bind(this)
+        };
+    }
+
+    /**
+     * Intended for extensions to override.
+     * Always call from `fakeThis` context.
+     * @param {{opcode: string}} block VM block
+     * @returns {{kind: string}} Node object from old compiler.
+     */
+    descendInput (block) { // eslint-disable-line no-unused-vars
+        return null;
+    }
+
+    /**
+     * Intended for extensions to override.
+     * Always call from `fakeThis` context.
+     * @param {{opcode: string}} block VM block
+     * @returns {{kind: string}} Node object from old compiler.
+     */
+    descendStackedBlock (block) { // eslint-disable-line no-unused-vars
+        return null;
+    }
+
+    /**
+     * Part of old compiler's public API.
+     * @param parentBlock Parent VM block.
+     * @param {string} inputName Name of input.
+     */
+    descendInputOfBlockFromOldCompiler (parentBlock, inputName) {
+        const node = this.real.descendInputOfBlock(parentBlock, inputName, true);
+        return node;
+    }
+
+    /**
+     * For internal use by new compiler only.
+     * @param block VM block
+     * @returns {IntermediateInput|null}
+     */
+    descendInputFromNewCompiler (block) {
+        const node = this.descendInput.call(this.fakeThis, block);
+        if (node) {
+            return new IntermediateInput(InputOpcode.OLD_COMPILER_COMPATIBILITY_LAYER, InputType.ANY, {
+                block: block,
+                oldNode: node
+            }, true);
+        }
+        return null;
+    }
+}
+
+const TYPE_NUMBER = 1;
+const TYPE_STRING = 2;
+const TYPE_BOOLEAN = 3;
+const TYPE_UNKNOWN = 4;
+const TYPE_NUMBER_NAN = 5;
+
+/**
+ * Part of the old compiler's public API.
+ */
+class TypedInput {
+    /**
+     * @param {string} source JavaScript
+     * @param {number|IntermediateInput} typeOrIntermediate
+     */
+    constructor (source, typeOrIntermediate) {
+        /**
+         * JavaScript.
+         * @type {string}
+         */
+        this.source = source;
+
+        if (typeOrIntermediate instanceof IntermediateInput) {
+            /**
+             * @type {IntermediateInput}
+             */
+            this.intermediate = typeOrIntermediate;
+        } else {
+            this.intermediate = null;
+            this.type = typeOrIntermediate;
+        }
+    }
+
+    asNumber () {
+        throw new Error('TODO asNumber');
+    }
+
+    asNumberOrNaN () {
+        throw new Error('TODO asNumberOrNaN');
+    }
+
+    asString () {
+        throw new Error('TODO asString');
+    }
+
+    asBoolean () {
+        throw new Error('TODO asBoolean');
+    }
+
+    asColor () {
+        throw new Error('TODO asColor');
+    }
+
+    asUnknown () {
+        return this.source;
+    }
+
+    asSafe () {
+        return this.source;
+    }
+
+    isAlwaysNumber () {
+        // TODO
+        return false;
+    }
+
+    isAlwaysNumberOrNaN () {
+        // TODO
+        return false;
+    }
+
+    isNeverNumber () {
+        // TODO
+        return false;
+    }
+}
+
+class JSGeneratorStub {
+    constructor (real) {
+        /**
+         * For internal use by new compiler only.
+         * @type {import("./jsgen")}
+         */
+        this.real = real;
+
+        this._fakeThis = {
+            descendInput: this.descendInputFromOldCompiler.bind(this)
+        };
+    }
+
+    /**
+     * Intended for extensions to override.
+     * Always call from `fakeThis` context.
+     * @param {{kind: string}} node Old compiler AST node.
+     * @returns {TypedInput} Old compiler TypedInput.
+     */
+    descendInput (node) {
+        throw new Error(`Unknown input: ${node.kind}`);
+    }
+
+    /**
+     * Part of old compiler's public API.
+     * @param {IntermediateInput} intermediate
+     * @returns {TypedInput}
+     */
+    descendInputFromOldCompiler (intermediate) {
+        const js = this.real.descendInput(intermediate);
+        return new TypedInput(js, intermediate);
+    }
+
+    /**
+     * @param {IntermediateInput} intermediate
+     * @returns {string} JavaScript
+     */
+    descendInputFromNewCompiler (intermediate) {
+        const oldNode = intermediate.inputs.oldNode;
+        const typedInput = this.descendInput.call(this._fakeThis, oldNode);
+        return typedInput.asSafe();
+    }
+}
+
+/**
+ * Part of old compiler's public API.
+ */
+JSGeneratorStub.unstable_exports = {
+    TYPE_NUMBER,
+    TYPE_STRING,
+    TYPE_BOOLEAN,
+    TYPE_UNKNOWN,
+    TYPE_NUMBER_NAN,
+    // factoryNameVariablePool,
+    // functionNameVariablePool,
+    // generatorNameVariablePool,
+    // VariablePool,
+    // PEN_EXT,
+    // PEN_STATE,
+    TypedInput
+    // ConstantInput,
+    // VariableInput,
+    // Frame,
+    // sanitize
+};
+
+const oldCompilerCompatibility = {
+    enabled: false,
+    IRGeneratorStub,
+    ScriptTreeGeneratorStub,
+    TypedInput,
+    JSGeneratorStub
+};
+
+module.exports = oldCompilerCompatibility;

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -35,6 +35,13 @@ class ScriptTreeGeneratorStub {
         this.real = real;
 
         this.fakeThis = {
+            thread: real.thread,
+            target: real.target,
+            blocks: real.blocks,
+            runtime: real.runtime,
+            stage: real.stage,
+            script: real.script,
+
             /**
              * @param parentBlock Parent VM block.
              * @param {string} inputName Name of input.
@@ -231,6 +238,17 @@ class JSGeneratorStub {
         this.real = real;
 
         this.fakeThis = {
+            script: real.script,
+            ir: real.ir,
+            target: real.target,
+
+            get frames () {
+                return real.frames;
+            },
+            get currentFrame () {
+                return real.currentFrame;
+            },
+
             get source () {
                 return real.source;
             },

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -319,7 +319,6 @@ class JSGeneratorStub {
      * @returns {void} source property on real JSGenerator is modified directly
      */
     descendStackedBlockFromNewCompiler (intermediate) {
-        this.fakeThis.source = '';
         const oldNode = intermediate.inputs.oldNode;
         this.descendStackedBlock.call(this.fakeThis, oldNode);
     }

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -1,19 +1,63 @@
+/**
+ * @fileoverview
+ * Reimplements a subset of the old (pre-September 2025) compiler
+ * to maintain compatibility with extensions patching the old compiler.
+ *
+ * Safety and compatibility is more important than performance. There may be
+ * unnecessary type casts and scripts may be marked as yielding even when they
+ * don't actually yield. Additionally, anything running in this compatibility layer
+ * is not expected to receive the performance benefits of the new compiler.
+ *
+ * These assumptions are made about extensions using this compatibility layer:
+ *  - Extensions do not try to combine this compatibility layer with any APIs
+ *    provided by the new compiler.
+ *  - Extensions treat IR nodes received from descendSubstack and similar as
+ *    opaque objects.
+ */
+
 const {InputOpcode, InputType} = require('./enums');
-const {IntermediateInput} = require('./intermediate');
+// eslint-disable-next-line no-unused-vars
+const {IntermediateInput, IntermediateStackBlock, IntermediateStack} = require('./intermediate');
 
 class IRGeneratorStub {
+
 }
 
 class ScriptTreeGeneratorStub {
+    /**
+     * @param {import("./irgen").ScriptTreeGenerator} real
+     */
     constructor (real) {
         /**
-         * The real script generator.
          * @type {import("./irgen").ScriptTreeGenerator}
          */
         this.real = real;
 
         this.fakeThis = {
-            descendInputOfBlock: this.descendInputOfBlockFromOldCompiler.bind(this)
+            /**
+             * @param parentBlock Parent VM block.
+             * @param {string} inputName Name of input.
+             * @returns opaque object
+             */
+            descendInputOfBlock (parentBlock, inputName) {
+                const node = real.descendInputOfBlock(parentBlock, inputName, true);
+                return node;
+            },
+
+            /**
+             * @param {*} parentBlock Parent VM block.
+             * @param {*} substackName Name of substack.
+             * @returns opaque object
+             */
+            descendSubstack (parentBlock, substackName) {
+                const substack = real.descendSubstack(parentBlock, substackName);
+                return substack;
+            },
+
+            analyzeLoop () {
+                // TODO: not always necessary
+                real.script.yields = true;
+            }
         };
     }
 
@@ -38,17 +82,6 @@ class ScriptTreeGeneratorStub {
     }
 
     /**
-     * Part of old compiler's public API.
-     * @param parentBlock Parent VM block.
-     * @param {string} inputName Name of input.
-     */
-    descendInputOfBlockFromOldCompiler (parentBlock, inputName) {
-        const node = this.real.descendInputOfBlock(parentBlock, inputName, true);
-        return node;
-    }
-
-    /**
-     * For internal use by new compiler only.
      * @param block VM block
      * @returns {IntermediateInput|null}
      */
@@ -56,7 +89,20 @@ class ScriptTreeGeneratorStub {
         const node = this.descendInput.call(this.fakeThis, block);
         if (node) {
             return new IntermediateInput(InputOpcode.OLD_COMPILER_COMPATIBILITY_LAYER, InputType.ANY, {
-                block: block,
+                oldNode: node
+            }, true);
+        }
+        return null;
+    }
+
+    /**
+     * @param block VM block
+     * @returns {IntermediateStackBlock|null}
+     */
+    descendStackedBlockFromNewCompiler (block) {
+        const node = this.descendStackedBlock.call(this.fakeThis, block);
+        if (node) {
+            return new IntermediateStackBlock(InputOpcode.OLD_COMPILER_COMPATIBILITY_LAYER, {
                 oldNode: node
             }, true);
         }
@@ -140,16 +186,72 @@ class TypedInput {
     }
 }
 
+/**
+ * Part of the old compiler's public API.
+ */
+class VariablePool {
+    constructor (prefix) {
+        this.prefix = prefix;
+        this.count = 0;
+    }
+
+    next () {
+        return `${this.prefix}${this.count++}`;
+    }
+}
+
+/**
+ * Part of the old compiler's public API.
+ */
+class Frame {
+    constructor (isLoop) {
+        this.isLoop = isLoop;
+        this.isLastBlock = false;
+    }
+}
+
 class JSGeneratorStub {
+    /**
+     * @param {import("./jsgen")} real
+     */
     constructor (real) {
         /**
-         * For internal use by new compiler only.
          * @type {import("./jsgen")}
          */
         this.real = real;
 
-        this._fakeThis = {
-            descendInput: this.descendInputFromOldCompiler.bind(this)
+        this.fakeThis = {
+            get source () {
+                return real.source;
+            },
+            set source (newSource) {
+                real.source = newSource;
+            },
+
+            localVariables: real.localVariables,
+
+            /**
+             * @param {IntermediateInput} intermediate
+             * @returns {void} output is concatenated in this.source
+             */
+            descendInput (intermediate) {
+                const js = real.descendInput(intermediate);
+                return new TypedInput(js, intermediate);
+            },
+
+            /**
+             * @param {IntermediateStack} stack Stack of blocks.
+             * @param {Frame} frame New frame
+             */
+            descendStack (stack, frame) {
+                real.descendStack(stack, frame);
+            },
+
+            yieldLoop: () => real.yieldLoop(),
+            yieldNotWarp: () => real.yieldNotWarp(),
+            yieldStuckOrNotWarp: () => real.yieldStuckOrNotWarp(),
+            yielded: () => real.yielded(),
+            requestRedraw: () => real.requestRedraw()
         };
     }
 
@@ -164,13 +266,12 @@ class JSGeneratorStub {
     }
 
     /**
-     * Part of old compiler's public API.
-     * @param {IntermediateInput} intermediate
-     * @returns {TypedInput}
+     * Intended for extensions to override.
+     * Always call from `fakeThis` context.
+     * @param {{kind: string}} node Old compiler AST node.
      */
-    descendInputFromOldCompiler (intermediate) {
-        const js = this.real.descendInput(intermediate);
-        return new TypedInput(js, intermediate);
+    descendStackedBlock (node) {
+        throw new Error(`Unknown stacked block: ${node.kind}`);
     }
 
     /**
@@ -179,8 +280,18 @@ class JSGeneratorStub {
      */
     descendInputFromNewCompiler (intermediate) {
         const oldNode = intermediate.inputs.oldNode;
-        const typedInput = this.descendInput.call(this._fakeThis, oldNode);
+        const typedInput = this.descendInput.call(this.fakeThis, oldNode);
         return typedInput.asSafe();
+    }
+
+    /**
+     * @param {IntermediateStackBlock} intermediate
+     * @returns {void} source property on real JSGenerator is modified directly
+     */
+    descendStackedBlockFromNewCompiler (intermediate) {
+        this.fakeThis.source = '';
+        const oldNode = intermediate.inputs.oldNode;
+        this.descendStackedBlock.call(this.fakeThis, oldNode);
     }
 }
 
@@ -196,13 +307,13 @@ JSGeneratorStub.unstable_exports = {
     // factoryNameVariablePool,
     // functionNameVariablePool,
     // generatorNameVariablePool,
-    // VariablePool,
+    VariablePool,
     // PEN_EXT,
     // PEN_STATE,
-    TypedInput
+    TypedInput,
     // ConstantInput,
     // VariableInput,
-    // Frame,
+    Frame
     // sanitize
 };
 

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -110,6 +110,7 @@ class ScriptTreeGeneratorStub {
     }
 }
 
+// These are part of the old compiler's API.
 const TYPE_NUMBER = 1;
 const TYPE_STRING = 2;
 const TYPE_BOOLEAN = 3;
@@ -117,7 +118,7 @@ const TYPE_UNKNOWN = 4;
 const TYPE_NUMBER_NAN = 5;
 
 /**
- * Part of the old compiler's public API.
+ * Part of the old compiler's API.
  */
 class TypedInput {
     /**
@@ -132,34 +133,42 @@ class TypedInput {
         this.source = source;
 
         if (typeOrIntermediate instanceof IntermediateInput) {
+            // Path used by the compatibility layer itself
+
             /**
              * @type {IntermediateInput}
              */
             this.intermediate = typeOrIntermediate;
+
+            /**
+             * @type {number} See TYPE_* constants above
+             */
+            this.type = TYPE_UNKNOWN;
         } else {
+            // Path used by extensions
             this.intermediate = null;
             this.type = typeOrIntermediate;
         }
     }
 
     asNumber () {
-        throw new Error('TODO asNumber');
+        return `(+${this.source} || 0)`;
     }
 
     asNumberOrNaN () {
-        throw new Error('TODO asNumberOrNaN');
+        return `(+${this.source})`;
     }
 
     asString () {
-        throw new Error('TODO asString');
+        return `("" + ${this.source})`;
     }
 
     asBoolean () {
-        throw new Error('TODO asBoolean');
+        return `toBoolean(${this.source})`;
     }
 
     asColor () {
-        throw new Error('TODO asColor');
+        return this.asUnknown();
     }
 
     asUnknown () {
@@ -167,7 +176,7 @@ class TypedInput {
     }
 
     asSafe () {
-        return this.source;
+        return this.asUnknown();
     }
 
     isAlwaysNumber () {
@@ -187,7 +196,7 @@ class TypedInput {
 }
 
 /**
- * Part of the old compiler's public API.
+ * Part of the old compiler's API.
  */
 class VariablePool {
     constructor (prefix) {
@@ -201,7 +210,7 @@ class VariablePool {
 }
 
 /**
- * Part of the old compiler's public API.
+ * Part of the old compiler's API.
  */
 class Frame {
     constructor (isLoop) {
@@ -296,7 +305,7 @@ class JSGeneratorStub {
 }
 
 /**
- * Part of old compiler's public API.
+ * Part of old compiler's API.
  */
 JSGeneratorStub.unstable_exports = {
     TYPE_NUMBER,

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -14,7 +14,7 @@
  *  - Extensions treat IR nodes received from descendSubstack and similar as
  *    opaque objects.
  *  - Extensions need to implement the JS generators for all AST node kinds
- *    they use. Can not rely on the defualt JS generator.
+ *    they use. Can not rely on the default JS generator.
  */
 
 const {InputOpcode, InputType} = require('./enums');
@@ -22,7 +22,8 @@ const {InputOpcode, InputType} = require('./enums');
 const {IntermediateInput, IntermediateStackBlock, IntermediateStack} = require('./intermediate');
 
 class IRGeneratorStub {
-
+    // Doesn't seem like extensions override anything, though the class may
+    // still need to exist to avoid type errors.
 }
 
 class ScriptTreeGeneratorStub {
@@ -257,7 +258,7 @@ class JSGeneratorStub {
                 real.source = newSource;
             },
 
-            localVariables: real.localVariables,
+            localVariables: new VariablePool('oldCompilerLocal'),
 
             /**
              * @param {IntermediateInput} intermediate
@@ -332,17 +333,9 @@ JSGeneratorStub.unstable_exports = {
     TYPE_BOOLEAN,
     TYPE_UNKNOWN,
     TYPE_NUMBER_NAN,
-    // factoryNameVariablePool,
-    // functionNameVariablePool,
-    // generatorNameVariablePool,
     VariablePool,
-    // PEN_EXT,
-    // PEN_STATE,
     TypedInput,
-    // ConstantInput,
-    // VariableInput,
     Frame
-    // sanitize
 };
 
 const oldCompilerCompatibility = {

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -13,7 +13,9 @@
  *    provided by the new compiler.
  *  - Extensions treat IR nodes received from descendSubstack and similar as
  *    opaque objects.
- *  - Extensions are not trying to override the behavior of the native blocks.
+ *  - Extensions need to implement the JS generators for all AST node kinds
+ *    they use. Can not rely on the defualt JS generator.
+ *  - Extensions do not try to override the behavior of native blocks.
  */
 
 const {InputOpcode, InputType} = require('./enums');

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -13,6 +13,7 @@
  *    provided by the new compiler.
  *  - Extensions treat IR nodes received from descendSubstack and similar as
  *    opaque objects.
+ *  - Extensions are not trying to override the behavior of the native blocks.
  */
 
 const {InputOpcode, InputType} = require('./enums');
@@ -327,7 +328,6 @@ JSGeneratorStub.unstable_exports = {
 };
 
 const oldCompilerCompatibility = {
-    enabled: false,
     IRGeneratorStub,
     ScriptTreeGeneratorStub,
     TypedInput,

--- a/src/compiler/old-compiler-compatibility.js
+++ b/src/compiler/old-compiler-compatibility.js
@@ -15,7 +15,6 @@
  *    opaque objects.
  *  - Extensions need to implement the JS generators for all AST node kinds
  *    they use. Can not rely on the defualt JS generator.
- *  - Extensions do not try to override the behavior of native blocks.
  */
 
 const {InputOpcode, InputType} = require('./enums');
@@ -347,6 +346,7 @@ JSGeneratorStub.unstable_exports = {
 };
 
 const oldCompilerCompatibility = {
+    enabled: false,
     IRGeneratorStub,
     ScriptTreeGeneratorStub,
     TypedInput,

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -223,9 +223,9 @@ class VirtualMachine extends EventEmitter {
             JSZip,
             Variable,
 
-            i_will_not_ask_for_help_when_these_break: () => {
+            these_broke_before_and_will_break_again: () => {
                 console.warn('You are using unsupported APIs. WHEN your code breaks, do not expect help.');
-                return ({
+                return {
                     JSGenerator: require('./compiler/jsgen.js'),
                     IRGenerator: require('./compiler/irgen.js').IRGenerator,
                     ScriptTreeGenerator: require('./compiler/irgen.js').ScriptTreeGenerator,
@@ -239,7 +239,22 @@ class VirtualMachine extends EventEmitter {
                     InputType: require('./compiler/enums.js').InputType,
                     Thread: require('./engine/thread.js'),
                     execute: require('./engine/execute.js')
-                });
+                };
+            },
+
+            i_will_not_ask_for_help_when_these_break: () => {
+                this.emit('LEGACY_EXTENSION_API', 'i_will_not_ask_for_help_when_these_break');
+
+                const oldCompilerCompatibility = require('./compiler/old-compiler-compatibility.js');
+                oldCompilerCompatibility.enabled = true;
+
+                return {
+                    IRGenerator: oldCompilerCompatibility.IRGeneratorStub,
+                    ScriptTreeGenerator: oldCompilerCompatibility.ScriptTreeGeneratorStub,
+                    JSGenerator: oldCompilerCompatibility.JSGeneratorStub,
+                    Thread: require('./engine/thread.js'),
+                    execute: require('./engine/execute.js')
+                };
             }
         };
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -244,7 +244,10 @@ class VirtualMachine extends EventEmitter {
 
             i_will_not_ask_for_help_when_these_break: () => {
                 this.emit('LEGACY_EXTENSION_API', 'i_will_not_ask_for_help_when_these_break');
+
                 const oldCompilerCompatibility = require('./compiler/old-compiler-compatibility.js');
+                oldCompilerCompatibility.enabled = true;
+
                 return {
                     IRGenerator: oldCompilerCompatibility.IRGeneratorStub,
                     ScriptTreeGenerator: oldCompilerCompatibility.ScriptTreeGeneratorStub,

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -244,10 +244,7 @@ class VirtualMachine extends EventEmitter {
 
             i_will_not_ask_for_help_when_these_break: () => {
                 this.emit('LEGACY_EXTENSION_API', 'i_will_not_ask_for_help_when_these_break');
-
                 const oldCompilerCompatibility = require('./compiler/old-compiler-compatibility.js');
-                oldCompilerCompatibility.enabled = true;
-
                 return {
                     IRGenerator: oldCompilerCompatibility.IRGeneratorStub,
                     ScriptTreeGenerator: oldCompilerCompatibility.ScriptTreeGeneratorStub,


### PR DESCRIPTION
The new compiler broke all the extensions doing compiler patches. We promised not to help them when those break but it seems enough people use those extensions that we sort of got forced into finding some solution, so this makes these changes:

 - The exports for the new compiler are now in `these_broke_before_and_will_break_again`
 - `i_will_not_ask_for_help_when_these_break` now returns some stubs that pretend to be the old compiler. It also emits an event so -gui can show a warning.
 - Focus is on compatibility & safety, not performance. There will be unnecessary casts and scripts marked as yielding.
 - Extensions that meet these assumptions should work without changes:
   - Extensions do not try to combine this compatibility layer with any APIs provided by the new compiler.
   - Extensions treat IR nodes received from descendSubstack and similar as opaque objects because they will be the new intermediate objects instead of { kind: "..." }
   - Extensions need to implement the JS generators for all AST node kinds they use. Can not rely on the default JS generator because those generators are expecting a different format than { kind: "..." }

Lack of tests is intentional since this will be removed at some point when we have a proper API we can tell people to use