### PR TITLE
Remove more unnecessary casts

### DIFF
--- a/src/compiler/iroptimizer.js
+++ b/src/compiler/iroptimizer.js
@@ -162,10 +162,18 @@ class IROptimizer {
             const innerType = inputs.target.type;
             if (innerType & InputType.NUMBER) return innerType;
             return InputType.NUMBER;
-        } case InputOpcode.CAST_NUMBER_OR_NAN: {
+        }
+
+        case InputOpcode.CAST_NUMBER_OR_NAN: {
             const innerType = inputs.target.type;
             if (innerType & InputType.NUMBER_OR_NAN) return innerType;
             return InputType.NUMBER_OR_NAN;
+        }
+
+        case InputOpcode.CAST_STRING: {
+            const innerType = inputs.target.type;
+            if (innerType & InputType.STRING) return innerType;
+            return InputType.STRING;
         }
 
         case InputOpcode.OP_ADD: {
@@ -699,9 +707,19 @@ class IROptimizer {
                 return input.inputs.target;
             }
             return input;
-        } case InputOpcode.CAST_NUMBER_OR_NAN: {
+        }
+
+        case InputOpcode.CAST_NUMBER_OR_NAN: {
             const targetType = input.inputs.target.type;
             if ((targetType & InputType.NUMBER_OR_NAN) === targetType) {
+                return input.inputs.target;
+            }
+            return input;
+        }
+
+        case InputOpcode.CAST_STRING: {
+            const targetType = input.inputs.target.type;
+            if ((targetType & InputType.STRING) === targetType) {
                 return input.inputs.target;
             }
             return input;

--- a/src/compiler/iroptimizer.js
+++ b/src/compiler/iroptimizer.js
@@ -158,6 +158,12 @@ class IROptimizer {
         case InputOpcode.ADDON_CALL:
             break;
 
+        case InputOpcode.CAST_BOOLEAN: {
+            const innerType = inputs.target.type;
+            if (innerType & InputType.BOOLEAN) return innerType;
+            return InputType.BOOLEAN;
+        }
+
         case InputOpcode.CAST_NUMBER: {
             const innerType = inputs.target.type;
             if (innerType & InputType.NUMBER) return innerType;
@@ -707,6 +713,14 @@ class IROptimizer {
         }
 
         switch (input.opcode) {
+        case InputOpcode.CAST_BOOLEAN: {
+            const targetType = input.inputs.target.type;
+            if ((targetType & InputType.BOOLEAN) === targetType) {
+                return input.inputs.target;
+            }
+            return input;
+        }
+
         case InputOpcode.CAST_NUMBER: {
             const targetType = input.inputs.target.type;
             if ((targetType & InputType.NUMBER) === targetType) {

--- a/src/compiler/iroptimizer.js
+++ b/src/compiler/iroptimizer.js
@@ -164,6 +164,12 @@ class IROptimizer {
             return InputType.NUMBER;
         }
 
+        case InputOpcode.CAST_NUMBER_INDEX: {
+            const innerType = inputs.target.type;
+            if (innerType & InputType.NUMBER_INDEX) return innerType;
+            return InputType.NUMBER_INDEX;
+        }
+
         case InputOpcode.CAST_NUMBER_OR_NAN: {
             const innerType = inputs.target.type;
             if (innerType & InputType.NUMBER_OR_NAN) return innerType;
@@ -704,6 +710,14 @@ class IROptimizer {
         case InputOpcode.CAST_NUMBER: {
             const targetType = input.inputs.target.type;
             if ((targetType & InputType.NUMBER) === targetType) {
+                return input.inputs.target;
+            }
+            return input;
+        }
+
+        case InputOpcode.CAST_NUMBER_INDEX: {
+            const targetType = input.inputs.target.type;
+            if ((targetType & InputType.NUMBER_INDEX) === targetType) {
                 return input.inputs.target;
             }
             return input;

--- a/test/snapshot/__snapshots__/tw-sensing-of.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-sensing-of.sb3.tw-snapshot
@@ -52,7 +52,7 @@ if (compareEqual((b4 ? b4.value : 0), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent variable",}, b0, false, false, ")nnN?*l+E)dC(fT5(_@q", null);
 }
 b5.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop #" }), 0)) {
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b5.value, PROPERTY: "backdrop #" }), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, "UFr{fbR3@a.u_paq:r]F", null);
 }
 if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop name" }), 0)) {

--- a/test/snapshot/__snapshots__/tw-simple-string-operations.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-simple-string-operations.sb3.tw-snapshot
@@ -24,11 +24,11 @@ return function funXYZ_a () {
 b0.value = "ababa";
 b1.value = "";
 b2.value = 1;
-for (var a0 = ("" + b0.value).length; a0 > 0; a0--) {
-if ((((("" + b0.value))[(b2.value | 0) - 1] || "").toLowerCase() === "a".toLowerCase())) {
-b1.value = (("" + b1.value) + "b");
+for (var a0 = b0.value.length; a0 > 0; a0--) {
+if ((((b0.value)[(b2.value | 0) - 1] || "").toLowerCase() === "a".toLowerCase())) {
+b1.value = (b1.value + "b");
 } else {
-b1.value = (("" + b1.value) + "a");
+b1.value = (b1.value + "a");
 }
 b2.value = (b2.value + 1);
 }

--- a/test/snapshot/__snapshots__/tw-simple-string-operations.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-simple-string-operations.sb3.tw-snapshot
@@ -25,7 +25,7 @@ b0.value = "ababa";
 b1.value = "";
 b2.value = 1;
 for (var a0 = b0.value.length; a0 > 0; a0--) {
-if ((((b0.value)[(b2.value | 0) - 1] || "").toLowerCase() === "a".toLowerCase())) {
+if ((((b0.value)[b2.value - 1] || "").toLowerCase() === "a".toLowerCase())) {
 b1.value = (b1.value + "b");
 } else {
 b1.value = (b1.value + "a");

--- a/test/snapshot/__snapshots__/warp-timer/tw-sensing-of.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-sensing-of.sb3.tw-snapshot
@@ -52,7 +52,7 @@ if (compareEqual((b4 ? b4.value : 0), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent variable",}, b0, false, false, ")nnN?*l+E)dC(fT5(_@q", null);
 }
 b5.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop #" }), 0)) {
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b5.value, PROPERTY: "backdrop #" }), 0)) {
 yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, "UFr{fbR3@a.u_paq:r]F", null);
 }
 if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop name" }), 0)) {


### PR DESCRIPTION
optimize away casts to string, to list index, and to boolean if the input type is already the right thing

it's especially noticeable in the basic string operations test case where basically all the casts and the floor on the index no longer exist