### PR TITLE
Fix all remaining negative zero bugs

### DIFF
--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -226,13 +226,11 @@ runtimeFunctions.retire = `const retire = () => {
 /**
  * Converts NaN to zero. Used to match Scratch's string-to-number.
  * Unlike (x || 0), -0 stays as -0 and is not converted to 0.
- * This function is written in this specific way to make it easy for browsers to inline.
- * We've found that calling isNaN() causes slowdowns in Firefox, so instead we utilize the
- * fact that NaN is the only JavaScript value that does not equal itself.
+ * This function needs to be written such that it's very easy for browsers to inline it.
  * @param {number} value A number. Might be NaN.
  * @returns {number} A number. Never NaN.
  */
-runtimeFunctions.toNotNaN = `const toNotNaN = value => value === value ? value : 0`;
+runtimeFunctions.toNotNaN = `const toNotNaN = value => Number.isNaN(value) ? 0 : value`;
 
 /**
  * Scratch cast to boolean.

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -224,6 +224,17 @@ runtimeFunctions.retire = `const retire = () => {
 }`;
 
 /**
+ * Converts NaN to zero. Used to match Scratch's string-to-number.
+ * Unlike (x || 0), -0 stays as -0 and is not converted to 0.
+ * This function is written in this specific way to make it easy for browsers to inline.
+ * We've found that calling isNaN() causes slowdowns in Firefox, so instead we utilize the
+ * fact that NaN is the only JavaScript value that does not equal itself.
+ * @param {number} value A number. Might be NaN.
+ * @returns {number} A number. Never NaN.
+ */
+runtimeFunctions.toNotNaN = `const toNotNaN = value => value === value ? value : 0`;
+
+/**
  * Scratch cast to boolean.
  * Similar to Cast.toBoolean()
  * @param {*} value The value to cast

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -185,9 +185,9 @@ class JSGenerator {
                 return `(+${this.descendInput(node.target.toType(InputType.BOOLEAN))})`;
             }
             if (node.target.isAlwaysType(InputType.NUMBER_OR_NAN)) {
-                return `(${this.descendInput(node.target)} || 0)`;
+                return `toNotNaN(${this.descendInput(node.target)})`;
             }
-            return `(+${this.descendInput(node.target)} || 0)`;
+            return `toNotNaN(+${this.descendInput(node.target)})`;
         case InputOpcode.CAST_NUMBER_OR_NAN:
             return `(+${this.descendInput(node.target)})`;
         case InputOpcode.CAST_NUMBER_INDEX:

--- a/test/snapshot/__snapshots__/order-library-reverse.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/order-library-reverse.sb3.tw-snapshot
@@ -9,14 +9,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "]4hbk*5ix]V00h|!x1oy", null);
 } else {
@@ -32,7 +32,7 @@ const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "1Ba%a0GIK#hwJ46y=WVt", null);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -40,7 +40,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * (+b1.value || 0));
+var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -48,7 +48,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * (+b1.value || 0));
+var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
@@ -67,14 +67,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "0i[-T:vYTt=bi47@byUE", null);
 } else {

--- a/test/snapshot/__snapshots__/order-library.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/order-library.sb3.tw-snapshot
@@ -8,7 +8,7 @@ const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "s+@:|^WPr8]N1Y9Hk2f5", null);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -16,7 +16,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * (+b1.value || 0));
+var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -24,7 +24,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * (+b1.value || 0));
+var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
@@ -43,14 +43,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "RSQ{nVCc)6E)(`KlnFCF", null);
 } else {
@@ -67,14 +67,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "KP?op(=Vg2#;@]!,C#.~", null);
 } else {

--- a/test/snapshot/__snapshots__/tw-NaN.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-NaN.sb3.tw-snapshot
@@ -12,61 +12,61 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aA", 
 if ((("" + (0 * Infinity)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "/", null);
 }
-if (((((0 * Infinity) || 0) * 1) === 0)) {
+if (((toNotNaN((0 * Infinity)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "?", null);
 }
 if ((("" + ((Math.acos(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "=", null);
 }
-if ((((((Math.acos(1.01) * 180) / Math.PI) || 0) * 1) === 0)) {
+if (((toNotNaN(((Math.acos(1.01) * 180) / Math.PI)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "]", null);
 }
 if ((("" + ((Math.asin(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "_", null);
 }
-if ((((((Math.asin(1.01) * 180) / Math.PI) || 0) * 1) === 0)) {
+if (((toNotNaN(((Math.asin(1.01) * 180) / Math.PI)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "{", null);
 }
 if ((("" + (0 / 0)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "}", null);
 }
-if (((((0 / 0) || 0) * 1) === 0)) {
+if (((toNotNaN((0 / 0)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aa", null);
 }
 if ((("" + Math.sqrt(-1)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ac", null);
 }
-if ((((Math.sqrt(-1) || 0) * 1) === 0)) {
+if (((toNotNaN(Math.sqrt(-1)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ae", null);
 }
 if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ag", null);
 }
-if ((((mod(0, 0) || 0) * 1) === 0)) {
+if (((toNotNaN(mod(0, 0)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ai", null);
 }
 if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ak", null);
 }
-if ((((Math.log(-1) || 0) * 1) === 0)) {
+if (((toNotNaN(Math.log(-1)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "am", null);
 }
 if ((("" + (Math.log(-1) / Math.LN10)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ao", null);
 }
-if (((((Math.log(-1) / Math.LN10) || 0) * 1) === 0)) {
+if (((toNotNaN((Math.log(-1) / Math.LN10)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aq", null);
 }
-if (((((Math.round(Math.sin((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10) || 0) * 1) === 0)) {
+if (((toNotNaN((Math.round(Math.sin((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "as", null);
 }
-if (((((Math.round(Math.cos((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10) || 0) * 1) === 0)) {
+if (((toNotNaN((Math.round(Math.cos((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "au", null);
 }
-if ((((tan((1 / 0)) || 0) * 1) === 0)) {
+if (((toNotNaN(tan((1 / 0))) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aw", null);
 }
-if ((((runtime.ext_scratch3_operators._random((-1 / 0), (1 / 0)) || 0) * 1) === 0)) {
+if (((toNotNaN(runtime.ext_scratch3_operators._random((-1 / 0), (1 / 0))) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ax", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ":", null);

--- a/test/snapshot/__snapshots__/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
@@ -22,7 +22,7 @@ retire(); return;
 return function* genXYZ_non_warp_recursion_ (p0) {
 if (compareGreaterThan(p0, 0)) {
 yield;
-yield* thread.procedures["Znon-warp recursion %s"](((+p0 || 0) - 1));
+yield* thread.procedures["Znon-warp recursion %s"]((toNotNaN(+p0) - 1));
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-block-with-null-for-variable-id.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-block-with-null-for-variable-id.sb3.tw-snapshot
@@ -21,7 +21,7 @@ retire(); return;
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-if (((+b0.value || 0) === 1)) {
+if ((toNotNaN(+b0.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 1",}, b1, false, false, "m", null);
 }
 retire(); return;
@@ -32,7 +32,7 @@ retire(); return;
 const b0 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
 const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-if (((+b0.value || 0) === 2)) {
+if ((toNotNaN(+b0.value) === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 2",}, b1, false, false, "q", null);
 }
 retire(); return;

--- a/test/snapshot/__snapshots__/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
@@ -10,11 +10,11 @@ yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "()*
 target.setSize(96);
 b1.value = 0;
 while (!(100 === Math.round(target.size))) {
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 target.setSize(target.size + ((100 - Math.round(target.size)) / 10));
 yield;
 }
-if (((+b1.value || 0) === 20)) {
+if ((toNotNaN(+b1.value) === 20)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "FPDFR?Wwq)kLj0A$0D{@", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "1,vLoJ4OQBv+Q#$VoYf=", null);

--- a/test/snapshot/__snapshots__/tw-comparison-matrix-runtime.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-comparison-matrix-runtime.sb3.tw-snapshot
@@ -24,19 +24,19 @@ thread.procedures["Wsetup values"]();
 b0.value = 0;
 b1.value = 0;
 for (var a0 = b2.value.length; a0 > 0; a0--) {
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 b3.value = 0;
 for (var a1 = b2.value.length; a1 > 0; a1--) {
-b3.value = ((+b3.value || 0) + 1);
-b0.value = ((+b0.value || 0) + 1);
+b3.value = (toNotNaN(+b3.value) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareGreaterThan(listGet(b2.value, b1.value), (b2.value[(b3.value | 0) - 1] ?? "")), (b4.value[(b0.value | 0) - 1] ?? ""))) {
 yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be > " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))),}, b5, true, false, "]", null);
 }
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareEqual(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
 yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be = " + ("" + listGet(b2.value, b3.value))))),}, b5, true, false, "|", null);
 }
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareLessThan(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
 yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be < " + ("" + listGet(b2.value, b3.value))))),}, b5, true, true, "ab", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}

--- a/test/snapshot/__snapshots__/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
@@ -10,7 +10,7 @@ return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
 b1.value = (0 + 0);
 yield* executeInCompatibilityLayer({"MESSAGE":"Hello!","SECS":0.1,}, b2, false, false, "d", null);
-if ((((+b1.value || 0) + 2) === 2)) {
+if (((toNotNaN(+b1.value) + 2) === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "i", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "m", null);

--- a/test/snapshot/__snapshots__/tw-custom-report-repeat.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-custom-report-repeat.sb3.tw-snapshot
@@ -8,11 +8,11 @@ const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
 b1.value = 0;
-for (var a0 = (+thread.procedures["Zblock name"]() || 0); a0 >= 0.5; a0--) {
-b1.value = ((+b1.value || 0) + 1);
+for (var a0 = toNotNaN(+thread.procedures["Zblock name"]()); a0 >= 0.5; a0--) {
+b1.value = (toNotNaN(+b1.value) + 1);
 yield;
 }
-if (((+b1.value || 0) === 40)) {
+if ((toNotNaN(+b1.value) === 40)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "n", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
@@ -15,7 +15,7 @@ target.setDirection((1 / 0));
 if ((target.direction === 95)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, "r", null);
 }
-target.setDirection(((0 / 0) || 0));
+target.setDirection(toNotNaN((0 / 0)));
 if ((target.direction === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "u", null);
 }

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
@@ -15,7 +15,7 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass variable",}, b0, false, fals
 b2.value = [];
 b2.value.push(3);
 b2._monitorUpToDate = false;
-if (((+(b2.value[1 - 1] ?? "") || 0) === 3)) {
+if ((toNotNaN(+(b2.value[1 - 1] ?? "")) === 3)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass list",}, b0, false, false, "m", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
@@ -73,7 +73,7 @@ return "";
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 yield;
 }
 retire(); return;

--- a/test/snapshot/__snapshots__/tw-gh-249-quicksort.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-gh-249-quicksort.sb3.tw-snapshot
@@ -41,9 +41,9 @@ if (!compareEqual((b2.value[(b1.value | 0) - 1] ?? ""), (b3.value[(b1.value | 0)
 b0.value = 0;
 yield* executeInCompatibilityLayer({"MESSAGE":("fail mismatch at index " + ("" + b1.value)),}, b4, true, false, ",", null);
 }
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 }
-if (((+b0.value || 0) === 1)) {
+if ((toNotNaN(+b0.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass sorted",}, b4, true, false, "aE", null);
 }
 return "";
@@ -62,16 +62,16 @@ const b7 = target.variables["JIHtr29*ug5G;5*`f2.K-min-"];
 const b8 = target.variables["JIHtr29*ug5G;5*`f2.K-j-"];
 return function funXYZ_qsort__ (p0,p1) {
 if (compareLessThan(p0, p1)) {
-if (!(((+p1 || 0) - (+p0 || 0)) <= 7)) {
-b0.value = (b1.value[(((((+p1 || 0) + (+p0 || 0)) || 0) / 2) | 0) - 1] ?? "");
+if (!((toNotNaN(+p1) - toNotNaN(+p0)) <= 7)) {
+b0.value = (b1.value[((toNotNaN((toNotNaN(+p1) + toNotNaN(+p0))) / 2) | 0) - 1] ?? "");
 b2.value = p0;
 b3.value = p1;
 while (true) {
 while (compareLessThan(listGet(b1.value, b2.value), b0.value)) {
-b2.value = ((+b2.value || 0) + 1);
+b2.value = (toNotNaN(+b2.value) + 1);
 }
 while (compareGreaterThan(listGet(b1.value, b3.value), b0.value)) {
-b3.value = ((+b3.value || 0) + -1);
+b3.value = (toNotNaN(+b3.value) + -1);
 }
 if (compareGreaterThan(b2.value, b3.value)) {
 thread.procedures["Wqsort %s %s"](p0,b3.value);
@@ -81,17 +81,17 @@ return "";
 b4.value = listGet(b1.value, b2.value);
 listReplace(b1, b2.value, listGet(b1.value, b3.value));
 listReplace(b1, b3.value, b4.value);
-b2.value = ((+b2.value || 0) + 1);
-b3.value = ((+b3.value || 0) + -1);
+b2.value = (toNotNaN(+b2.value) + 1);
+b3.value = (toNotNaN(+b3.value) + -1);
 }
 }
 } else {
 b5.value = p0;
-for (var a0 = (((+p1 || 0) - (+p0 || 0)) || 0); a0 >= 0.5; a0--) {
+for (var a0 = toNotNaN((toNotNaN(+p1) - toNotNaN(+p0))); a0 >= 0.5; a0--) {
 b6.value = b5.value;
 b7.value = listGet(b1.value, b5.value);
-b8.value = ((+b5.value || 0) + 1);
-for (var a1 = (((+p1 || 0) - (+b5.value || 0)) || 0); a1 >= 0.5; a1--) {
+b8.value = (toNotNaN(+b5.value) + 1);
+for (var a1 = toNotNaN((toNotNaN(+p1) - toNotNaN(+b5.value))); a1 >= 0.5; a1--) {
 if (compareLessThan((b1.value[(b8.value | 0) - 1] ?? ""), b7.value)) {
 b7.value = (b1.value[(b8.value | 0) - 1] ?? "");
 b6.value = b8.value;
@@ -104,7 +104,7 @@ b4.value = listGet(b1.value, b5.value);
 listReplace(b1, b5.value, b7.value);
 listReplace(b1, b6.value, b4.value);
 }
-b5.value = ((+b5.value || 0) + 1);
+b5.value = (toNotNaN(+b5.value) + 1);
 }
 }
 }

--- a/test/snapshot/__snapshots__/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
@@ -22,7 +22,7 @@ const b1 = stage.variables["t)]?yi[*8XU73qhMqOa8"];
 return function funXYZ_test_ (p0) {
 b0.value = p0;
 while (!(("" + listGet(b1.value, b0.value)).toLowerCase() === "something".toLowerCase())) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -17,11 +17,11 @@ b1._monitorUpToDate = false;
 b2.value = 0;
 b3.value = "bwah";
 while (!(("" + b3.value).toLowerCase() === "eof".toLowerCase())) {
-b2.value = ((+b2.value || 0) + 1);
+b2.value = (toNotNaN(+b2.value) + 1);
 b3.value = (b1.value[(b2.value | 0) - 1] ?? "");
 yield;
 }
-if (((+b2.value || 0) === 2)) {
+if ((toNotNaN(+b2.value) === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "q", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "o", null);

--- a/test/snapshot/__snapshots__/tw-procedure-return-non-existant.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-non-existant.sb3.tw-snapshot
@@ -7,7 +7,7 @@ const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * -1);
 runtime.requestRedraw();

--- a/test/snapshot/__snapshots__/tw-procedure-return-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-recursion.sb3.tw-snapshot
@@ -10,7 +10,7 @@ return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 18",}, b0, false, false, "G", null);
 b1.value = 0;
 b2.value = (yield* thread.procedures["Znon warp recursion should yield %s"](8));
-if (((+b1.value || 0) === 4)) {
+if ((toNotNaN(+b1.value) === 4)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp recursion yields",}, b0, false, false, "ao", null);
 }
 b1.value = 0;
@@ -20,7 +20,7 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass warp recursion does not yiel
 }
 b1.value = 0;
 b2.value = (yield* thread.procedures["Zfib %s"](7));
-if (((+b1.value || 0) === 20)) {
+if ((toNotNaN(+b1.value) === 20)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp fib yielded",}, b0, false, false, "au", null);
 }
 yield* thread.procedures["Zrecursing yields between each %s"]("initial");
@@ -34,7 +34,7 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function* genXYZ_non_warp_recursion_s (p0) {
 if (compareGreaterThan(p0, 0)) {
-return (yield* yieldThenCallGenerator(thread.procedures["Znon warp recursion should yield %s"], ((+p0 || 0) - 1)));
+return (yield* yieldThenCallGenerator(thread.procedures["Znon warp recursion should yield %s"], (toNotNaN(+p0) - 1)));
 }
 return "";
 }; })
@@ -43,7 +43,7 @@ return "";
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function funXYZ_warp_recursion_shoul (p0) {
 if (compareGreaterThan(p0, 0)) {
-return thread.procedures["Wwarp recursion should not yield %s"](((+p0 || 0) - 1));
+return thread.procedures["Wwarp recursion should not yield %s"]((toNotNaN(+p0) - 1));
 }
 return "";
 }; })
@@ -54,7 +54,7 @@ return function* genXYZ_fib_ (p0) {
 if (compareLessThan(p0, 2)) {
 return p0;
 } else {
-return ((+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], ((+p0 || 0) - 1))) || 0) + (+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], ((+p0 || 0) - 2))) || 0));
+return (toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], (toNotNaN(+p0) - 1)))) + toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], (toNotNaN(+p0) - 2)))));
 }
 return "";
 }; })
@@ -67,8 +67,8 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_recursing_yields_bet (p0) {
 if ((("" + p0).toLowerCase() === "initial".toLowerCase())) {
 b0.value = 0;
-b1.value = ((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3)) || 0) + (+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3)) || 0)) || 0)) || 0)) || 0)) || 0));
-if (((+b0.value || 0) === 3)) {
+b1.value = (toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))) + toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))))))))))));
+if ((toNotNaN(+b0.value) === 3)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass recursing between calls yields final",}, b2, false, false, "aK", null);
 } else {
 yield* executeInCompatibilityLayer({"MESSAGE":"fail recursing between calls yields final",}, b2, false, false, "aL", null);
@@ -131,7 +131,7 @@ const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * -1);
 runtime.requestRedraw();

--- a/test/snapshot/__snapshots__/tw-procedure-return-simple.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-simple.sb3.tw-snapshot
@@ -13,10 +13,10 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass simplest",}, b0, false, fals
 if ((("" + thread.procedures["Znesting 1"]()).toLowerCase() === "42-54".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass nesting1",}, b0, false, false, "=", null);
 }
-if (((+thread.procedures["Wwarp fib %s"](12) || 0) === 144)) {
+if ((toNotNaN(+thread.procedures["Wwarp fib %s"](12)) === 144)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass fib 12",}, b0, false, false, "@", null);
 }
-if (((+thread.procedures["Wfactorial %s"](12) || 0) === 479001600)) {
+if ((toNotNaN(+thread.procedures["Wfactorial %s"](12)) === 479001600)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass factorial 12",}, b0, false, false, "]", null);
 }
 b1.value = (yield* thread.procedures["Zno shadowing 1 %s %s"]("f","g"));
@@ -53,7 +53,7 @@ return "";
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function funXYZ_factorial_ (p0) {
 if (compareGreaterThan(p0, 1)) {
-return ((+p0 || 0) * (+thread.procedures["Wfactorial %s"](((+p0 || 0) - 1)) || 0));
+return (toNotNaN(+p0) * toNotNaN(+thread.procedures["Wfactorial %s"]((toNotNaN(+p0) - 1))));
 }
 return 1;
 return "";
@@ -88,7 +88,7 @@ return "";
 // Sprite1 Znesting 3 %s %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function funXYZ_nesting_3__ (p0,p1) {
-return ((+p0 || 0) * (+p1 || 0));
+return (toNotNaN(+p0) * toNotNaN(+p1));
 return "";
 }; })
 
@@ -98,7 +98,7 @@ return function funXYZ_fib_ (p0) {
 if (compareLessThan(p0, 2)) {
 return p0;
 } else {
-return ((+thread.procedures["Wfib %s"](((+p0 || 0) - 1)) || 0) + (+thread.procedures["Wfib %s"](((+p0 || 0) - 2)) || 0));
+return (toNotNaN(+thread.procedures["Wfib %s"]((toNotNaN(+p0) - 1))) + toNotNaN(+thread.procedures["Wfib %s"]((toNotNaN(+p0) - 2))));
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-procedure-return-stops-scripts.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-stops-scripts.sb3.tw-snapshot
@@ -8,11 +8,11 @@ const b1 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "f", null);
 yield* thread.procedures["Wreturn stops the script immediately"]();
-if (((+b1.value || 0) === 25)) {
+if ((toNotNaN(+b1.value) === 25)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass return stopped the script immediately",}, b0, false, false, "u", null);
 }
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test return outside of custom block" }));
-if (((+b1.value || 0) === 18)) {
+if ((toNotNaN(+b1.value) === 18)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass return worked to stop outside of custom block",}, b0, false, false, "x", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "v", null);
@@ -41,7 +41,7 @@ const b0 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 18)) {
 retire(); return;
 }

--- a/test/snapshot/__snapshots__/tw-procedure-return-warp.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-warp.sb3.tw-snapshot
@@ -7,7 +7,7 @@ const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * -1);
 runtime.requestRedraw();
@@ -49,7 +49,7 @@ yield;
 thread.timer = null;
 yield;
 }
-if (((+b0.value || 0) === 5)) {
+if ((toNotNaN(+b0.value) === 5)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 1",}, b1, false, false, "R", null);
 }
 if ((("" + (yield* thread.procedures["Wverify runs warp %s"]((yield* thread.procedures["Zverify runs non warp %s"]((yield* thread.procedures["Wverify runs warp %s"]("abc"))))))).toLowerCase() === "warp: non warp: warp: abc".toLowerCase())) {
@@ -67,7 +67,7 @@ yield;
 thread.timer = null;
 yield;
 }
-if (((+b0.value || 0) === 5)) {
+if ((toNotNaN(+b0.value) === 5)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 2",}, b1, false, false, "W", null);
 }
 return "";

--- a/test/snapshot/__snapshots__/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
@@ -30,7 +30,7 @@ return function* genXYZ () {
 b0.value = 0;
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b1, false, false, "0/2-)Gp^^=haQ1OMD.xb", null);
 for (var a0 = 15; a0 > 0; a0--) {
-if (((+b2.value || 0) === 200)) {
+if ((toNotNaN(+b2.value) === 200)) {
 b2.value = 50;
 } else {
 b2.value = 200;

--- a/test/snapshot/__snapshots__/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
@@ -15,8 +15,8 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = target.variables["ts-.PQ{/]mN_9@MbG:m/"];
 return function funXYZ_test_1 () {
-for (var a0 = (+thread.procedures["Wany procedure reporter"]() || 0); a0 >= 0.5; a0--) {
-b0.value = ((+b0.value || 0) + 1);
+for (var a0 = toNotNaN(+thread.procedures["Wany procedure reporter"]()); a0 >= 0.5; a0--) {
+b0.value = (toNotNaN(+b0.value) + 1);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-restart-broadcast-threads.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-restart-broadcast-threads.sb3.tw-snapshot
@@ -18,7 +18,7 @@ while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-if (((+b1.value || 0) === 1)) {
+if ((toNotNaN(+b1.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "`SX*FG*Lwo*0_T=box-@", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "|#`zzPA_x%{`FyIAQhb4", null);
@@ -29,6 +29,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-safe-procedure-argument-casting.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-safe-procedure-argument-casting.sb3.tw-snapshot
@@ -7,11 +7,11 @@ const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "J#qm1yA(@Z6mj%Mgh;0X", null);
 thread.procedures["Zswitch %s"]("1");
-if ((((target.currentCostume + 1) === 2) && ((+target.getCostumes()[target.currentCostume].name || 0) === 1))) {
+if ((((target.currentCostume + 1) === 2) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 1))) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ";DM$.QW6o-O+T/oBdqt!", null);
 }
 thread.procedures["Zswitch %s"]("2");
-if ((((target.currentCostume + 1) === 1) && ((+target.getCostumes()[target.currentCostume].name || 0) === 2))) {
+if ((((target.currentCostume + 1) === 1) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 2))) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "71a9Slk0w=^~x;5T@nw,", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "$R-1lb(Mu?gdTIH^;kC_", null);

--- a/test/snapshot/__snapshots__/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
@@ -29,7 +29,7 @@ yield;
 }
 b1.value = 2;
 } else {
-if (((+b1.value || 0) === 1)) {
+if ((toNotNaN(+b1.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "p", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, "n", null);

--- a/test/snapshot/__snapshots__/tw-tangent.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-tangent.sb3.tw-snapshot
@@ -9,46 +9,46 @@ yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b0, false, false, "p"
 if (compareEqual(tan(0), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 0",}, b0, false, false, "O", null);
 }
-if (((tan(90) || 0) === Infinity)) {
+if ((toNotNaN(tan(90)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 90",}, b0, false, false, "G", null);
 }
 if (compareEqual(tan(180), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 180",}, b0, false, false, "I", null);
 }
-if (((tan(270) || 0) === -Infinity)) {
+if ((toNotNaN(tan(270)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 270",}, b0, false, false, "K", null);
 }
 if (compareEqual(tan(360), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 360",}, b0, false, false, "M", null);
 }
-if (((tan(450) || 0) === Infinity)) {
+if ((toNotNaN(tan(450)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 450",}, b0, false, false, "Q", null);
 }
 if (compareEqual(tan(540), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 540",}, b0, false, false, "S", null);
 }
-if (((tan(630) || 0) === -Infinity)) {
+if ((toNotNaN(tan(630)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 630",}, b0, false, false, "U", null);
 }
 if (compareEqual(tan(720), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 720",}, b0, false, false, "W", null);
 }
-if (((tan(810) || 0) === Infinity)) {
+if ((toNotNaN(tan(810)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 810",}, b0, false, false, "Y", null);
 }
-if (((tan(-90) || 0) === -Infinity)) {
+if ((toNotNaN(tan(-90)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -90",}, b0, false, false, "0", null);
 }
 if (compareEqual(tan(-180), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -180",}, b0, false, false, "2", null);
 }
-if (((tan(-270) || 0) === Infinity)) {
+if ((toNotNaN(tan(-270)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -270",}, b0, false, false, "4", null);
 }
 if (compareEqual(tan(-360), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -360",}, b0, false, false, "6", null);
 }
-if (((tan(-450) || 0) === -Infinity)) {
+if ((toNotNaN(tan(-450)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -450",}, b0, false, false, "9", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "8", null);

--- a/test/snapshot/__snapshots__/tw-unsafe-equals.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-unsafe-equals.sb3.tw-snapshot
@@ -18,43 +18,43 @@ b1.value = 10;
 if ((b1.value === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "Ul:BCck-}Fvdux~x#$${", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, "8]2$7P)o#+#Lo]mFSBbx", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 5",}, b0, false, false, "ZU^{OfKTg|+Au$$q0[]u", null);
 }
 for (var a0 = 1; a0 > 0; a0--) {
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 6",}, b0, false, false, "HB+_IN}6=K[*ksxKXH0`", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 7",}, b0, false, false, ";73ODiwcp8IthYURTX;S", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 8",}, b0, false, true, "${[MFmBL-D*1rbas9Q89", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
 }
 yield;
 }
 b2.value = "010";
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 9",}, b0, false, false, "#.`@SBj!g-c0:_q/tMZo", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 10",}, b0, false, false, "B`o?V6/q6g),/2w};a#y", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 11",}, b0, false, false, "TJ:#TkYBys*!RYiKLXb)", null);
 }
 for (var a1 = 1; a1 > 0; a1--) {
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 12",}, b0, false, false, ",Z,~10Qo~j;(+VL+I3q:", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 13",}, b0, false, false, "|Mqx([(26M%#ggW9)U0s", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 14",}, b0, false, true, "YvtiKF231lU8p5Qd97RP", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
 }

--- a/test/snapshot/__snapshots__/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
@@ -24,7 +24,7 @@ retire(); return;
 const b0 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
 const b1 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
 return function* genXYZ () {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 5)) {
 b1.value = "end";
 }

--- a/test/snapshot/__snapshots__/warp-timer/order-library-reverse.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/order-library-reverse.sb3.tw-snapshot
@@ -9,14 +9,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "]4hbk*5ix]V00h|!x1oy", null);
 } else {
@@ -32,7 +32,7 @@ const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "1Ba%a0GIK#hwJ46y=WVt", null);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -40,7 +40,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * (+b1.value || 0));
+var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -48,7 +48,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * (+b1.value || 0));
+var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
@@ -67,14 +67,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "0i[-T:vYTt=bi47@byUE", null);
 } else {

--- a/test/snapshot/__snapshots__/warp-timer/order-library.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/order-library.sb3.tw-snapshot
@@ -8,7 +8,7 @@ const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "s+@:|^WPr8]N1Y9Hk2f5", null);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -16,7 +16,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * (+b1.value || 0));
+var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -24,7 +24,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * (+b1.value || 0));
+var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
@@ -43,14 +43,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "RSQ{nVCc)6E)(`KlnFCF", null);
 } else {
@@ -67,14 +67,14 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * (+b1.value || 0));
+var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "KP?op(=Vg2#;@]!,C#.~", null);
 } else {

--- a/test/snapshot/__snapshots__/warp-timer/tw-NaN.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-NaN.sb3.tw-snapshot
@@ -12,61 +12,61 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aA", 
 if ((("" + (0 * Infinity)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "/", null);
 }
-if (((((0 * Infinity) || 0) * 1) === 0)) {
+if (((toNotNaN((0 * Infinity)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "?", null);
 }
 if ((("" + ((Math.acos(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "=", null);
 }
-if ((((((Math.acos(1.01) * 180) / Math.PI) || 0) * 1) === 0)) {
+if (((toNotNaN(((Math.acos(1.01) * 180) / Math.PI)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "]", null);
 }
 if ((("" + ((Math.asin(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "_", null);
 }
-if ((((((Math.asin(1.01) * 180) / Math.PI) || 0) * 1) === 0)) {
+if (((toNotNaN(((Math.asin(1.01) * 180) / Math.PI)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "{", null);
 }
 if ((("" + (0 / 0)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "}", null);
 }
-if (((((0 / 0) || 0) * 1) === 0)) {
+if (((toNotNaN((0 / 0)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aa", null);
 }
 if ((("" + Math.sqrt(-1)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ac", null);
 }
-if ((((Math.sqrt(-1) || 0) * 1) === 0)) {
+if (((toNotNaN(Math.sqrt(-1)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ae", null);
 }
 if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ag", null);
 }
-if ((((mod(0, 0) || 0) * 1) === 0)) {
+if (((toNotNaN(mod(0, 0)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ai", null);
 }
 if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ak", null);
 }
-if ((((Math.log(-1) || 0) * 1) === 0)) {
+if (((toNotNaN(Math.log(-1)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "am", null);
 }
 if ((("" + (Math.log(-1) / Math.LN10)).toLowerCase() === "NaN".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ao", null);
 }
-if (((((Math.log(-1) / Math.LN10) || 0) * 1) === 0)) {
+if (((toNotNaN((Math.log(-1) / Math.LN10)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aq", null);
 }
-if (((((Math.round(Math.sin((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10) || 0) * 1) === 0)) {
+if (((toNotNaN((Math.round(Math.sin((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "as", null);
 }
-if (((((Math.round(Math.cos((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10) || 0) * 1) === 0)) {
+if (((toNotNaN((Math.round(Math.cos((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "au", null);
 }
-if ((((tan((1 / 0)) || 0) * 1) === 0)) {
+if (((toNotNaN(tan((1 / 0))) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aw", null);
 }
-if ((((runtime.ext_scratch3_operators._random((-1 / 0), (1 / 0)) || 0) * 1) === 0)) {
+if (((toNotNaN(runtime.ext_scratch3_operators._random((-1 / 0), (1 / 0))) * 1) === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ax", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ":", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
@@ -22,7 +22,7 @@ retire(); return;
 return function* genXYZ_non_warp_recursion_ (p0) {
 if (compareGreaterThan(p0, 0)) {
 yield;
-yield* thread.procedures["Znon-warp recursion %s"](((+p0 || 0) - 1));
+yield* thread.procedures["Znon-warp recursion %s"]((toNotNaN(+p0) - 1));
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-block-with-null-for-variable-id.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-block-with-null-for-variable-id.sb3.tw-snapshot
@@ -21,7 +21,7 @@ retire(); return;
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-if (((+b0.value || 0) === 1)) {
+if ((toNotNaN(+b0.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 1",}, b1, false, false, "m", null);
 }
 retire(); return;
@@ -32,7 +32,7 @@ retire(); return;
 const b0 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
 const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-if (((+b0.value || 0) === 2)) {
+if ((toNotNaN(+b0.value) === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 2",}, b1, false, false, "q", null);
 }
 retire(); return;

--- a/test/snapshot/__snapshots__/warp-timer/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
@@ -10,11 +10,11 @@ yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "()*
 target.setSize(96);
 b1.value = 0;
 while (!(100 === Math.round(target.size))) {
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 target.setSize(target.size + ((100 - Math.round(target.size)) / 10));
 yield;
 }
-if (((+b1.value || 0) === 20)) {
+if ((toNotNaN(+b1.value) === 20)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "FPDFR?Wwq)kLj0A$0D{@", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "1,vLoJ4OQBv+Q#$VoYf=", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-comparison-matrix-runtime.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-comparison-matrix-runtime.sb3.tw-snapshot
@@ -24,19 +24,19 @@ thread.procedures["Wsetup values"]();
 b0.value = 0;
 b1.value = 0;
 for (var a0 = b2.value.length; a0 > 0; a0--) {
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 b3.value = 0;
 for (var a1 = b2.value.length; a1 > 0; a1--) {
-b3.value = ((+b3.value || 0) + 1);
-b0.value = ((+b0.value || 0) + 1);
+b3.value = (toNotNaN(+b3.value) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareGreaterThan(listGet(b2.value, b1.value), (b2.value[(b3.value | 0) - 1] ?? "")), (b4.value[(b0.value | 0) - 1] ?? ""))) {
 yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be > " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))),}, b5, true, false, "]", null);
 }
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareEqual(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
 yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be = " + ("" + listGet(b2.value, b3.value))))),}, b5, true, false, "|", null);
 }
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareLessThan(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
 yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be < " + ("" + listGet(b2.value, b3.value))))),}, b5, true, true, "ab", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}

--- a/test/snapshot/__snapshots__/warp-timer/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
@@ -10,7 +10,7 @@ return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
 b1.value = (0 + 0);
 yield* executeInCompatibilityLayer({"MESSAGE":"Hello!","SECS":0.1,}, b2, false, false, "d", null);
-if ((((+b1.value || 0) + 2) === 2)) {
+if (((toNotNaN(+b1.value) + 2) === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "i", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "m", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-custom-report-repeat.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-custom-report-repeat.sb3.tw-snapshot
@@ -8,11 +8,11 @@ const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
 b1.value = 0;
-for (var a0 = (+thread.procedures["Zblock name"]() || 0); a0 >= 0.5; a0--) {
-b1.value = ((+b1.value || 0) + 1);
+for (var a0 = toNotNaN(+thread.procedures["Zblock name"]()); a0 >= 0.5; a0--) {
+b1.value = (toNotNaN(+b1.value) + 1);
 yield;
 }
-if (((+b1.value || 0) === 40)) {
+if ((toNotNaN(+b1.value) === 40)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "n", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
@@ -15,7 +15,7 @@ target.setDirection((1 / 0));
 if ((target.direction === 95)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, "r", null);
 }
-target.setDirection(((0 / 0) || 0));
+target.setDirection(toNotNaN((0 / 0)));
 if ((target.direction === 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "u", null);
 }

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
@@ -15,7 +15,7 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass variable",}, b0, false, fals
 b2.value = [];
 b2.value.push(3);
 b2._monitorUpToDate = false;
-if (((+(b2.value[1 - 1] ?? "") || 0) === 3)) {
+if ((toNotNaN(+(b2.value[1 - 1] ?? "")) === 3)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass list",}, b0, false, false, "m", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
@@ -75,7 +75,7 @@ return "";
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 yield;
 }
 retire(); return;

--- a/test/snapshot/__snapshots__/warp-timer/tw-gh-249-quicksort.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-gh-249-quicksort.sb3.tw-snapshot
@@ -42,10 +42,10 @@ if (!compareEqual(listGet(b2.value, b1.value), listGet(b3.value, b1.value))) {
 b0.value = 0;
 yield* executeInCompatibilityLayer({"MESSAGE":("fail mismatch at index " + ("" + b1.value)),}, b4, true, false, ",", null);
 }
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 if (isStuck()) yield;
 }
-if (((+b0.value || 0) === 1)) {
+if ((toNotNaN(+b0.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass sorted",}, b4, true, false, "aE", null);
 }
 return "";
@@ -64,17 +64,17 @@ const b7 = target.variables["JIHtr29*ug5G;5*`f2.K-min-"];
 const b8 = target.variables["JIHtr29*ug5G;5*`f2.K-j-"];
 return function* genXYZ_qsort__ (p0,p1) {
 if (compareLessThan(p0, p1)) {
-if (!(((+p1 || 0) - (+p0 || 0)) <= 7)) {
-b0.value = (b1.value[(((((+p1 || 0) + (+p0 || 0)) || 0) / 2) | 0) - 1] ?? "");
+if (!((toNotNaN(+p1) - toNotNaN(+p0)) <= 7)) {
+b0.value = (b1.value[((toNotNaN((toNotNaN(+p1) + toNotNaN(+p0))) / 2) | 0) - 1] ?? "");
 b2.value = p0;
 b3.value = p1;
 while (true) {
 while (compareLessThan(listGet(b1.value, b2.value), b0.value)) {
-b2.value = ((+b2.value || 0) + 1);
+b2.value = (toNotNaN(+b2.value) + 1);
 if (isStuck()) yield;
 }
 while (compareGreaterThan(listGet(b1.value, b3.value), b0.value)) {
-b3.value = ((+b3.value || 0) + -1);
+b3.value = (toNotNaN(+b3.value) + -1);
 if (isStuck()) yield;
 }
 if (compareGreaterThan(b2.value, b3.value)) {
@@ -85,23 +85,23 @@ return "";
 b4.value = listGet(b1.value, b2.value);
 listReplace(b1, b2.value, listGet(b1.value, b3.value));
 listReplace(b1, b3.value, b4.value);
-b2.value = ((+b2.value || 0) + 1);
-b3.value = ((+b3.value || 0) + -1);
+b2.value = (toNotNaN(+b2.value) + 1);
+b3.value = (toNotNaN(+b3.value) + -1);
 }
 if (isStuck()) yield;
 }
 } else {
 b5.value = p0;
-for (var a0 = (((+p1 || 0) - (+p0 || 0)) || 0); a0 >= 0.5; a0--) {
+for (var a0 = toNotNaN((toNotNaN(+p1) - toNotNaN(+p0))); a0 >= 0.5; a0--) {
 b6.value = b5.value;
 b7.value = listGet(b1.value, b5.value);
-b8.value = ((+b5.value || 0) + 1);
-for (var a1 = (((+p1 || 0) - (+b5.value || 0)) || 0); a1 >= 0.5; a1--) {
+b8.value = (toNotNaN(+b5.value) + 1);
+for (var a1 = toNotNaN((toNotNaN(+p1) - toNotNaN(+b5.value))); a1 >= 0.5; a1--) {
 if (compareLessThan(listGet(b1.value, b8.value), b7.value)) {
 b7.value = listGet(b1.value, b8.value);
 b6.value = b8.value;
 }
-b8.value = ((+b8.value || 0) + 1);
+b8.value = (toNotNaN(+b8.value) + 1);
 if (isStuck()) yield;
 }
 if (compareEqual(b6.value, b5.value)) {
@@ -110,7 +110,7 @@ b4.value = listGet(b1.value, b5.value);
 listReplace(b1, b5.value, b7.value);
 listReplace(b1, b6.value, b4.value);
 }
-b5.value = ((+b5.value || 0) + 1);
+b5.value = (toNotNaN(+b5.value) + 1);
 if (isStuck()) yield;
 }
 }

--- a/test/snapshot/__snapshots__/warp-timer/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
@@ -22,7 +22,7 @@ const b1 = stage.variables["t)]?yi[*8XU73qhMqOa8"];
 return function* genXYZ_test_ (p0) {
 b0.value = p0;
 while (!(("" + listGet(b1.value, b0.value)).toLowerCase() === "something".toLowerCase())) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if (isStuck()) yield;
 }
 return "";

--- a/test/snapshot/__snapshots__/warp-timer/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -17,11 +17,11 @@ b1._monitorUpToDate = false;
 b2.value = 0;
 b3.value = "bwah";
 while (!(("" + b3.value).toLowerCase() === "eof".toLowerCase())) {
-b2.value = ((+b2.value || 0) + 1);
+b2.value = (toNotNaN(+b2.value) + 1);
 b3.value = (b1.value[(b2.value | 0) - 1] ?? "");
 yield;
 }
-if (((+b2.value || 0) === 2)) {
+if ((toNotNaN(+b2.value) === 2)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "q", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "o", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-non-existant.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-non-existant.sb3.tw-snapshot
@@ -7,7 +7,7 @@ const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * -1);
 runtime.requestRedraw();

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-recursion.sb3.tw-snapshot
@@ -10,7 +10,7 @@ return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 18",}, b0, false, false, "G", null);
 b1.value = 0;
 b2.value = (yield* thread.procedures["Znon warp recursion should yield %s"](8));
-if (((+b1.value || 0) === 4)) {
+if ((toNotNaN(+b1.value) === 4)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp recursion yields",}, b0, false, false, "ao", null);
 }
 b1.value = 0;
@@ -20,7 +20,7 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass warp recursion does not yiel
 }
 b1.value = 0;
 b2.value = (yield* thread.procedures["Zfib %s"](7));
-if (((+b1.value || 0) === 20)) {
+if ((toNotNaN(+b1.value) === 20)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp fib yielded",}, b0, false, false, "au", null);
 }
 yield* thread.procedures["Zrecursing yields between each %s"]("initial");
@@ -34,7 +34,7 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function* genXYZ_non_warp_recursion_s (p0) {
 if (compareGreaterThan(p0, 0)) {
-return (yield* yieldThenCallGenerator(thread.procedures["Znon warp recursion should yield %s"], ((+p0 || 0) - 1)));
+return (yield* yieldThenCallGenerator(thread.procedures["Znon warp recursion should yield %s"], (toNotNaN(+p0) - 1)));
 }
 return "";
 }; })
@@ -43,7 +43,7 @@ return "";
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function funXYZ_warp_recursion_shoul (p0) {
 if (compareGreaterThan(p0, 0)) {
-return thread.procedures["Wwarp recursion should not yield %s"](((+p0 || 0) - 1));
+return thread.procedures["Wwarp recursion should not yield %s"]((toNotNaN(+p0) - 1));
 }
 return "";
 }; })
@@ -54,7 +54,7 @@ return function* genXYZ_fib_ (p0) {
 if (compareLessThan(p0, 2)) {
 return p0;
 } else {
-return ((+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], ((+p0 || 0) - 1))) || 0) + (+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], ((+p0 || 0) - 2))) || 0));
+return (toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], (toNotNaN(+p0) - 1)))) + toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zfib %s"], (toNotNaN(+p0) - 2)))));
 }
 return "";
 }; })
@@ -67,8 +67,8 @@ const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_recursing_yields_bet (p0) {
 if ((("" + p0).toLowerCase() === "initial".toLowerCase())) {
 b0.value = 0;
-b1.value = ((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2)) || 0) + (((+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3)) || 0) + (+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3)) || 0)) || 0)) || 0)) || 0)) || 0));
-if (((+b0.value || 0) === 3)) {
+b1.value = (toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))) + toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))))))))))));
+if ((toNotNaN(+b0.value) === 3)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass recursing between calls yields final",}, b2, false, false, "aK", null);
 } else {
 yield* executeInCompatibilityLayer({"MESSAGE":"fail recursing between calls yields final",}, b2, false, false, "aL", null);
@@ -131,7 +131,7 @@ const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * -1);
 runtime.requestRedraw();

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-simple.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-simple.sb3.tw-snapshot
@@ -13,10 +13,10 @@ yield* executeInCompatibilityLayer({"MESSAGE":"pass simplest",}, b0, false, fals
 if ((("" + thread.procedures["Znesting 1"]()).toLowerCase() === "42-54".toLowerCase())) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass nesting1",}, b0, false, false, "=", null);
 }
-if (((+thread.procedures["Wwarp fib %s"](12) || 0) === 144)) {
+if ((toNotNaN(+thread.procedures["Wwarp fib %s"](12)) === 144)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass fib 12",}, b0, false, false, "@", null);
 }
-if (((+thread.procedures["Wfactorial %s"](12) || 0) === 479001600)) {
+if ((toNotNaN(+thread.procedures["Wfactorial %s"](12)) === 479001600)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass factorial 12",}, b0, false, false, "]", null);
 }
 b1.value = (yield* thread.procedures["Zno shadowing 1 %s %s"]("f","g"));
@@ -53,7 +53,7 @@ return "";
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function funXYZ_factorial_ (p0) {
 if (compareGreaterThan(p0, 1)) {
-return ((+p0 || 0) * (+thread.procedures["Wfactorial %s"](((+p0 || 0) - 1)) || 0));
+return (toNotNaN(+p0) * toNotNaN(+thread.procedures["Wfactorial %s"]((toNotNaN(+p0) - 1))));
 }
 return 1;
 return "";
@@ -88,7 +88,7 @@ return "";
 // Sprite1 Znesting 3 %s %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 return function funXYZ_nesting_3__ (p0,p1) {
-return ((+p0 || 0) * (+p1 || 0));
+return (toNotNaN(+p0) * toNotNaN(+p1));
 return "";
 }; })
 
@@ -98,7 +98,7 @@ return function funXYZ_fib_ (p0) {
 if (compareLessThan(p0, 2)) {
 return p0;
 } else {
-return ((+thread.procedures["Wfib %s"](((+p0 || 0) - 1)) || 0) + (+thread.procedures["Wfib %s"](((+p0 || 0) - 2)) || 0));
+return (toNotNaN(+thread.procedures["Wfib %s"]((toNotNaN(+p0) - 1))) + toNotNaN(+thread.procedures["Wfib %s"]((toNotNaN(+p0) - 2))));
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-stops-scripts.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-stops-scripts.sb3.tw-snapshot
@@ -8,11 +8,11 @@ const b1 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "f", null);
 yield* thread.procedures["Wreturn stops the script immediately"]();
-if (((+b1.value || 0) === 25)) {
+if ((toNotNaN(+b1.value) === 25)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass return stopped the script immediately",}, b0, false, false, "u", null);
 }
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test return outside of custom block" }));
-if (((+b1.value || 0) === 18)) {
+if ((toNotNaN(+b1.value) === 18)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass return worked to stop outside of custom block",}, b0, false, false, "x", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "v", null);
@@ -26,7 +26,7 @@ const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_return_stops_the_scr () {
 b0.value = 0;
 for (var a0 = 100; a0 > 0; a0--) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 25)) {
 return "stopped!";
 }
@@ -42,7 +42,7 @@ const b0 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 18)) {
 retire(); return;
 }

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-warp.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-warp.sb3.tw-snapshot
@@ -7,7 +7,7 @@ const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
 b0.value = 0;
 while (true) {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * -1);
 runtime.requestRedraw();
@@ -49,7 +49,7 @@ yield;
 thread.timer = null;
 yield;
 }
-if (((+b0.value || 0) === 5)) {
+if ((toNotNaN(+b0.value) === 5)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 1",}, b1, false, false, "R", null);
 }
 if ((("" + (yield* thread.procedures["Wverify runs warp %s"]((yield* thread.procedures["Zverify runs non warp %s"]((yield* thread.procedures["Wverify runs warp %s"]("abc"))))))).toLowerCase() === "warp: non warp: warp: abc".toLowerCase())) {
@@ -67,7 +67,7 @@ yield;
 thread.timer = null;
 yield;
 }
-if (((+b0.value || 0) === 5)) {
+if ((toNotNaN(+b0.value) === 5)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 2",}, b1, false, false, "W", null);
 }
 return "";

--- a/test/snapshot/__snapshots__/warp-timer/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
@@ -30,7 +30,7 @@ return function* genXYZ () {
 b0.value = 0;
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b1, false, false, "0/2-)Gp^^=haQ1OMD.xb", null);
 for (var a0 = 15; a0 > 0; a0--) {
-if (((+b2.value || 0) === 200)) {
+if ((toNotNaN(+b2.value) === 200)) {
 b2.value = 50;
 } else {
 b2.value = 200;

--- a/test/snapshot/__snapshots__/warp-timer/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
@@ -15,8 +15,8 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = target.variables["ts-.PQ{/]mN_9@MbG:m/"];
 return function* genXYZ_test_1 () {
-for (var a0 = (+thread.procedures["Wany procedure reporter"]() || 0); a0 >= 0.5; a0--) {
-b0.value = ((+b0.value || 0) + 1);
+for (var a0 = toNotNaN(+thread.procedures["Wany procedure reporter"]()); a0 >= 0.5; a0--) {
+b0.value = (toNotNaN(+b0.value) + 1);
 if (isStuck()) yield;
 }
 return "";

--- a/test/snapshot/__snapshots__/warp-timer/tw-restart-broadcast-threads.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-restart-broadcast-threads.sb3.tw-snapshot
@@ -18,7 +18,7 @@ while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-if (((+b1.value || 0) === 1)) {
+if ((toNotNaN(+b1.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "`SX*FG*Lwo*0_T=box-@", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "|#`zzPA_x%{`FyIAQhb4", null);
@@ -29,6 +29,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-safe-procedure-argument-casting.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-safe-procedure-argument-casting.sb3.tw-snapshot
@@ -7,11 +7,11 @@ const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "J#qm1yA(@Z6mj%Mgh;0X", null);
 thread.procedures["Zswitch %s"]("1");
-if ((((target.currentCostume + 1) === 2) && ((+target.getCostumes()[target.currentCostume].name || 0) === 1))) {
+if ((((target.currentCostume + 1) === 2) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 1))) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ";DM$.QW6o-O+T/oBdqt!", null);
 }
 thread.procedures["Zswitch %s"]("2");
-if ((((target.currentCostume + 1) === 1) && ((+target.getCostumes()[target.currentCostume].name || 0) === 2))) {
+if ((((target.currentCostume + 1) === 1) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 2))) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "71a9Slk0w=^~x;5T@nw,", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "$R-1lb(Mu?gdTIH^;kC_", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
@@ -29,7 +29,7 @@ yield;
 }
 b1.value = 2;
 } else {
-if (((+b1.value || 0) === 1)) {
+if ((toNotNaN(+b1.value) === 1)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "p", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, "n", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-simple-string-operations.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-simple-string-operations.sb3.tw-snapshot
@@ -24,13 +24,13 @@ return function* genXYZ_a () {
 b0.value = "ababa";
 b1.value = "";
 b2.value = 1;
-for (var a0 = ("" + b0.value).length; a0 > 0; a0--) {
+for (var a0 = b0.value.length; a0 > 0; a0--) {
 if ((((("" + b0.value))[((+b2.value) | 0) - 1] || "").toLowerCase() === "a".toLowerCase())) {
 b1.value = (("" + b1.value) + "b");
 } else {
 b1.value = (("" + b1.value) + "a");
 }
-b2.value = ((+b2.value || 0) + 1);
+b2.value = (toNotNaN(+b2.value) + 1);
 if (isStuck()) yield;
 }
 return "";

--- a/test/snapshot/__snapshots__/warp-timer/tw-tangent.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-tangent.sb3.tw-snapshot
@@ -9,46 +9,46 @@ yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b0, false, false, "p"
 if (compareEqual(tan(0), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 0",}, b0, false, false, "O", null);
 }
-if (((tan(90) || 0) === Infinity)) {
+if ((toNotNaN(tan(90)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 90",}, b0, false, false, "G", null);
 }
 if (compareEqual(tan(180), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 180",}, b0, false, false, "I", null);
 }
-if (((tan(270) || 0) === -Infinity)) {
+if ((toNotNaN(tan(270)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 270",}, b0, false, false, "K", null);
 }
 if (compareEqual(tan(360), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 360",}, b0, false, false, "M", null);
 }
-if (((tan(450) || 0) === Infinity)) {
+if ((toNotNaN(tan(450)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 450",}, b0, false, false, "Q", null);
 }
 if (compareEqual(tan(540), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 540",}, b0, false, false, "S", null);
 }
-if (((tan(630) || 0) === -Infinity)) {
+if ((toNotNaN(tan(630)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 630",}, b0, false, false, "U", null);
 }
 if (compareEqual(tan(720), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 720",}, b0, false, false, "W", null);
 }
-if (((tan(810) || 0) === Infinity)) {
+if ((toNotNaN(tan(810)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 810",}, b0, false, false, "Y", null);
 }
-if (((tan(-90) || 0) === -Infinity)) {
+if ((toNotNaN(tan(-90)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -90",}, b0, false, false, "0", null);
 }
 if (compareEqual(tan(-180), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -180",}, b0, false, false, "2", null);
 }
-if (((tan(-270) || 0) === Infinity)) {
+if ((toNotNaN(tan(-270)) === Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -270",}, b0, false, false, "4", null);
 }
 if (compareEqual(tan(-360), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -360",}, b0, false, false, "6", null);
 }
-if (((tan(-450) || 0) === -Infinity)) {
+if ((toNotNaN(tan(-450)) === -Infinity)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass -450",}, b0, false, false, "9", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "8", null);

--- a/test/snapshot/__snapshots__/warp-timer/tw-unsafe-equals.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-unsafe-equals.sb3.tw-snapshot
@@ -18,43 +18,43 @@ b1.value = 10;
 if ((b1.value === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "Ul:BCck-}Fvdux~x#$${", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, "8]2$7P)o#+#Lo]mFSBbx", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 5",}, b0, false, false, "ZU^{OfKTg|+Au$$q0[]u", null);
 }
 for (var a0 = 1; a0 > 0; a0--) {
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 6",}, b0, false, false, "HB+_IN}6=K[*ksxKXH0`", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 7",}, b0, false, false, ";73ODiwcp8IthYURTX;S", null);
 }
-if (((+b1.value || 0) === 10)) {
+if ((toNotNaN(+b1.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 8",}, b0, false, true, "${[MFmBL-D*1rbas9Q89", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
 }
 yield;
 }
 b2.value = "010";
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 9",}, b0, false, false, "#.`@SBj!g-c0:_q/tMZo", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 10",}, b0, false, false, "B`o?V6/q6g),/2w};a#y", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 11",}, b0, false, false, "TJ:#TkYBys*!RYiKLXb)", null);
 }
 for (var a1 = 1; a1 > 0; a1--) {
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 12",}, b0, false, false, ",Z,~10Qo~j;(+VL+I3q:", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 13",}, b0, false, false, "|Mqx([(26M%#ggW9)U0s", null);
 }
-if (((+b2.value || 0) === 10)) {
+if ((toNotNaN(+b2.value) === 10)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass 14",}, b0, false, true, "YvtiKF231lU8p5Qd97RP", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
 }

--- a/test/snapshot/__snapshots__/warp-timer/tw-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -16,7 +16,7 @@ b1._monitorUpToDate = false;
 b1.value.push("final");
 b1._monitorUpToDate = false;
 yield* thread.procedures["Wtest"]();
-if (((+b2.value || 0) === 4)) {
+if ((toNotNaN(+b2.value) === 4)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "u", null);
 }
 yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "t", null);
@@ -33,7 +33,7 @@ b0.value = "";
 b1.value = 1;
 while (!(("" + b0.value).toLowerCase() === "final".toLowerCase())) {
 b0.value = listGet(b2.value, b1.value);
-b1.value = ((+b1.value || 0) + 1);
+b1.value = (toNotNaN(+b1.value) + 1);
 if (isStuck()) yield;
 }
 return "";

--- a/test/snapshot/__snapshots__/warp-timer/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
@@ -24,7 +24,7 @@ retire(); return;
 const b0 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
 const b1 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
 return function* genXYZ () {
-b0.value = ((+b0.value || 0) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 5)) {
 b1.value = "end";
 }


### PR DESCRIPTION
My understanding is that the new compiler tries to reason about -0 a good bit but the use of `(x||0)` prevents it from fixing all of the bugs. This replaces that syntax with a jsexecute function that returns 0 only for NaN and leaves -0 unchanged.

Draft because:
 * Need more performance testing. Brief initial testing found no slowdown in Linux in Scratch. @Geotale said this might even be faster in ideal conditions.
 * Need some solid test cases to add.

Test @ https://experiments.turbowarp.org/fix-negative-zero/