### PR TITLE
Fix incorrect type in sensing () of () block

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -540,7 +540,7 @@ class ScriptTreeGenerator {
                 case 'costume name':
                     return new IntermediateInput(InputOpcode.SENSING_OF_COSTUME_NAME, InputType.STRING, {object});
                 case 'size':
-                    return new IntermediateInput(InputOpcode.SENSING_OF_SIZE, InputType.NUMBER_POS_REAL, {object});
+                    return new IntermediateInput(InputOpcode.SENSING_OF_SIZE, InputType.NUMBER_POS, {object});
                 }
             }
 

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -530,9 +530,9 @@ class ScriptTreeGenerator {
             } else {
                 switch (property) {
                 case 'x position':
-                    return new IntermediateInput(InputOpcode.SENSING_OF_POS_X, InputType.NUMBER_REAL, {object});
+                    return new IntermediateInput(InputOpcode.SENSING_OF_POS_X, InputType.NUMBER, {object});
                 case 'y position':
-                    return new IntermediateInput(InputOpcode.SENSING_OF_POS_Y, InputType.NUMBER_REAL, {object});
+                    return new IntermediateInput(InputOpcode.SENSING_OF_POS_Y, InputType.NUMBER, {object});
                 case 'direction':
                     return new IntermediateInput(InputOpcode.SENSING_OF_DIRECTION, InputType.NUMBER_REAL, {object});
                 case 'costume #':


### PR DESCRIPTION
When fixing #269 I forgot about the sensing () of () block which can also get x position, y position and size. This fixes the types for those too.