### PR TITLE
Compile looks_say and looks_think without compatibility layer

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -352,7 +352,10 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this.runtime.emit(Scratch3LooksBlocks.SAY_OR_THINK, util.target, 'think', args.MESSAGE);
+        this._think(args.MESSAGE, util.target);
+    }
+    _think (message, target) { // used by compiler
+        this.runtime.emit(Scratch3LooksBlocks.SAY_OR_THINK, target, 'think', message);
     }
 
     thinkforsecs (args, util) {

--- a/src/compiler/compat-blocks.js
+++ b/src/compiler/compat-blocks.js
@@ -10,11 +10,9 @@
 const stacked = [
     'looks_changestretchby',
     'looks_hideallsprites',
-    'looks_say',
     'looks_sayforsecs',
     'looks_setstretchto',
     'looks_switchbackdroptoandwait',
-    'looks_think',
     'looks_thinkforsecs',
     'motion_align_scene',
     'motion_glidesecstoxy',

--- a/src/compiler/enums.js
+++ b/src/compiler/enums.js
@@ -152,6 +152,8 @@ const StackOpcode = {
     LOOKS_BACKDROP_SET: 'looks.switchBackdrop',
     LOOKS_COSTUME_NEXT: 'looks.nextCostume',
     LOOKS_COSTUME_SET: 'looks.switchCostume',
+    LOOKS_SAY: 'looks.say',
+    LOOKS_THINK: 'looks.think',
 
     MOTION_X_SET: 'motion.setX',
     MOTION_X_CHANGE: 'motion.changeX',

--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -806,6 +806,10 @@ class ScriptTreeGenerator {
             return new IntermediateStackBlock(StackOpcode.LOOKS_BACKDROP_NEXT);
         case 'looks_nextcostume':
             return new IntermediateStackBlock(StackOpcode.LOOKS_COSTUME_NEXT);
+        case 'looks_say':
+            return new IntermediateStackBlock(StackOpcode.LOOKS_SAY, {
+                message: this.descendInputOfBlock(block, 'MESSAGE')
+            });
         case 'looks_seteffectto':
             return new IntermediateStackBlock(StackOpcode.LOOKS_EFFECT_SET, {
                 effect: block.fields.EFFECT.value.toLowerCase(),
@@ -824,6 +828,10 @@ class ScriptTreeGenerator {
         case 'looks_switchcostumeto':
             return new IntermediateStackBlock(StackOpcode.LOOKS_COSTUME_SET, {
                 costume: this.descendInputOfBlock(block, 'COSTUME', true)
+            });
+        case 'looks_think':
+            return new IntermediateStackBlock(StackOpcode.LOOKS_THINK, {
+                message: this.descendInputOfBlock(block, 'MESSAGE')
             });
 
         case 'motion_changexby':

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -779,6 +779,12 @@ class JSGenerator {
         case StackOpcode.LOOKS_COSTUME_SET:
             this.source += `runtime.ext_scratch3_looks._setCostume(target, ${this.descendInput(node.costume)});\n`;
             break;
+        case StackOpcode.LOOKS_SAY:
+            this.source += `runtime.ext_scratch3_looks._say(${this.descendInput(node.message)}, target);\n`;
+            break;
+        case StackOpcode.LOOKS_THINK:
+            this.source += `runtime.ext_scratch3_looks._think(${this.descendInput(node.message)}, target);\n`;
+            break;
 
         case StackOpcode.MOTION_X_CHANGE:
             this.source += `target.setXY(target.x + ${this.descendInput(node.dx)}, target.y);\n`;

--- a/test/snapshot/__snapshots__/order-library-reverse.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/order-library-reverse.sb3.tw-snapshot
@@ -5,7 +5,6 @@
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-order"];
 const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -18,21 +17,20 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "]4hbk*5ix]V00h|!x1oy", null);
+runtime.ext_scratch3_looks._say("pass order is correct (1)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 1 != " + ("" + b0.value)),}, b2, false, false, "H=x@7SpNJeX|!}8x5y4,", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 1 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })
 
 // Sprite3 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
+const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "1Ba%a0GIK#hwJ46y=WVt", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a0 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -40,7 +38,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a1 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -48,14 +46,14 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a2 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
 yield;
 }
 thread.timer = null;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "}-I/zE+.RSi`:h[RxMvQ", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -63,7 +61,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-order"];
 const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -76,9 +73,9 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "0i[-T:vYTt=bi47@byUE", null);
+runtime.ext_scratch3_looks._say("pass order is correct (2)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 2 != " + ("" + b0.value)),}, b2, false, false, "Coc1aZ;L9M-RyEt`syps", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 2 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/order-library.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/order-library.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite3 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
+const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "s+@:|^WPr8]N1Y9Hk2f5", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a0 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -16,7 +15,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a1 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -24,14 +23,14 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a2 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
 yield;
 }
 thread.timer = null;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "7e7aA!PF-sxf1uka+sh2", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -39,7 +38,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-order"];
 const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -52,9 +50,9 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "RSQ{nVCc)6E)(`KlnFCF", null);
+runtime.ext_scratch3_looks._say("pass order is correct (1)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 1 != " + ("" + b0.value)),}, b2, false, false, "8k^j~`c^|YO@hkFd?~2d", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 1 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })
@@ -63,7 +61,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-order"];
 const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -76,9 +73,9 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "KP?op(=Vg2#;@]!,C#.~", null);
+runtime.ext_scratch3_looks._say("pass order is correct (2)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 2 != " + ("" + b0.value)),}, b2, false, false, "=]|}L~4uQXTNtwJKw_;R", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 2 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-NaN.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-NaN.sb3.tw-snapshot
@@ -3,72 +3,71 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 21",}, b0, false, false, "B", null);
+runtime.ext_scratch3_looks._say("plan 21", target);
 if (!(("" + (0 / 0)).toLowerCase() === "0".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aA", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + (0 * Infinity)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "/", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((0 * Infinity)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "?", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + ((Math.acos(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "=", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(((Math.acos(1.01) * 180) / Math.PI)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "]", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + ((Math.asin(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "_", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(((Math.asin(1.01) * 180) / Math.PI)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "{", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + (0 / 0)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "}", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((0 / 0)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aa", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + Math.sqrt(-1)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ac", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(Math.sqrt(-1)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ae", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ag", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(mod(0, 0)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ai", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ak", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(Math.log(-1)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "am", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + (Math.log(-1) / Math.LN10)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ao", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((Math.log(-1) / Math.LN10)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aq", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((Math.round(Math.sin((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "as", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((Math.round(Math.cos((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "au", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(tan((1 / 0))) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aw", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(runtime.ext_scratch3_operators._random((-1 / 0), (1 / 0))) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ax", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ":", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-add-can-return-nan.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-add-can-return-nan.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "6_?4sPB-|g:DtjdOm5Q-", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (!((Infinity + -Infinity) <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ")-u2YbbMb;gXMPOidjPj", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "zqE}hdaes.b)@mO1{R;X", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-all-at-once.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-all-at-once.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "1TRvh{mBarwY!BX8`o$R", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (true) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "K|r`QjC126S.93lMawiD", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "QaZ%(g:;bB~D+24z:U?l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
@@ -3,17 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "j", null);
-b1.value = (1 + 2);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (1 + 2);
 yield* thread.procedures["Znon-warp recursion %s"](2);
-if ((("" + listGet(b2.value, b1.value)).toLowerCase() === "the only thing".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "t", null);
+if ((("" + listGet(b1.value, b0.value)).toLowerCase() === "the only thing".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-automatic-variable-creation-literal-null-id.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-automatic-variable-creation-literal-null-id.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = target.variables["null"];
+const b0 = target.variables["null"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "a", null);
-b1.value = 5;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
+b0.value = 5;
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-block-with-null-for-variable-id.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-block-with-null-for-variable-id.sb3.tw-snapshot
@@ -3,26 +3,24 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "c", null);
-b1.value = 1;
-b2.value = 2;
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = 1;
+b1.value = 2;
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "check 1" }));
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "check 2" }));
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((toNotNaN(+b0.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 1",}, b1, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass variable 1", target);
 }
 retire(); return;
 }; })
@@ -30,10 +28,9 @@ retire(); return;
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((toNotNaN(+b0.value) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 2",}, b1, false, false, "q", null);
+runtime.ext_scratch3_looks._say("pass variable 2", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-boolean-arguments-are-not-cast.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-boolean-arguments-are-not-cast.sb3.tw-snapshot
@@ -3,22 +3,20 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "f", null);
-yield* thread.procedures["ZBlock A %s"]("Hai!!!");
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+thread.procedures["ZBlock A %s"]("Hai!!!");
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 ZBlock A %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_Block_A_ (p0) {
+return function funXYZ_Block_A_ (p0) {
 if ((("" + p0).toLowerCase() === "Hai!!!".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass did not cast",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass did not cast", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail was casted",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("fail was casted", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-broadcast-id-and-name-desync.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-broadcast-id-and-name-desync.sb3.tw-snapshot
@@ -3,18 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "?@x?KlY[GHB#^le;O^;Z", null);
+runtime.ext_scratch3_looks._say("pass", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "*S!`s:/sOEm#Bd%7=h7E", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" }));
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "g#w*ISI)$Wi.45AszY|1", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
@@ -3,20 +3,19 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "()*H*UE)$Jc!c}qb{,O)", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 target.setSize(96);
-b1.value = 0;
+b0.value = 0;
 while (!(100 === Math.round(target.size))) {
-b1.value = (toNotNaN(+b1.value) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 target.setSize(target.size + ((100 - Math.round(target.size)) / 10));
 yield;
 }
-if ((toNotNaN(+b1.value) === 20)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "FPDFR?Wwq)kLj0A$0D{@", null);
+if ((toNotNaN(+b0.value) === 20)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "1,vLoJ4OQBv+Q#$VoYf=", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-color-input-returns-hex.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-color-input-returns-hex.sb3.tw-snapshot
@@ -3,14 +3,13 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
-b1.value = "#22388a";
-if ((b1.value.toLowerCase() === "#22388a".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "f", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "#22388a";
+if ((b0.value.toLowerCase() === "#22388a".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-comparison-matrix-inline.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-comparison-matrix-inline.sb3.tw-snapshot
@@ -3,1773 +3,1772 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "f)", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 1: 0 should be < 0",}, b0, false, false, "tB", null);
+runtime.ext_scratch3_looks._say("fail 1: 0 should be < 0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 2: 0 should be = 0",}, b0, false, false, "tD", null);
+runtime.ext_scratch3_looks._say("fail 2: 0 should be = 0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 3: 0 should be > 0",}, b0, false, false, "tF", null);
+runtime.ext_scratch3_looks._say("fail 3: 0 should be > 0", target);
 }
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 4: 0 should be < 0.0",}, b0, false, false, "tH", null);
+runtime.ext_scratch3_looks._say("fail 4: 0 should be < 0.0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 5: 0 should be = 0.0",}, b0, false, false, "tJ", null);
+runtime.ext_scratch3_looks._say("fail 5: 0 should be = 0.0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 6: 0 should be > 0.0",}, b0, false, false, "tL", null);
+runtime.ext_scratch3_looks._say("fail 6: 0 should be > 0.0", target);
 }
 if (!(("" + (0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 7: 0 should be < 1.23",}, b0, false, false, "tN", null);
+runtime.ext_scratch3_looks._say("fail 7: 0 should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 8: 0 should be = 1.23",}, b0, false, false, "tP", null);
+runtime.ext_scratch3_looks._say("fail 8: 0 should be = 1.23", target);
 }
 if (!(("" + (0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 9: 0 should be > 1.23",}, b0, false, false, "tR", null);
+runtime.ext_scratch3_looks._say("fail 9: 0 should be > 1.23", target);
 }
 if (!(("" + (0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 10: 0 should be < .23",}, b0, false, false, "tT", null);
+runtime.ext_scratch3_looks._say("fail 10: 0 should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 11: 0 should be = .23",}, b0, false, false, "tV", null);
+runtime.ext_scratch3_looks._say("fail 11: 0 should be = .23", target);
 }
 if (!(("" + (0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 12: 0 should be > .23",}, b0, false, false, "tX", null);
+runtime.ext_scratch3_looks._say("fail 12: 0 should be > .23", target);
 }
 if (!(("" + (0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 13: 0 should be < 0.123",}, b0, false, false, "tZ", null);
+runtime.ext_scratch3_looks._say("fail 13: 0 should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 14: 0 should be = 0.123",}, b0, false, false, "t1", null);
+runtime.ext_scratch3_looks._say("fail 14: 0 should be = 0.123", target);
 }
 if (!(("" + (0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 15: 0 should be > 0.123",}, b0, false, false, "t3", null);
+runtime.ext_scratch3_looks._say("fail 15: 0 should be > 0.123", target);
 }
 if (!(("" + (0 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 16: 0 should be < -0",}, b0, false, false, "t5", null);
+runtime.ext_scratch3_looks._say("fail 16: 0 should be < -0", target);
 }
 if (!(("" + (0 === -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 17: 0 should be = -0",}, b0, false, false, "t7", null);
+runtime.ext_scratch3_looks._say("fail 17: 0 should be = -0", target);
 }
 if (!(("" + (0 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 18: 0 should be > -0",}, b0, false, false, "t9", null);
+runtime.ext_scratch3_looks._say("fail 18: 0 should be > -0", target);
 }
 if (!(("" + (0 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 19: 0 should be < -1",}, b0, false, false, "t#", null);
+runtime.ext_scratch3_looks._say("fail 19: 0 should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 20: 0 should be = -1",}, b0, false, false, "t(", null);
+runtime.ext_scratch3_looks._say("fail 20: 0 should be = -1", target);
 }
 if (!(("" + (0 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 21: 0 should be > -1",}, b0, false, false, "t*", null);
+runtime.ext_scratch3_looks._say("fail 21: 0 should be > -1", target);
 }
 if (!(("" + ("0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 22: 0 should be < true",}, b0, false, false, "t,", null);
+runtime.ext_scratch3_looks._say("fail 22: 0 should be < true", target);
 }
 if (!(("" + ("0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 23: 0 should be = true",}, b0, false, false, "t.", null);
+runtime.ext_scratch3_looks._say("fail 23: 0 should be = true", target);
 }
 if (!(("" + ("0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 24: 0 should be > true",}, b0, false, false, "t:", null);
+runtime.ext_scratch3_looks._say("fail 24: 0 should be > true", target);
 }
 if (!(("" + ("0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 25: 0 should be < false",}, b0, false, false, "t=", null);
+runtime.ext_scratch3_looks._say("fail 25: 0 should be < false", target);
 }
 if (!(("" + ("0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 26: 0 should be = false",}, b0, false, false, "t@", null);
+runtime.ext_scratch3_looks._say("fail 26: 0 should be = false", target);
 }
 if (!(("" + ("0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 27: 0 should be > false",}, b0, false, false, "t]", null);
+runtime.ext_scratch3_looks._say("fail 27: 0 should be > false", target);
 }
 if (!(("" + ("0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 28: 0 should be < NaN",}, b0, false, false, "t_", null);
+runtime.ext_scratch3_looks._say("fail 28: 0 should be < NaN", target);
 }
 if (!(("" + ("0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 29: 0 should be = NaN",}, b0, false, false, "t{", null);
+runtime.ext_scratch3_looks._say("fail 29: 0 should be = NaN", target);
 }
 if (!(("" + ("0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 30: 0 should be > NaN",}, b0, false, false, "t}", null);
+runtime.ext_scratch3_looks._say("fail 30: 0 should be > NaN", target);
 }
 if (!(("" + (0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 31: 0 should be < Infinity",}, b0, false, false, "ua", null);
+runtime.ext_scratch3_looks._say("fail 31: 0 should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 32: 0 should be = Infinity",}, b0, false, false, "uc", null);
+runtime.ext_scratch3_looks._say("fail 32: 0 should be = Infinity", target);
 }
 if (!(("" + (0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 33: 0 should be > Infinity",}, b0, false, false, "ue", null);
+runtime.ext_scratch3_looks._say("fail 33: 0 should be > Infinity", target);
 }
 if (!(("" + ("0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 34: 0 should be < banana",}, b0, false, false, "ug", null);
+runtime.ext_scratch3_looks._say("fail 34: 0 should be < banana", target);
 }
 if (!(("" + ("0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 35: 0 should be = banana",}, b0, false, false, "ui", null);
+runtime.ext_scratch3_looks._say("fail 35: 0 should be = banana", target);
 }
 if (!(("" + ("0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 36: 0 should be > banana",}, b0, false, false, "uk", null);
+runtime.ext_scratch3_looks._say("fail 36: 0 should be > banana", target);
 }
 if (!(("" + ("0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 37: 0 should be < 🎉",}, b0, false, false, "um", null);
+runtime.ext_scratch3_looks._say("fail 37: 0 should be < 🎉", target);
 }
 if (!(("" + ("0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 38: 0 should be = 🎉",}, b0, false, false, "uo", null);
+runtime.ext_scratch3_looks._say("fail 38: 0 should be = 🎉", target);
 }
 if (!(("" + ("0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 39: 0 should be > 🎉",}, b0, false, false, "uq", null);
+runtime.ext_scratch3_looks._say("fail 39: 0 should be > 🎉", target);
 }
 if (!(("" + ("0".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 40: 0 should be < ",}, b0, false, false, "us", null);
+runtime.ext_scratch3_looks._say("fail 40: 0 should be < ", target);
 }
 if (!(("" + ("0".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 41: 0 should be = ",}, b0, false, false, "uu", null);
+runtime.ext_scratch3_looks._say("fail 41: 0 should be = ", target);
 }
 if (!(("" + ("0".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 42: 0 should be > ",}, b0, false, false, "uw", null);
+runtime.ext_scratch3_looks._say("fail 42: 0 should be > ", target);
 }
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 43: 0.0 should be < 0",}, b0, false, false, "uy", null);
+runtime.ext_scratch3_looks._say("fail 43: 0.0 should be < 0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 44: 0.0 should be = 0",}, b0, false, false, "uA", null);
+runtime.ext_scratch3_looks._say("fail 44: 0.0 should be = 0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 45: 0.0 should be > 0",}, b0, false, false, "uC", null);
+runtime.ext_scratch3_looks._say("fail 45: 0.0 should be > 0", target);
 }
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 46: 0.0 should be < 0.0",}, b0, false, false, "uE", null);
+runtime.ext_scratch3_looks._say("fail 46: 0.0 should be < 0.0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 47: 0.0 should be = 0.0",}, b0, false, false, "uG", null);
+runtime.ext_scratch3_looks._say("fail 47: 0.0 should be = 0.0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 48: 0.0 should be > 0.0",}, b0, false, false, "uI", null);
+runtime.ext_scratch3_looks._say("fail 48: 0.0 should be > 0.0", target);
 }
 if (!(("" + (0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 49: 0.0 should be < 1.23",}, b0, false, false, "uK", null);
+runtime.ext_scratch3_looks._say("fail 49: 0.0 should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 50: 0.0 should be = 1.23",}, b0, false, false, "uM", null);
+runtime.ext_scratch3_looks._say("fail 50: 0.0 should be = 1.23", target);
 }
 if (!(("" + (0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 51: 0.0 should be > 1.23",}, b0, false, false, "uO", null);
+runtime.ext_scratch3_looks._say("fail 51: 0.0 should be > 1.23", target);
 }
 if (!(("" + (0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 52: 0.0 should be < .23",}, b0, false, false, "uQ", null);
+runtime.ext_scratch3_looks._say("fail 52: 0.0 should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 53: 0.0 should be = .23",}, b0, false, false, "uS", null);
+runtime.ext_scratch3_looks._say("fail 53: 0.0 should be = .23", target);
 }
 if (!(("" + (0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 54: 0.0 should be > .23",}, b0, false, false, "uU", null);
+runtime.ext_scratch3_looks._say("fail 54: 0.0 should be > .23", target);
 }
 if (!(("" + (0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 55: 0.0 should be < 0.123",}, b0, false, false, "uW", null);
+runtime.ext_scratch3_looks._say("fail 55: 0.0 should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 56: 0.0 should be = 0.123",}, b0, false, false, "uY", null);
+runtime.ext_scratch3_looks._say("fail 56: 0.0 should be = 0.123", target);
 }
 if (!(("" + (0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 57: 0.0 should be > 0.123",}, b0, false, false, "u0", null);
+runtime.ext_scratch3_looks._say("fail 57: 0.0 should be > 0.123", target);
 }
 if (!(("" + (0 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 58: 0.0 should be < -0",}, b0, false, false, "u2", null);
+runtime.ext_scratch3_looks._say("fail 58: 0.0 should be < -0", target);
 }
 if (!(("" + (0 === -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 59: 0.0 should be = -0",}, b0, false, false, "u4", null);
+runtime.ext_scratch3_looks._say("fail 59: 0.0 should be = -0", target);
 }
 if (!(("" + (0 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 60: 0.0 should be > -0",}, b0, false, false, "u6", null);
+runtime.ext_scratch3_looks._say("fail 60: 0.0 should be > -0", target);
 }
 if (!(("" + (0 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 61: 0.0 should be < -1",}, b0, false, false, "u8", null);
+runtime.ext_scratch3_looks._say("fail 61: 0.0 should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 62: 0.0 should be = -1",}, b0, false, false, "u!", null);
+runtime.ext_scratch3_looks._say("fail 62: 0.0 should be = -1", target);
 }
 if (!(("" + (0 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 63: 0.0 should be > -1",}, b0, false, false, "u%", null);
+runtime.ext_scratch3_looks._say("fail 63: 0.0 should be > -1", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 64: 0.0 should be < true",}, b0, false, false, "u)", null);
+runtime.ext_scratch3_looks._say("fail 64: 0.0 should be < true", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 65: 0.0 should be = true",}, b0, false, false, "u+", null);
+runtime.ext_scratch3_looks._say("fail 65: 0.0 should be = true", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 66: 0.0 should be > true",}, b0, false, false, "u-", null);
+runtime.ext_scratch3_looks._say("fail 66: 0.0 should be > true", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 67: 0.0 should be < false",}, b0, false, false, "u/", null);
+runtime.ext_scratch3_looks._say("fail 67: 0.0 should be < false", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 68: 0.0 should be = false",}, b0, false, false, "u;", null);
+runtime.ext_scratch3_looks._say("fail 68: 0.0 should be = false", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 69: 0.0 should be > false",}, b0, false, false, "u?", null);
+runtime.ext_scratch3_looks._say("fail 69: 0.0 should be > false", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 70: 0.0 should be < NaN",}, b0, false, false, "u[", null);
+runtime.ext_scratch3_looks._say("fail 70: 0.0 should be < NaN", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 71: 0.0 should be = NaN",}, b0, false, false, "u^", null);
+runtime.ext_scratch3_looks._say("fail 71: 0.0 should be = NaN", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 72: 0.0 should be > NaN",}, b0, false, false, "u`", null);
+runtime.ext_scratch3_looks._say("fail 72: 0.0 should be > NaN", target);
 }
 if (!(("" + (0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 73: 0.0 should be < Infinity",}, b0, false, false, "u|", null);
+runtime.ext_scratch3_looks._say("fail 73: 0.0 should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 74: 0.0 should be = Infinity",}, b0, false, false, "u~", null);
+runtime.ext_scratch3_looks._say("fail 74: 0.0 should be = Infinity", target);
 }
 if (!(("" + (0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 75: 0.0 should be > Infinity",}, b0, false, false, "vb", null);
+runtime.ext_scratch3_looks._say("fail 75: 0.0 should be > Infinity", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 76: 0.0 should be < banana",}, b0, false, false, "vd", null);
+runtime.ext_scratch3_looks._say("fail 76: 0.0 should be < banana", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 77: 0.0 should be = banana",}, b0, false, false, "vf", null);
+runtime.ext_scratch3_looks._say("fail 77: 0.0 should be = banana", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 78: 0.0 should be > banana",}, b0, false, false, "vh", null);
+runtime.ext_scratch3_looks._say("fail 78: 0.0 should be > banana", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 79: 0.0 should be < 🎉",}, b0, false, false, "vj", null);
+runtime.ext_scratch3_looks._say("fail 79: 0.0 should be < 🎉", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 80: 0.0 should be = 🎉",}, b0, false, false, "vl", null);
+runtime.ext_scratch3_looks._say("fail 80: 0.0 should be = 🎉", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 81: 0.0 should be > 🎉",}, b0, false, false, "vn", null);
+runtime.ext_scratch3_looks._say("fail 81: 0.0 should be > 🎉", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 82: 0.0 should be < ",}, b0, false, false, "vp", null);
+runtime.ext_scratch3_looks._say("fail 82: 0.0 should be < ", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 83: 0.0 should be = ",}, b0, false, false, "vr", null);
+runtime.ext_scratch3_looks._say("fail 83: 0.0 should be = ", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 84: 0.0 should be > ",}, b0, false, false, "vt", null);
+runtime.ext_scratch3_looks._say("fail 84: 0.0 should be > ", target);
 }
 if (!(("" + (1.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 85: 1.23 should be < 0",}, b0, false, false, "vv", null);
+runtime.ext_scratch3_looks._say("fail 85: 1.23 should be < 0", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 86: 1.23 should be = 0",}, b0, false, false, "vx", null);
+runtime.ext_scratch3_looks._say("fail 86: 1.23 should be = 0", target);
 }
 if (!(("" + (1.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 87: 1.23 should be > 0",}, b0, false, false, "vz", null);
+runtime.ext_scratch3_looks._say("fail 87: 1.23 should be > 0", target);
 }
 if (!(("" + (1.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 88: 1.23 should be < 0.0",}, b0, false, false, "vB", null);
+runtime.ext_scratch3_looks._say("fail 88: 1.23 should be < 0.0", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 89: 1.23 should be = 0.0",}, b0, false, false, "vD", null);
+runtime.ext_scratch3_looks._say("fail 89: 1.23 should be = 0.0", target);
 }
 if (!(("" + (1.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 90: 1.23 should be > 0.0",}, b0, false, false, "vF", null);
+runtime.ext_scratch3_looks._say("fail 90: 1.23 should be > 0.0", target);
 }
 if (!(("" + (1.23 < 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 91: 1.23 should be < 1.23",}, b0, false, false, "vH", null);
+runtime.ext_scratch3_looks._say("fail 91: 1.23 should be < 1.23", target);
 }
 if (!(("" + (1.23 === 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 92: 1.23 should be = 1.23",}, b0, false, false, "vJ", null);
+runtime.ext_scratch3_looks._say("fail 92: 1.23 should be = 1.23", target);
 }
 if (!(("" + (1.23 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 93: 1.23 should be > 1.23",}, b0, false, false, "vL", null);
+runtime.ext_scratch3_looks._say("fail 93: 1.23 should be > 1.23", target);
 }
 if (!(("" + (1.23 < 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 94: 1.23 should be < .23",}, b0, false, false, "vN", null);
+runtime.ext_scratch3_looks._say("fail 94: 1.23 should be < .23", target);
 }
 if (!(("" + (1.23 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 95: 1.23 should be = .23",}, b0, false, false, "vP", null);
+runtime.ext_scratch3_looks._say("fail 95: 1.23 should be = .23", target);
 }
 if (!(("" + (1.23 > 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 96: 1.23 should be > .23",}, b0, false, false, "vR", null);
+runtime.ext_scratch3_looks._say("fail 96: 1.23 should be > .23", target);
 }
 if (!(("" + (1.23 < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 97: 1.23 should be < 0.123",}, b0, false, false, "vT", null);
+runtime.ext_scratch3_looks._say("fail 97: 1.23 should be < 0.123", target);
 }
 if (!(("" + (1.23 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 98: 1.23 should be = 0.123",}, b0, false, false, "vV", null);
+runtime.ext_scratch3_looks._say("fail 98: 1.23 should be = 0.123", target);
 }
 if (!(("" + (1.23 > 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 99: 1.23 should be > 0.123",}, b0, false, false, "vX", null);
+runtime.ext_scratch3_looks._say("fail 99: 1.23 should be > 0.123", target);
 }
 if (!(("" + (1.23 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 100: 1.23 should be < -0",}, b0, false, false, "vZ", null);
+runtime.ext_scratch3_looks._say("fail 100: 1.23 should be < -0", target);
 }
 if (!(("" + (1.23 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 101: 1.23 should be = -0",}, b0, false, false, "v1", null);
+runtime.ext_scratch3_looks._say("fail 101: 1.23 should be = -0", target);
 }
 if (!(("" + (1.23 > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 102: 1.23 should be > -0",}, b0, false, false, "v3", null);
+runtime.ext_scratch3_looks._say("fail 102: 1.23 should be > -0", target);
 }
 if (!(("" + (1.23 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 103: 1.23 should be < -1",}, b0, false, false, "v5", null);
+runtime.ext_scratch3_looks._say("fail 103: 1.23 should be < -1", target);
 }
 if (!(("" + (1.23 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 104: 1.23 should be = -1",}, b0, false, false, "v7", null);
+runtime.ext_scratch3_looks._say("fail 104: 1.23 should be = -1", target);
 }
 if (!(("" + (1.23 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 105: 1.23 should be > -1",}, b0, false, false, "v9", null);
+runtime.ext_scratch3_looks._say("fail 105: 1.23 should be > -1", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 106: 1.23 should be < true",}, b0, false, false, "v#", null);
+runtime.ext_scratch3_looks._say("fail 106: 1.23 should be < true", target);
 }
 if (!(("" + (1.23 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 107: 1.23 should be = true",}, b0, false, false, "v(", null);
+runtime.ext_scratch3_looks._say("fail 107: 1.23 should be = true", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 108: 1.23 should be > true",}, b0, false, false, "v*", null);
+runtime.ext_scratch3_looks._say("fail 108: 1.23 should be > true", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 109: 1.23 should be < false",}, b0, false, false, "v,", null);
+runtime.ext_scratch3_looks._say("fail 109: 1.23 should be < false", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 110: 1.23 should be = false",}, b0, false, false, "v.", null);
+runtime.ext_scratch3_looks._say("fail 110: 1.23 should be = false", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 111: 1.23 should be > false",}, b0, false, false, "v:", null);
+runtime.ext_scratch3_looks._say("fail 111: 1.23 should be > false", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 112: 1.23 should be < NaN",}, b0, false, false, "v=", null);
+runtime.ext_scratch3_looks._say("fail 112: 1.23 should be < NaN", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 113: 1.23 should be = NaN",}, b0, false, false, "v@", null);
+runtime.ext_scratch3_looks._say("fail 113: 1.23 should be = NaN", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 114: 1.23 should be > NaN",}, b0, false, false, "v]", null);
+runtime.ext_scratch3_looks._say("fail 114: 1.23 should be > NaN", target);
 }
 if (!(("" + (1.23 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 115: 1.23 should be < Infinity",}, b0, false, false, "v_", null);
+runtime.ext_scratch3_looks._say("fail 115: 1.23 should be < Infinity", target);
 }
 if (!(("" + (1.23 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 116: 1.23 should be = Infinity",}, b0, false, false, "v{", null);
+runtime.ext_scratch3_looks._say("fail 116: 1.23 should be = Infinity", target);
 }
 if (!(("" + (1.23 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 117: 1.23 should be > Infinity",}, b0, false, false, "v}", null);
+runtime.ext_scratch3_looks._say("fail 117: 1.23 should be > Infinity", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 118: 1.23 should be < banana",}, b0, false, false, "wa", null);
+runtime.ext_scratch3_looks._say("fail 118: 1.23 should be < banana", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 119: 1.23 should be = banana",}, b0, false, false, "wc", null);
+runtime.ext_scratch3_looks._say("fail 119: 1.23 should be = banana", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 120: 1.23 should be > banana",}, b0, false, false, "we", null);
+runtime.ext_scratch3_looks._say("fail 120: 1.23 should be > banana", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 121: 1.23 should be < 🎉",}, b0, false, false, "wg", null);
+runtime.ext_scratch3_looks._say("fail 121: 1.23 should be < 🎉", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 122: 1.23 should be = 🎉",}, b0, false, false, "wi", null);
+runtime.ext_scratch3_looks._say("fail 122: 1.23 should be = 🎉", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 123: 1.23 should be > 🎉",}, b0, false, false, "wk", null);
+runtime.ext_scratch3_looks._say("fail 123: 1.23 should be > 🎉", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 124: 1.23 should be < ",}, b0, false, false, "wm", null);
+runtime.ext_scratch3_looks._say("fail 124: 1.23 should be < ", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 125: 1.23 should be = ",}, b0, false, false, "wo", null);
+runtime.ext_scratch3_looks._say("fail 125: 1.23 should be = ", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 126: 1.23 should be > ",}, b0, false, false, "wq", null);
+runtime.ext_scratch3_looks._say("fail 126: 1.23 should be > ", target);
 }
 if (!(("" + (0.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 127: .23 should be < 0",}, b0, false, false, "ws", null);
+runtime.ext_scratch3_looks._say("fail 127: .23 should be < 0", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 128: .23 should be = 0",}, b0, false, false, "wu", null);
+runtime.ext_scratch3_looks._say("fail 128: .23 should be = 0", target);
 }
 if (!(("" + (0.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 129: .23 should be > 0",}, b0, false, false, "ww", null);
+runtime.ext_scratch3_looks._say("fail 129: .23 should be > 0", target);
 }
 if (!(("" + (0.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 130: .23 should be < 0.0",}, b0, false, false, "wy", null);
+runtime.ext_scratch3_looks._say("fail 130: .23 should be < 0.0", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 131: .23 should be = 0.0",}, b0, false, false, "wA", null);
+runtime.ext_scratch3_looks._say("fail 131: .23 should be = 0.0", target);
 }
 if (!(("" + (0.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 132: .23 should be > 0.0",}, b0, false, false, "wC", null);
+runtime.ext_scratch3_looks._say("fail 132: .23 should be > 0.0", target);
 }
 if (!(("" + (0.23 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 133: .23 should be < 1.23",}, b0, false, false, "wE", null);
+runtime.ext_scratch3_looks._say("fail 133: .23 should be < 1.23", target);
 }
 if (!(("" + (0.23 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 134: .23 should be = 1.23",}, b0, false, false, "wG", null);
+runtime.ext_scratch3_looks._say("fail 134: .23 should be = 1.23", target);
 }
 if (!(("" + (0.23 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 135: .23 should be > 1.23",}, b0, false, false, "wI", null);
+runtime.ext_scratch3_looks._say("fail 135: .23 should be > 1.23", target);
 }
 if (!(("" + (0.23 < 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 136: .23 should be < .23",}, b0, false, false, "wK", null);
+runtime.ext_scratch3_looks._say("fail 136: .23 should be < .23", target);
 }
 if (!(("" + (0.23 === 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 137: .23 should be = .23",}, b0, false, false, "wM", null);
+runtime.ext_scratch3_looks._say("fail 137: .23 should be = .23", target);
 }
 if (!(("" + (0.23 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 138: .23 should be > .23",}, b0, false, false, "wO", null);
+runtime.ext_scratch3_looks._say("fail 138: .23 should be > .23", target);
 }
 if (!(("" + (0.23 < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 139: .23 should be < 0.123",}, b0, false, false, "wQ", null);
+runtime.ext_scratch3_looks._say("fail 139: .23 should be < 0.123", target);
 }
 if (!(("" + (0.23 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 140: .23 should be = 0.123",}, b0, false, false, "wS", null);
+runtime.ext_scratch3_looks._say("fail 140: .23 should be = 0.123", target);
 }
 if (!(("" + (0.23 > 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 141: .23 should be > 0.123",}, b0, false, false, "wU", null);
+runtime.ext_scratch3_looks._say("fail 141: .23 should be > 0.123", target);
 }
 if (!(("" + (0.23 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 142: .23 should be < -0",}, b0, false, false, "wW", null);
+runtime.ext_scratch3_looks._say("fail 142: .23 should be < -0", target);
 }
 if (!(("" + (0.23 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 143: .23 should be = -0",}, b0, false, false, "wY", null);
+runtime.ext_scratch3_looks._say("fail 143: .23 should be = -0", target);
 }
 if (!(("" + (0.23 > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 144: .23 should be > -0",}, b0, false, false, "w0", null);
+runtime.ext_scratch3_looks._say("fail 144: .23 should be > -0", target);
 }
 if (!(("" + (0.23 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 145: .23 should be < -1",}, b0, false, false, "w2", null);
+runtime.ext_scratch3_looks._say("fail 145: .23 should be < -1", target);
 }
 if (!(("" + (0.23 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 146: .23 should be = -1",}, b0, false, false, "w4", null);
+runtime.ext_scratch3_looks._say("fail 146: .23 should be = -1", target);
 }
 if (!(("" + (0.23 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 147: .23 should be > -1",}, b0, false, false, "w6", null);
+runtime.ext_scratch3_looks._say("fail 147: .23 should be > -1", target);
 }
 if (!(("" + (".23".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 148: .23 should be < true",}, b0, false, false, "w8", null);
+runtime.ext_scratch3_looks._say("fail 148: .23 should be < true", target);
 }
 if (!(("" + (0.23 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 149: .23 should be = true",}, b0, false, false, "w!", null);
+runtime.ext_scratch3_looks._say("fail 149: .23 should be = true", target);
 }
 if (!(("" + (".23".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 150: .23 should be > true",}, b0, false, false, "w%", null);
+runtime.ext_scratch3_looks._say("fail 150: .23 should be > true", target);
 }
 if (!(("" + (".23".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 151: .23 should be < false",}, b0, false, false, "w)", null);
+runtime.ext_scratch3_looks._say("fail 151: .23 should be < false", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 152: .23 should be = false",}, b0, false, false, "w+", null);
+runtime.ext_scratch3_looks._say("fail 152: .23 should be = false", target);
 }
 if (!(("" + (".23".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 153: .23 should be > false",}, b0, false, false, "w-", null);
+runtime.ext_scratch3_looks._say("fail 153: .23 should be > false", target);
 }
 if (!(("" + (".23".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 154: .23 should be < NaN",}, b0, false, false, "w/", null);
+runtime.ext_scratch3_looks._say("fail 154: .23 should be < NaN", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 155: .23 should be = NaN",}, b0, false, false, "w;", null);
+runtime.ext_scratch3_looks._say("fail 155: .23 should be = NaN", target);
 }
 if (!(("" + (".23".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 156: .23 should be > NaN",}, b0, false, false, "w?", null);
+runtime.ext_scratch3_looks._say("fail 156: .23 should be > NaN", target);
 }
 if (!(("" + (0.23 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 157: .23 should be < Infinity",}, b0, false, false, "w[", null);
+runtime.ext_scratch3_looks._say("fail 157: .23 should be < Infinity", target);
 }
 if (!(("" + (0.23 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 158: .23 should be = Infinity",}, b0, false, false, "w^", null);
+runtime.ext_scratch3_looks._say("fail 158: .23 should be = Infinity", target);
 }
 if (!(("" + (0.23 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 159: .23 should be > Infinity",}, b0, false, false, "w`", null);
+runtime.ext_scratch3_looks._say("fail 159: .23 should be > Infinity", target);
 }
 if (!(("" + (".23".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 160: .23 should be < banana",}, b0, false, false, "w|", null);
+runtime.ext_scratch3_looks._say("fail 160: .23 should be < banana", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 161: .23 should be = banana",}, b0, false, false, "w~", null);
+runtime.ext_scratch3_looks._say("fail 161: .23 should be = banana", target);
 }
 if (!(("" + (".23".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 162: .23 should be > banana",}, b0, false, false, "xb", null);
+runtime.ext_scratch3_looks._say("fail 162: .23 should be > banana", target);
 }
 if (!(("" + (".23".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 163: .23 should be < 🎉",}, b0, false, false, "xd", null);
+runtime.ext_scratch3_looks._say("fail 163: .23 should be < 🎉", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 164: .23 should be = 🎉",}, b0, false, false, "xf", null);
+runtime.ext_scratch3_looks._say("fail 164: .23 should be = 🎉", target);
 }
 if (!(("" + (".23".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 165: .23 should be > 🎉",}, b0, false, false, "xh", null);
+runtime.ext_scratch3_looks._say("fail 165: .23 should be > 🎉", target);
 }
 if (!(("" + (".23".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 166: .23 should be < ",}, b0, false, false, "xj", null);
+runtime.ext_scratch3_looks._say("fail 166: .23 should be < ", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 167: .23 should be = ",}, b0, false, false, "xl", null);
+runtime.ext_scratch3_looks._say("fail 167: .23 should be = ", target);
 }
 if (!(("" + (".23".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 168: .23 should be > ",}, b0, false, false, "xn", null);
+runtime.ext_scratch3_looks._say("fail 168: .23 should be > ", target);
 }
 if (!(("" + (0.123 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 169: 0.123 should be < 0",}, b0, false, false, "xp", null);
+runtime.ext_scratch3_looks._say("fail 169: 0.123 should be < 0", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 170: 0.123 should be = 0",}, b0, false, false, "xr", null);
+runtime.ext_scratch3_looks._say("fail 170: 0.123 should be = 0", target);
 }
 if (!(("" + (0.123 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 171: 0.123 should be > 0",}, b0, false, false, "xt", null);
+runtime.ext_scratch3_looks._say("fail 171: 0.123 should be > 0", target);
 }
 if (!(("" + (0.123 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 172: 0.123 should be < 0.0",}, b0, false, false, "xv", null);
+runtime.ext_scratch3_looks._say("fail 172: 0.123 should be < 0.0", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 173: 0.123 should be = 0.0",}, b0, false, false, "xx", null);
+runtime.ext_scratch3_looks._say("fail 173: 0.123 should be = 0.0", target);
 }
 if (!(("" + (0.123 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 174: 0.123 should be > 0.0",}, b0, false, false, "xz", null);
+runtime.ext_scratch3_looks._say("fail 174: 0.123 should be > 0.0", target);
 }
 if (!(("" + (0.123 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 175: 0.123 should be < 1.23",}, b0, false, false, "xB", null);
+runtime.ext_scratch3_looks._say("fail 175: 0.123 should be < 1.23", target);
 }
 if (!(("" + (0.123 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 176: 0.123 should be = 1.23",}, b0, false, false, "xD", null);
+runtime.ext_scratch3_looks._say("fail 176: 0.123 should be = 1.23", target);
 }
 if (!(("" + (0.123 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 177: 0.123 should be > 1.23",}, b0, false, false, "xF", null);
+runtime.ext_scratch3_looks._say("fail 177: 0.123 should be > 1.23", target);
 }
 if (!(("" + (0.123 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 178: 0.123 should be < .23",}, b0, false, false, "xH", null);
+runtime.ext_scratch3_looks._say("fail 178: 0.123 should be < .23", target);
 }
 if (!(("" + (0.123 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 179: 0.123 should be = .23",}, b0, false, false, "xJ", null);
+runtime.ext_scratch3_looks._say("fail 179: 0.123 should be = .23", target);
 }
 if (!(("" + (0.123 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 180: 0.123 should be > .23",}, b0, false, false, "xL", null);
+runtime.ext_scratch3_looks._say("fail 180: 0.123 should be > .23", target);
 }
 if (!(("" + (0.123 < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 181: 0.123 should be < 0.123",}, b0, false, false, "xN", null);
+runtime.ext_scratch3_looks._say("fail 181: 0.123 should be < 0.123", target);
 }
 if (!(("" + (0.123 === 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 182: 0.123 should be = 0.123",}, b0, false, false, "xP", null);
+runtime.ext_scratch3_looks._say("fail 182: 0.123 should be = 0.123", target);
 }
 if (!(("" + (0.123 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 183: 0.123 should be > 0.123",}, b0, false, false, "xR", null);
+runtime.ext_scratch3_looks._say("fail 183: 0.123 should be > 0.123", target);
 }
 if (!(("" + (0.123 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 184: 0.123 should be < -0",}, b0, false, false, "xT", null);
+runtime.ext_scratch3_looks._say("fail 184: 0.123 should be < -0", target);
 }
 if (!(("" + (0.123 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 185: 0.123 should be = -0",}, b0, false, false, "xV", null);
+runtime.ext_scratch3_looks._say("fail 185: 0.123 should be = -0", target);
 }
 if (!(("" + (0.123 > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 186: 0.123 should be > -0",}, b0, false, false, "xX", null);
+runtime.ext_scratch3_looks._say("fail 186: 0.123 should be > -0", target);
 }
 if (!(("" + (0.123 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 187: 0.123 should be < -1",}, b0, false, false, "xZ", null);
+runtime.ext_scratch3_looks._say("fail 187: 0.123 should be < -1", target);
 }
 if (!(("" + (0.123 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 188: 0.123 should be = -1",}, b0, false, false, "x1", null);
+runtime.ext_scratch3_looks._say("fail 188: 0.123 should be = -1", target);
 }
 if (!(("" + (0.123 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 189: 0.123 should be > -1",}, b0, false, false, "x3", null);
+runtime.ext_scratch3_looks._say("fail 189: 0.123 should be > -1", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 190: 0.123 should be < true",}, b0, false, false, "x5", null);
+runtime.ext_scratch3_looks._say("fail 190: 0.123 should be < true", target);
 }
 if (!(("" + (0.123 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 191: 0.123 should be = true",}, b0, false, false, "x7", null);
+runtime.ext_scratch3_looks._say("fail 191: 0.123 should be = true", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 192: 0.123 should be > true",}, b0, false, false, "x9", null);
+runtime.ext_scratch3_looks._say("fail 192: 0.123 should be > true", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 193: 0.123 should be < false",}, b0, false, false, "x#", null);
+runtime.ext_scratch3_looks._say("fail 193: 0.123 should be < false", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 194: 0.123 should be = false",}, b0, false, false, "x(", null);
+runtime.ext_scratch3_looks._say("fail 194: 0.123 should be = false", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 195: 0.123 should be > false",}, b0, false, false, "x*", null);
+runtime.ext_scratch3_looks._say("fail 195: 0.123 should be > false", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 196: 0.123 should be < NaN",}, b0, false, false, "x,", null);
+runtime.ext_scratch3_looks._say("fail 196: 0.123 should be < NaN", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 197: 0.123 should be = NaN",}, b0, false, false, "x.", null);
+runtime.ext_scratch3_looks._say("fail 197: 0.123 should be = NaN", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 198: 0.123 should be > NaN",}, b0, false, false, "x:", null);
+runtime.ext_scratch3_looks._say("fail 198: 0.123 should be > NaN", target);
 }
 if (!(("" + (0.123 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 199: 0.123 should be < Infinity",}, b0, false, false, "x=", null);
+runtime.ext_scratch3_looks._say("fail 199: 0.123 should be < Infinity", target);
 }
 if (!(("" + (0.123 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 200: 0.123 should be = Infinity",}, b0, false, false, "x@", null);
+runtime.ext_scratch3_looks._say("fail 200: 0.123 should be = Infinity", target);
 }
 if (!(("" + (0.123 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 201: 0.123 should be > Infinity",}, b0, false, false, "x]", null);
+runtime.ext_scratch3_looks._say("fail 201: 0.123 should be > Infinity", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 202: 0.123 should be < banana",}, b0, false, false, "x_", null);
+runtime.ext_scratch3_looks._say("fail 202: 0.123 should be < banana", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 203: 0.123 should be = banana",}, b0, false, false, "x{", null);
+runtime.ext_scratch3_looks._say("fail 203: 0.123 should be = banana", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 204: 0.123 should be > banana",}, b0, false, false, "x}", null);
+runtime.ext_scratch3_looks._say("fail 204: 0.123 should be > banana", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 205: 0.123 should be < 🎉",}, b0, false, false, "ya", null);
+runtime.ext_scratch3_looks._say("fail 205: 0.123 should be < 🎉", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 206: 0.123 should be = 🎉",}, b0, false, false, "yc", null);
+runtime.ext_scratch3_looks._say("fail 206: 0.123 should be = 🎉", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 207: 0.123 should be > 🎉",}, b0, false, false, "ye", null);
+runtime.ext_scratch3_looks._say("fail 207: 0.123 should be > 🎉", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 208: 0.123 should be < ",}, b0, false, false, "yg", null);
+runtime.ext_scratch3_looks._say("fail 208: 0.123 should be < ", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 209: 0.123 should be = ",}, b0, false, false, "yi", null);
+runtime.ext_scratch3_looks._say("fail 209: 0.123 should be = ", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 210: 0.123 should be > ",}, b0, false, false, "yk", null);
+runtime.ext_scratch3_looks._say("fail 210: 0.123 should be > ", target);
 }
 if (!(("" + (-0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 211: -0 should be < 0",}, b0, false, false, "ym", null);
+runtime.ext_scratch3_looks._say("fail 211: -0 should be < 0", target);
 }
 if (!(("" + (-0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 212: -0 should be = 0",}, b0, false, false, "yo", null);
+runtime.ext_scratch3_looks._say("fail 212: -0 should be = 0", target);
 }
 if (!(("" + (-0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 213: -0 should be > 0",}, b0, false, false, "yq", null);
+runtime.ext_scratch3_looks._say("fail 213: -0 should be > 0", target);
 }
 if (!(("" + (-0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 214: -0 should be < 0.0",}, b0, false, false, "ys", null);
+runtime.ext_scratch3_looks._say("fail 214: -0 should be < 0.0", target);
 }
 if (!(("" + (-0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 215: -0 should be = 0.0",}, b0, false, false, "yu", null);
+runtime.ext_scratch3_looks._say("fail 215: -0 should be = 0.0", target);
 }
 if (!(("" + (-0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 216: -0 should be > 0.0",}, b0, false, false, "yw", null);
+runtime.ext_scratch3_looks._say("fail 216: -0 should be > 0.0", target);
 }
 if (!(("" + (-0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 217: -0 should be < 1.23",}, b0, false, false, "yy", null);
+runtime.ext_scratch3_looks._say("fail 217: -0 should be < 1.23", target);
 }
 if (!(("" + (-0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 218: -0 should be = 1.23",}, b0, false, false, "yA", null);
+runtime.ext_scratch3_looks._say("fail 218: -0 should be = 1.23", target);
 }
 if (!(("" + (-0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 219: -0 should be > 1.23",}, b0, false, false, "yC", null);
+runtime.ext_scratch3_looks._say("fail 219: -0 should be > 1.23", target);
 }
 if (!(("" + (-0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 220: -0 should be < .23",}, b0, false, false, "yE", null);
+runtime.ext_scratch3_looks._say("fail 220: -0 should be < .23", target);
 }
 if (!(("" + (-0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 221: -0 should be = .23",}, b0, false, false, "yG", null);
+runtime.ext_scratch3_looks._say("fail 221: -0 should be = .23", target);
 }
 if (!(("" + (-0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 222: -0 should be > .23",}, b0, false, false, "yI", null);
+runtime.ext_scratch3_looks._say("fail 222: -0 should be > .23", target);
 }
 if (!(("" + (-0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 223: -0 should be < 0.123",}, b0, false, false, "yK", null);
+runtime.ext_scratch3_looks._say("fail 223: -0 should be < 0.123", target);
 }
 if (!(("" + (-0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 224: -0 should be = 0.123",}, b0, false, false, "yM", null);
+runtime.ext_scratch3_looks._say("fail 224: -0 should be = 0.123", target);
 }
 if (!(("" + (-0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 225: -0 should be > 0.123",}, b0, false, false, "yO", null);
+runtime.ext_scratch3_looks._say("fail 225: -0 should be > 0.123", target);
 }
 if (!(("" + (-0 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 226: -0 should be < -0",}, b0, false, false, "yQ", null);
+runtime.ext_scratch3_looks._say("fail 226: -0 should be < -0", target);
 }
 if (!(("" + (-0 === -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 227: -0 should be = -0",}, b0, false, false, "yS", null);
+runtime.ext_scratch3_looks._say("fail 227: -0 should be = -0", target);
 }
 if (!(("" + (-0 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 228: -0 should be > -0",}, b0, false, false, "yU", null);
+runtime.ext_scratch3_looks._say("fail 228: -0 should be > -0", target);
 }
 if (!(("" + (-0 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 229: -0 should be < -1",}, b0, false, false, "yW", null);
+runtime.ext_scratch3_looks._say("fail 229: -0 should be < -1", target);
 }
 if (!(("" + (-0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 230: -0 should be = -1",}, b0, false, false, "yY", null);
+runtime.ext_scratch3_looks._say("fail 230: -0 should be = -1", target);
 }
 if (!(("" + (-0 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 231: -0 should be > -1",}, b0, false, false, "y0", null);
+runtime.ext_scratch3_looks._say("fail 231: -0 should be > -1", target);
 }
 if (!(("" + ("-0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 232: -0 should be < true",}, b0, false, false, "y2", null);
+runtime.ext_scratch3_looks._say("fail 232: -0 should be < true", target);
 }
 if (!(("" + ("-0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 233: -0 should be = true",}, b0, false, false, "y4", null);
+runtime.ext_scratch3_looks._say("fail 233: -0 should be = true", target);
 }
 if (!(("" + ("-0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 234: -0 should be > true",}, b0, false, false, "y6", null);
+runtime.ext_scratch3_looks._say("fail 234: -0 should be > true", target);
 }
 if (!(("" + ("-0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 235: -0 should be < false",}, b0, false, false, "y8", null);
+runtime.ext_scratch3_looks._say("fail 235: -0 should be < false", target);
 }
 if (!(("" + ("-0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 236: -0 should be = false",}, b0, false, false, "y!", null);
+runtime.ext_scratch3_looks._say("fail 236: -0 should be = false", target);
 }
 if (!(("" + ("-0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 237: -0 should be > false",}, b0, false, false, "y%", null);
+runtime.ext_scratch3_looks._say("fail 237: -0 should be > false", target);
 }
 if (!(("" + ("-0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 238: -0 should be < NaN",}, b0, false, false, "y)", null);
+runtime.ext_scratch3_looks._say("fail 238: -0 should be < NaN", target);
 }
 if (!(("" + ("-0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 239: -0 should be = NaN",}, b0, false, false, "y+", null);
+runtime.ext_scratch3_looks._say("fail 239: -0 should be = NaN", target);
 }
 if (!(("" + ("-0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 240: -0 should be > NaN",}, b0, false, false, "y-", null);
+runtime.ext_scratch3_looks._say("fail 240: -0 should be > NaN", target);
 }
 if (!(("" + (-0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 241: -0 should be < Infinity",}, b0, false, false, "y/", null);
+runtime.ext_scratch3_looks._say("fail 241: -0 should be < Infinity", target);
 }
 if (!(("" + (-0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 242: -0 should be = Infinity",}, b0, false, false, "y;", null);
+runtime.ext_scratch3_looks._say("fail 242: -0 should be = Infinity", target);
 }
 if (!(("" + (-0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 243: -0 should be > Infinity",}, b0, false, false, "y?", null);
+runtime.ext_scratch3_looks._say("fail 243: -0 should be > Infinity", target);
 }
 if (!(("" + ("-0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 244: -0 should be < banana",}, b0, false, false, "y[", null);
+runtime.ext_scratch3_looks._say("fail 244: -0 should be < banana", target);
 }
 if (!(("" + ("-0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 245: -0 should be = banana",}, b0, false, false, "y^", null);
+runtime.ext_scratch3_looks._say("fail 245: -0 should be = banana", target);
 }
 if (!(("" + ("-0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 246: -0 should be > banana",}, b0, false, false, "y`", null);
+runtime.ext_scratch3_looks._say("fail 246: -0 should be > banana", target);
 }
 if (!(("" + ("-0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 247: -0 should be < 🎉",}, b0, false, false, "y|", null);
+runtime.ext_scratch3_looks._say("fail 247: -0 should be < 🎉", target);
 }
 if (!(("" + ("-0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 248: -0 should be = 🎉",}, b0, false, false, "y~", null);
+runtime.ext_scratch3_looks._say("fail 248: -0 should be = 🎉", target);
 }
 if (!(("" + ("-0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 249: -0 should be > 🎉",}, b0, false, false, "zb", null);
+runtime.ext_scratch3_looks._say("fail 249: -0 should be > 🎉", target);
 }
 if (!(("" + ("-0".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 250: -0 should be < ",}, b0, false, false, "zd", null);
+runtime.ext_scratch3_looks._say("fail 250: -0 should be < ", target);
 }
 if (!(("" + ("-0".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 251: -0 should be = ",}, b0, false, false, "zf", null);
+runtime.ext_scratch3_looks._say("fail 251: -0 should be = ", target);
 }
 if (!(("" + ("-0".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 252: -0 should be > ",}, b0, false, false, "zh", null);
+runtime.ext_scratch3_looks._say("fail 252: -0 should be > ", target);
 }
 if (!(("" + (-1 < 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 253: -1 should be < 0",}, b0, false, false, "zj", null);
+runtime.ext_scratch3_looks._say("fail 253: -1 should be < 0", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 254: -1 should be = 0",}, b0, false, false, "zl", null);
+runtime.ext_scratch3_looks._say("fail 254: -1 should be = 0", target);
 }
 if (!(("" + (-1 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 255: -1 should be > 0",}, b0, false, false, "zn", null);
+runtime.ext_scratch3_looks._say("fail 255: -1 should be > 0", target);
 }
 if (!(("" + (-1 < 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 256: -1 should be < 0.0",}, b0, false, false, "zp", null);
+runtime.ext_scratch3_looks._say("fail 256: -1 should be < 0.0", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 257: -1 should be = 0.0",}, b0, false, false, "zr", null);
+runtime.ext_scratch3_looks._say("fail 257: -1 should be = 0.0", target);
 }
 if (!(("" + (-1 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 258: -1 should be > 0.0",}, b0, false, false, "zt", null);
+runtime.ext_scratch3_looks._say("fail 258: -1 should be > 0.0", target);
 }
 if (!(("" + (-1 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 259: -1 should be < 1.23",}, b0, false, false, "zv", null);
+runtime.ext_scratch3_looks._say("fail 259: -1 should be < 1.23", target);
 }
 if (!(("" + (-1 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 260: -1 should be = 1.23",}, b0, false, false, "zx", null);
+runtime.ext_scratch3_looks._say("fail 260: -1 should be = 1.23", target);
 }
 if (!(("" + (-1 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 261: -1 should be > 1.23",}, b0, false, false, "zz", null);
+runtime.ext_scratch3_looks._say("fail 261: -1 should be > 1.23", target);
 }
 if (!(("" + (-1 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 262: -1 should be < .23",}, b0, false, false, "zB", null);
+runtime.ext_scratch3_looks._say("fail 262: -1 should be < .23", target);
 }
 if (!(("" + (-1 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 263: -1 should be = .23",}, b0, false, false, "zD", null);
+runtime.ext_scratch3_looks._say("fail 263: -1 should be = .23", target);
 }
 if (!(("" + (-1 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 264: -1 should be > .23",}, b0, false, false, "zF", null);
+runtime.ext_scratch3_looks._say("fail 264: -1 should be > .23", target);
 }
 if (!(("" + (-1 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 265: -1 should be < 0.123",}, b0, false, false, "zH", null);
+runtime.ext_scratch3_looks._say("fail 265: -1 should be < 0.123", target);
 }
 if (!(("" + (-1 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 266: -1 should be = 0.123",}, b0, false, false, "zJ", null);
+runtime.ext_scratch3_looks._say("fail 266: -1 should be = 0.123", target);
 }
 if (!(("" + (-1 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 267: -1 should be > 0.123",}, b0, false, false, "zL", null);
+runtime.ext_scratch3_looks._say("fail 267: -1 should be > 0.123", target);
 }
 if (!(("" + (-1 < -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 268: -1 should be < -0",}, b0, false, false, "zN", null);
+runtime.ext_scratch3_looks._say("fail 268: -1 should be < -0", target);
 }
 if (!(("" + (-1 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 269: -1 should be = -0",}, b0, false, false, "zP", null);
+runtime.ext_scratch3_looks._say("fail 269: -1 should be = -0", target);
 }
 if (!(("" + (-1 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 270: -1 should be > -0",}, b0, false, false, "zR", null);
+runtime.ext_scratch3_looks._say("fail 270: -1 should be > -0", target);
 }
 if (!(("" + (-1 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 271: -1 should be < -1",}, b0, false, false, "zT", null);
+runtime.ext_scratch3_looks._say("fail 271: -1 should be < -1", target);
 }
 if (!(("" + (-1 === -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 272: -1 should be = -1",}, b0, false, false, "zV", null);
+runtime.ext_scratch3_looks._say("fail 272: -1 should be = -1", target);
 }
 if (!(("" + (-1 > -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 273: -1 should be > -1",}, b0, false, false, "zX", null);
+runtime.ext_scratch3_looks._say("fail 273: -1 should be > -1", target);
 }
 if (!(("" + ("-1".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 274: -1 should be < true",}, b0, false, false, "zZ", null);
+runtime.ext_scratch3_looks._say("fail 274: -1 should be < true", target);
 }
 if (!(("" + (-1 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 275: -1 should be = true",}, b0, false, false, "z1", null);
+runtime.ext_scratch3_looks._say("fail 275: -1 should be = true", target);
 }
 if (!(("" + ("-1".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 276: -1 should be > true",}, b0, false, false, "z3", null);
+runtime.ext_scratch3_looks._say("fail 276: -1 should be > true", target);
 }
 if (!(("" + ("-1".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 277: -1 should be < false",}, b0, false, false, "z5", null);
+runtime.ext_scratch3_looks._say("fail 277: -1 should be < false", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 278: -1 should be = false",}, b0, false, false, "z7", null);
+runtime.ext_scratch3_looks._say("fail 278: -1 should be = false", target);
 }
 if (!(("" + ("-1".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 279: -1 should be > false",}, b0, false, false, "z9", null);
+runtime.ext_scratch3_looks._say("fail 279: -1 should be > false", target);
 }
 if (!(("" + ("-1".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 280: -1 should be < NaN",}, b0, false, false, "z#", null);
+runtime.ext_scratch3_looks._say("fail 280: -1 should be < NaN", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 281: -1 should be = NaN",}, b0, false, false, "z(", null);
+runtime.ext_scratch3_looks._say("fail 281: -1 should be = NaN", target);
 }
 if (!(("" + ("-1".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 282: -1 should be > NaN",}, b0, false, false, "z*", null);
+runtime.ext_scratch3_looks._say("fail 282: -1 should be > NaN", target);
 }
 if (!(("" + (-1 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 283: -1 should be < Infinity",}, b0, false, false, "z,", null);
+runtime.ext_scratch3_looks._say("fail 283: -1 should be < Infinity", target);
 }
 if (!(("" + (-1 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 284: -1 should be = Infinity",}, b0, false, false, "z.", null);
+runtime.ext_scratch3_looks._say("fail 284: -1 should be = Infinity", target);
 }
 if (!(("" + (-1 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 285: -1 should be > Infinity",}, b0, false, false, "z:", null);
+runtime.ext_scratch3_looks._say("fail 285: -1 should be > Infinity", target);
 }
 if (!(("" + ("-1".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 286: -1 should be < banana",}, b0, false, false, "z=", null);
+runtime.ext_scratch3_looks._say("fail 286: -1 should be < banana", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 287: -1 should be = banana",}, b0, false, false, "z@", null);
+runtime.ext_scratch3_looks._say("fail 287: -1 should be = banana", target);
 }
 if (!(("" + ("-1".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 288: -1 should be > banana",}, b0, false, false, "z]", null);
+runtime.ext_scratch3_looks._say("fail 288: -1 should be > banana", target);
 }
 if (!(("" + ("-1".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 289: -1 should be < 🎉",}, b0, false, false, "z_", null);
+runtime.ext_scratch3_looks._say("fail 289: -1 should be < 🎉", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 290: -1 should be = 🎉",}, b0, false, false, "z{", null);
+runtime.ext_scratch3_looks._say("fail 290: -1 should be = 🎉", target);
 }
 if (!(("" + ("-1".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 291: -1 should be > 🎉",}, b0, false, false, "z}", null);
+runtime.ext_scratch3_looks._say("fail 291: -1 should be > 🎉", target);
 }
 if (!(("" + ("-1".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 292: -1 should be < ",}, b0, false, false, "Aa", null);
+runtime.ext_scratch3_looks._say("fail 292: -1 should be < ", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 293: -1 should be = ",}, b0, false, false, "Ac", null);
+runtime.ext_scratch3_looks._say("fail 293: -1 should be = ", target);
 }
 if (!(("" + ("-1".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 294: -1 should be > ",}, b0, false, false, "Ae", null);
+runtime.ext_scratch3_looks._say("fail 294: -1 should be > ", target);
 }
 if (!(("" + ("true".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 295: true should be < 0",}, b0, false, false, "Ag", null);
+runtime.ext_scratch3_looks._say("fail 295: true should be < 0", target);
 }
 if (!(("" + ("true".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 296: true should be = 0",}, b0, false, false, "Ai", null);
+runtime.ext_scratch3_looks._say("fail 296: true should be = 0", target);
 }
 if (!(("" + ("true".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 297: true should be > 0",}, b0, false, false, "Ak", null);
+runtime.ext_scratch3_looks._say("fail 297: true should be > 0", target);
 }
 if (!(("" + ("true".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 298: true should be < 0.0",}, b0, false, false, "Am", null);
+runtime.ext_scratch3_looks._say("fail 298: true should be < 0.0", target);
 }
 if (!(("" + ("true".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 299: true should be = 0.0",}, b0, false, false, "Ao", null);
+runtime.ext_scratch3_looks._say("fail 299: true should be = 0.0", target);
 }
 if (!(("" + ("true".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 300: true should be > 0.0",}, b0, false, false, "Aq", null);
+runtime.ext_scratch3_looks._say("fail 300: true should be > 0.0", target);
 }
 if (!(("" + ("true".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 301: true should be < 1.23",}, b0, false, false, "As", null);
+runtime.ext_scratch3_looks._say("fail 301: true should be < 1.23", target);
 }
 if (!(("" + (1 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 302: true should be = 1.23",}, b0, false, false, "Au", null);
+runtime.ext_scratch3_looks._say("fail 302: true should be = 1.23", target);
 }
 if (!(("" + ("true".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 303: true should be > 1.23",}, b0, false, false, "Aw", null);
+runtime.ext_scratch3_looks._say("fail 303: true should be > 1.23", target);
 }
 if (!(("" + ("true".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 304: true should be < .23",}, b0, false, false, "Ay", null);
+runtime.ext_scratch3_looks._say("fail 304: true should be < .23", target);
 }
 if (!(("" + (1 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 305: true should be = .23",}, b0, false, false, "AA", null);
+runtime.ext_scratch3_looks._say("fail 305: true should be = .23", target);
 }
 if (!(("" + ("true".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 306: true should be > .23",}, b0, false, false, "AC", null);
+runtime.ext_scratch3_looks._say("fail 306: true should be > .23", target);
 }
 if (!(("" + ("true".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 307: true should be < 0.123",}, b0, false, false, "AE", null);
+runtime.ext_scratch3_looks._say("fail 307: true should be < 0.123", target);
 }
 if (!(("" + (1 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 308: true should be = 0.123",}, b0, false, false, "AG", null);
+runtime.ext_scratch3_looks._say("fail 308: true should be = 0.123", target);
 }
 if (!(("" + ("true".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 309: true should be > 0.123",}, b0, false, false, "AI", null);
+runtime.ext_scratch3_looks._say("fail 309: true should be > 0.123", target);
 }
 if (!(("" + ("true".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 310: true should be < -0",}, b0, false, false, "AK", null);
+runtime.ext_scratch3_looks._say("fail 310: true should be < -0", target);
 }
 if (!(("" + ("true".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 311: true should be = -0",}, b0, false, false, "AM", null);
+runtime.ext_scratch3_looks._say("fail 311: true should be = -0", target);
 }
 if (!(("" + ("true".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 312: true should be > -0",}, b0, false, false, "AO", null);
+runtime.ext_scratch3_looks._say("fail 312: true should be > -0", target);
 }
 if (!(("" + ("true".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 313: true should be < -1",}, b0, false, false, "AQ", null);
+runtime.ext_scratch3_looks._say("fail 313: true should be < -1", target);
 }
 if (!(("" + (1 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 314: true should be = -1",}, b0, false, false, "AS", null);
+runtime.ext_scratch3_looks._say("fail 314: true should be = -1", target);
 }
 if (!(("" + ("true".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 315: true should be > -1",}, b0, false, false, "AU", null);
+runtime.ext_scratch3_looks._say("fail 315: true should be > -1", target);
 }
 if (!(("" + ("true".toLowerCase() < "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 316: true should be < true",}, b0, false, false, "AW", null);
+runtime.ext_scratch3_looks._say("fail 316: true should be < true", target);
 }
 if (!(("" + ("true".toLowerCase() === "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 317: true should be = true",}, b0, false, false, "AY", null);
+runtime.ext_scratch3_looks._say("fail 317: true should be = true", target);
 }
 if (!(("" + ("true".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 318: true should be > true",}, b0, false, false, "A0", null);
+runtime.ext_scratch3_looks._say("fail 318: true should be > true", target);
 }
 if (!(("" + ("true".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 319: true should be < false",}, b0, false, false, "A2", null);
+runtime.ext_scratch3_looks._say("fail 319: true should be < false", target);
 }
 if (!(("" + ("true".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 320: true should be = false",}, b0, false, false, "A4", null);
+runtime.ext_scratch3_looks._say("fail 320: true should be = false", target);
 }
 if (!(("" + ("true".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 321: true should be > false",}, b0, false, false, "A6", null);
+runtime.ext_scratch3_looks._say("fail 321: true should be > false", target);
 }
 if (!(("" + ("true".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 322: true should be < NaN",}, b0, false, false, "A8", null);
+runtime.ext_scratch3_looks._say("fail 322: true should be < NaN", target);
 }
 if (!(("" + ("true".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 323: true should be = NaN",}, b0, false, false, "A!", null);
+runtime.ext_scratch3_looks._say("fail 323: true should be = NaN", target);
 }
 if (!(("" + ("true".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 324: true should be > NaN",}, b0, false, false, "A%", null);
+runtime.ext_scratch3_looks._say("fail 324: true should be > NaN", target);
 }
 if (!(("" + ("true".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 325: true should be < Infinity",}, b0, false, false, "A)", null);
+runtime.ext_scratch3_looks._say("fail 325: true should be < Infinity", target);
 }
 if (!(("" + (1 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 326: true should be = Infinity",}, b0, false, false, "A+", null);
+runtime.ext_scratch3_looks._say("fail 326: true should be = Infinity", target);
 }
 if (!(("" + ("true".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 327: true should be > Infinity",}, b0, false, false, "A-", null);
+runtime.ext_scratch3_looks._say("fail 327: true should be > Infinity", target);
 }
 if (!(("" + ("true".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 328: true should be < banana",}, b0, false, false, "A/", null);
+runtime.ext_scratch3_looks._say("fail 328: true should be < banana", target);
 }
 if (!(("" + ("true".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 329: true should be = banana",}, b0, false, false, "A;", null);
+runtime.ext_scratch3_looks._say("fail 329: true should be = banana", target);
 }
 if (!(("" + ("true".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 330: true should be > banana",}, b0, false, false, "A?", null);
+runtime.ext_scratch3_looks._say("fail 330: true should be > banana", target);
 }
 if (!(("" + ("true".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 331: true should be < 🎉",}, b0, false, false, "A[", null);
+runtime.ext_scratch3_looks._say("fail 331: true should be < 🎉", target);
 }
 if (!(("" + ("true".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 332: true should be = 🎉",}, b0, false, false, "A^", null);
+runtime.ext_scratch3_looks._say("fail 332: true should be = 🎉", target);
 }
 if (!(("" + ("true".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 333: true should be > 🎉",}, b0, false, false, "A`", null);
+runtime.ext_scratch3_looks._say("fail 333: true should be > 🎉", target);
 }
 if (!(("" + ("true".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 334: true should be < ",}, b0, false, false, "A|", null);
+runtime.ext_scratch3_looks._say("fail 334: true should be < ", target);
 }
 if (!(("" + ("true".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 335: true should be = ",}, b0, false, false, "A~", null);
+runtime.ext_scratch3_looks._say("fail 335: true should be = ", target);
 }
 if (!(("" + ("true".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 336: true should be > ",}, b0, false, false, "Bb", null);
+runtime.ext_scratch3_looks._say("fail 336: true should be > ", target);
 }
 if (!(("" + ("false".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 337: false should be < 0",}, b0, false, false, "Bd", null);
+runtime.ext_scratch3_looks._say("fail 337: false should be < 0", target);
 }
 if (!(("" + ("false".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 338: false should be = 0",}, b0, false, false, "Bf", null);
+runtime.ext_scratch3_looks._say("fail 338: false should be = 0", target);
 }
 if (!(("" + ("false".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 339: false should be > 0",}, b0, false, false, "Bh", null);
+runtime.ext_scratch3_looks._say("fail 339: false should be > 0", target);
 }
 if (!(("" + ("false".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 340: false should be < 0.0",}, b0, false, false, "Bj", null);
+runtime.ext_scratch3_looks._say("fail 340: false should be < 0.0", target);
 }
 if (!(("" + ("false".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 341: false should be = 0.0",}, b0, false, false, "Bl", null);
+runtime.ext_scratch3_looks._say("fail 341: false should be = 0.0", target);
 }
 if (!(("" + ("false".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 342: false should be > 0.0",}, b0, false, false, "Bn", null);
+runtime.ext_scratch3_looks._say("fail 342: false should be > 0.0", target);
 }
 if (!(("" + ("false".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 343: false should be < 1.23",}, b0, false, false, "Bp", null);
+runtime.ext_scratch3_looks._say("fail 343: false should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 344: false should be = 1.23",}, b0, false, false, "Br", null);
+runtime.ext_scratch3_looks._say("fail 344: false should be = 1.23", target);
 }
 if (!(("" + ("false".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 345: false should be > 1.23",}, b0, false, false, "Bt", null);
+runtime.ext_scratch3_looks._say("fail 345: false should be > 1.23", target);
 }
 if (!(("" + ("false".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 346: false should be < .23",}, b0, false, false, "Bv", null);
+runtime.ext_scratch3_looks._say("fail 346: false should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 347: false should be = .23",}, b0, false, false, "Bx", null);
+runtime.ext_scratch3_looks._say("fail 347: false should be = .23", target);
 }
 if (!(("" + ("false".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 348: false should be > .23",}, b0, false, false, "Bz", null);
+runtime.ext_scratch3_looks._say("fail 348: false should be > .23", target);
 }
 if (!(("" + ("false".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 349: false should be < 0.123",}, b0, false, false, "BB", null);
+runtime.ext_scratch3_looks._say("fail 349: false should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 350: false should be = 0.123",}, b0, false, false, "BD", null);
+runtime.ext_scratch3_looks._say("fail 350: false should be = 0.123", target);
 }
 if (!(("" + ("false".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 351: false should be > 0.123",}, b0, false, false, "BF", null);
+runtime.ext_scratch3_looks._say("fail 351: false should be > 0.123", target);
 }
 if (!(("" + ("false".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 352: false should be < -0",}, b0, false, false, "BH", null);
+runtime.ext_scratch3_looks._say("fail 352: false should be < -0", target);
 }
 if (!(("" + ("false".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 353: false should be = -0",}, b0, false, false, "BJ", null);
+runtime.ext_scratch3_looks._say("fail 353: false should be = -0", target);
 }
 if (!(("" + ("false".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 354: false should be > -0",}, b0, false, false, "BL", null);
+runtime.ext_scratch3_looks._say("fail 354: false should be > -0", target);
 }
 if (!(("" + ("false".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 355: false should be < -1",}, b0, false, false, "BN", null);
+runtime.ext_scratch3_looks._say("fail 355: false should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 356: false should be = -1",}, b0, false, false, "BP", null);
+runtime.ext_scratch3_looks._say("fail 356: false should be = -1", target);
 }
 if (!(("" + ("false".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 357: false should be > -1",}, b0, false, false, "BR", null);
+runtime.ext_scratch3_looks._say("fail 357: false should be > -1", target);
 }
 if (!(("" + ("false".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 358: false should be < true",}, b0, false, false, "BT", null);
+runtime.ext_scratch3_looks._say("fail 358: false should be < true", target);
 }
 if (!(("" + ("false".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 359: false should be = true",}, b0, false, false, "BV", null);
+runtime.ext_scratch3_looks._say("fail 359: false should be = true", target);
 }
 if (!(("" + ("false".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 360: false should be > true",}, b0, false, false, "BX", null);
+runtime.ext_scratch3_looks._say("fail 360: false should be > true", target);
 }
 if (!(("" + ("false".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 361: false should be < false",}, b0, false, false, "BZ", null);
+runtime.ext_scratch3_looks._say("fail 361: false should be < false", target);
 }
 if (!(("" + ("false".toLowerCase() === "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 362: false should be = false",}, b0, false, false, "B1", null);
+runtime.ext_scratch3_looks._say("fail 362: false should be = false", target);
 }
 if (!(("" + ("false".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 363: false should be > false",}, b0, false, false, "B3", null);
+runtime.ext_scratch3_looks._say("fail 363: false should be > false", target);
 }
 if (!(("" + ("false".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 364: false should be < NaN",}, b0, false, false, "B5", null);
+runtime.ext_scratch3_looks._say("fail 364: false should be < NaN", target);
 }
 if (!(("" + ("false".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 365: false should be = NaN",}, b0, false, false, "B7", null);
+runtime.ext_scratch3_looks._say("fail 365: false should be = NaN", target);
 }
 if (!(("" + ("false".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 366: false should be > NaN",}, b0, false, false, "B9", null);
+runtime.ext_scratch3_looks._say("fail 366: false should be > NaN", target);
 }
 if (!(("" + ("false".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 367: false should be < Infinity",}, b0, false, false, "B#", null);
+runtime.ext_scratch3_looks._say("fail 367: false should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 368: false should be = Infinity",}, b0, false, false, "B(", null);
+runtime.ext_scratch3_looks._say("fail 368: false should be = Infinity", target);
 }
 if (!(("" + ("false".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 369: false should be > Infinity",}, b0, false, false, "B*", null);
+runtime.ext_scratch3_looks._say("fail 369: false should be > Infinity", target);
 }
 if (!(("" + ("false".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 370: false should be < banana",}, b0, false, false, "B,", null);
+runtime.ext_scratch3_looks._say("fail 370: false should be < banana", target);
 }
 if (!(("" + ("false".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 371: false should be = banana",}, b0, false, false, "B.", null);
+runtime.ext_scratch3_looks._say("fail 371: false should be = banana", target);
 }
 if (!(("" + ("false".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 372: false should be > banana",}, b0, false, false, "B:", null);
+runtime.ext_scratch3_looks._say("fail 372: false should be > banana", target);
 }
 if (!(("" + ("false".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 373: false should be < 🎉",}, b0, false, false, "B=", null);
+runtime.ext_scratch3_looks._say("fail 373: false should be < 🎉", target);
 }
 if (!(("" + ("false".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 374: false should be = 🎉",}, b0, false, false, "B@", null);
+runtime.ext_scratch3_looks._say("fail 374: false should be = 🎉", target);
 }
 if (!(("" + ("false".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 375: false should be > 🎉",}, b0, false, false, "B]", null);
+runtime.ext_scratch3_looks._say("fail 375: false should be > 🎉", target);
 }
 if (!(("" + ("false".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 376: false should be < ",}, b0, false, false, "B_", null);
+runtime.ext_scratch3_looks._say("fail 376: false should be < ", target);
 }
 if (!(("" + ("false".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 377: false should be = ",}, b0, false, false, "B{", null);
+runtime.ext_scratch3_looks._say("fail 377: false should be = ", target);
 }
 if (!(("" + ("false".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 378: false should be > ",}, b0, false, false, "B}", null);
+runtime.ext_scratch3_looks._say("fail 378: false should be > ", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 379: NaN should be < 0",}, b0, false, false, "Ca", null);
+runtime.ext_scratch3_looks._say("fail 379: NaN should be < 0", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 380: NaN should be = 0",}, b0, false, false, "Cc", null);
+runtime.ext_scratch3_looks._say("fail 380: NaN should be = 0", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 381: NaN should be > 0",}, b0, false, false, "Ce", null);
+runtime.ext_scratch3_looks._say("fail 381: NaN should be > 0", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 382: NaN should be < 0.0",}, b0, false, false, "Cg", null);
+runtime.ext_scratch3_looks._say("fail 382: NaN should be < 0.0", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 383: NaN should be = 0.0",}, b0, false, false, "Ci", null);
+runtime.ext_scratch3_looks._say("fail 383: NaN should be = 0.0", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 384: NaN should be > 0.0",}, b0, false, false, "Ck", null);
+runtime.ext_scratch3_looks._say("fail 384: NaN should be > 0.0", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 385: NaN should be < 1.23",}, b0, false, false, "Cm", null);
+runtime.ext_scratch3_looks._say("fail 385: NaN should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 386: NaN should be = 1.23",}, b0, false, false, "Co", null);
+runtime.ext_scratch3_looks._say("fail 386: NaN should be = 1.23", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 387: NaN should be > 1.23",}, b0, false, false, "Cq", null);
+runtime.ext_scratch3_looks._say("fail 387: NaN should be > 1.23", target);
 }
 if (!(("" + ("NaN".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 388: NaN should be < .23",}, b0, false, false, "Cs", null);
+runtime.ext_scratch3_looks._say("fail 388: NaN should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 389: NaN should be = .23",}, b0, false, false, "Cu", null);
+runtime.ext_scratch3_looks._say("fail 389: NaN should be = .23", target);
 }
 if (!(("" + ("NaN".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 390: NaN should be > .23",}, b0, false, false, "Cw", null);
+runtime.ext_scratch3_looks._say("fail 390: NaN should be > .23", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 391: NaN should be < 0.123",}, b0, false, false, "Cy", null);
+runtime.ext_scratch3_looks._say("fail 391: NaN should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 392: NaN should be = 0.123",}, b0, false, false, "CA", null);
+runtime.ext_scratch3_looks._say("fail 392: NaN should be = 0.123", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 393: NaN should be > 0.123",}, b0, false, false, "CC", null);
+runtime.ext_scratch3_looks._say("fail 393: NaN should be > 0.123", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 394: NaN should be < -0",}, b0, false, false, "CE", null);
+runtime.ext_scratch3_looks._say("fail 394: NaN should be < -0", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 395: NaN should be = -0",}, b0, false, false, "CG", null);
+runtime.ext_scratch3_looks._say("fail 395: NaN should be = -0", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 396: NaN should be > -0",}, b0, false, false, "CI", null);
+runtime.ext_scratch3_looks._say("fail 396: NaN should be > -0", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 397: NaN should be < -1",}, b0, false, false, "CK", null);
+runtime.ext_scratch3_looks._say("fail 397: NaN should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 398: NaN should be = -1",}, b0, false, false, "CM", null);
+runtime.ext_scratch3_looks._say("fail 398: NaN should be = -1", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 399: NaN should be > -1",}, b0, false, false, "CO", null);
+runtime.ext_scratch3_looks._say("fail 399: NaN should be > -1", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 400: NaN should be < true",}, b0, false, false, "CQ", null);
+runtime.ext_scratch3_looks._say("fail 400: NaN should be < true", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 401: NaN should be = true",}, b0, false, false, "CS", null);
+runtime.ext_scratch3_looks._say("fail 401: NaN should be = true", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 402: NaN should be > true",}, b0, false, false, "CU", null);
+runtime.ext_scratch3_looks._say("fail 402: NaN should be > true", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 403: NaN should be < false",}, b0, false, false, "CW", null);
+runtime.ext_scratch3_looks._say("fail 403: NaN should be < false", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 404: NaN should be = false",}, b0, false, false, "CY", null);
+runtime.ext_scratch3_looks._say("fail 404: NaN should be = false", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 405: NaN should be > false",}, b0, false, false, "C0", null);
+runtime.ext_scratch3_looks._say("fail 405: NaN should be > false", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 406: NaN should be < NaN",}, b0, false, false, "C2", null);
+runtime.ext_scratch3_looks._say("fail 406: NaN should be < NaN", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 407: NaN should be = NaN",}, b0, false, false, "C4", null);
+runtime.ext_scratch3_looks._say("fail 407: NaN should be = NaN", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 408: NaN should be > NaN",}, b0, false, false, "C6", null);
+runtime.ext_scratch3_looks._say("fail 408: NaN should be > NaN", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 409: NaN should be < Infinity",}, b0, false, false, "C8", null);
+runtime.ext_scratch3_looks._say("fail 409: NaN should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 410: NaN should be = Infinity",}, b0, false, false, "C!", null);
+runtime.ext_scratch3_looks._say("fail 410: NaN should be = Infinity", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 411: NaN should be > Infinity",}, b0, false, false, "C%", null);
+runtime.ext_scratch3_looks._say("fail 411: NaN should be > Infinity", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 412: NaN should be < banana",}, b0, false, false, "C)", null);
+runtime.ext_scratch3_looks._say("fail 412: NaN should be < banana", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 413: NaN should be = banana",}, b0, false, false, "C+", null);
+runtime.ext_scratch3_looks._say("fail 413: NaN should be = banana", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 414: NaN should be > banana",}, b0, false, false, "C-", null);
+runtime.ext_scratch3_looks._say("fail 414: NaN should be > banana", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 415: NaN should be < 🎉",}, b0, false, false, "C/", null);
+runtime.ext_scratch3_looks._say("fail 415: NaN should be < 🎉", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 416: NaN should be = 🎉",}, b0, false, false, "C;", null);
+runtime.ext_scratch3_looks._say("fail 416: NaN should be = 🎉", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 417: NaN should be > 🎉",}, b0, false, false, "C?", null);
+runtime.ext_scratch3_looks._say("fail 417: NaN should be > 🎉", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 418: NaN should be < ",}, b0, false, false, "C[", null);
+runtime.ext_scratch3_looks._say("fail 418: NaN should be < ", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 419: NaN should be = ",}, b0, false, false, "C^", null);
+runtime.ext_scratch3_looks._say("fail 419: NaN should be = ", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 420: NaN should be > ",}, b0, false, false, "C`", null);
+runtime.ext_scratch3_looks._say("fail 420: NaN should be > ", target);
 }
 if (!(("" + (Infinity < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 421: Infinity should be < 0",}, b0, false, false, "C|", null);
+runtime.ext_scratch3_looks._say("fail 421: Infinity should be < 0", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 422: Infinity should be = 0",}, b0, false, false, "C~", null);
+runtime.ext_scratch3_looks._say("fail 422: Infinity should be = 0", target);
 }
 if (!(("" + (Infinity > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 423: Infinity should be > 0",}, b0, false, false, "Db", null);
+runtime.ext_scratch3_looks._say("fail 423: Infinity should be > 0", target);
 }
 if (!(("" + (Infinity < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 424: Infinity should be < 0.0",}, b0, false, false, "Dd", null);
+runtime.ext_scratch3_looks._say("fail 424: Infinity should be < 0.0", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 425: Infinity should be = 0.0",}, b0, false, false, "Df", null);
+runtime.ext_scratch3_looks._say("fail 425: Infinity should be = 0.0", target);
 }
 if (!(("" + (Infinity > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 426: Infinity should be > 0.0",}, b0, false, false, "Dh", null);
+runtime.ext_scratch3_looks._say("fail 426: Infinity should be > 0.0", target);
 }
 if (!(("" + (Infinity < 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 427: Infinity should be < 1.23",}, b0, false, false, "Dj", null);
+runtime.ext_scratch3_looks._say("fail 427: Infinity should be < 1.23", target);
 }
 if (!(("" + (Infinity === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 428: Infinity should be = 1.23",}, b0, false, false, "Dl", null);
+runtime.ext_scratch3_looks._say("fail 428: Infinity should be = 1.23", target);
 }
 if (!(("" + (Infinity > 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 429: Infinity should be > 1.23",}, b0, false, false, "Dn", null);
+runtime.ext_scratch3_looks._say("fail 429: Infinity should be > 1.23", target);
 }
 if (!(("" + (Infinity < 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 430: Infinity should be < .23",}, b0, false, false, "Dp", null);
+runtime.ext_scratch3_looks._say("fail 430: Infinity should be < .23", target);
 }
 if (!(("" + (Infinity === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 431: Infinity should be = .23",}, b0, false, false, "Dr", null);
+runtime.ext_scratch3_looks._say("fail 431: Infinity should be = .23", target);
 }
 if (!(("" + (Infinity > 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 432: Infinity should be > .23",}, b0, false, false, "Dt", null);
+runtime.ext_scratch3_looks._say("fail 432: Infinity should be > .23", target);
 }
 if (!(("" + (Infinity < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 433: Infinity should be < 0.123",}, b0, false, false, "Dv", null);
+runtime.ext_scratch3_looks._say("fail 433: Infinity should be < 0.123", target);
 }
 if (!(("" + (Infinity === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 434: Infinity should be = 0.123",}, b0, false, false, "Dx", null);
+runtime.ext_scratch3_looks._say("fail 434: Infinity should be = 0.123", target);
 }
 if (!(("" + (Infinity > 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 435: Infinity should be > 0.123",}, b0, false, false, "Dz", null);
+runtime.ext_scratch3_looks._say("fail 435: Infinity should be > 0.123", target);
 }
 if (!(("" + (Infinity < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 436: Infinity should be < -0",}, b0, false, false, "DB", null);
+runtime.ext_scratch3_looks._say("fail 436: Infinity should be < -0", target);
 }
 if (!(("" + (Infinity === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 437: Infinity should be = -0",}, b0, false, false, "DD", null);
+runtime.ext_scratch3_looks._say("fail 437: Infinity should be = -0", target);
 }
 if (!(("" + (Infinity > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 438: Infinity should be > -0",}, b0, false, false, "DF", null);
+runtime.ext_scratch3_looks._say("fail 438: Infinity should be > -0", target);
 }
 if (!(("" + (Infinity < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 439: Infinity should be < -1",}, b0, false, false, "DH", null);
+runtime.ext_scratch3_looks._say("fail 439: Infinity should be < -1", target);
 }
 if (!(("" + (Infinity === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 440: Infinity should be = -1",}, b0, false, false, "DJ", null);
+runtime.ext_scratch3_looks._say("fail 440: Infinity should be = -1", target);
 }
 if (!(("" + (Infinity > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 441: Infinity should be > -1",}, b0, false, false, "DL", null);
+runtime.ext_scratch3_looks._say("fail 441: Infinity should be > -1", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 442: Infinity should be < true",}, b0, false, false, "DN", null);
+runtime.ext_scratch3_looks._say("fail 442: Infinity should be < true", target);
 }
 if (!(("" + (Infinity === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 443: Infinity should be = true",}, b0, false, false, "DP", null);
+runtime.ext_scratch3_looks._say("fail 443: Infinity should be = true", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 444: Infinity should be > true",}, b0, false, false, "DR", null);
+runtime.ext_scratch3_looks._say("fail 444: Infinity should be > true", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 445: Infinity should be < false",}, b0, false, false, "DT", null);
+runtime.ext_scratch3_looks._say("fail 445: Infinity should be < false", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 446: Infinity should be = false",}, b0, false, false, "DV", null);
+runtime.ext_scratch3_looks._say("fail 446: Infinity should be = false", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 447: Infinity should be > false",}, b0, false, false, "DX", null);
+runtime.ext_scratch3_looks._say("fail 447: Infinity should be > false", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 448: Infinity should be < NaN",}, b0, false, false, "DZ", null);
+runtime.ext_scratch3_looks._say("fail 448: Infinity should be < NaN", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 449: Infinity should be = NaN",}, b0, false, false, "D1", null);
+runtime.ext_scratch3_looks._say("fail 449: Infinity should be = NaN", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 450: Infinity should be > NaN",}, b0, false, false, "D3", null);
+runtime.ext_scratch3_looks._say("fail 450: Infinity should be > NaN", target);
 }
 if (!(("" + (Infinity < Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 451: Infinity should be < Infinity",}, b0, false, false, "D5", null);
+runtime.ext_scratch3_looks._say("fail 451: Infinity should be < Infinity", target);
 }
 if (!(("" + (Infinity === Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 452: Infinity should be = Infinity",}, b0, false, false, "D7", null);
+runtime.ext_scratch3_looks._say("fail 452: Infinity should be = Infinity", target);
 }
 if (!(("" + (Infinity > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 453: Infinity should be > Infinity",}, b0, false, false, "D9", null);
+runtime.ext_scratch3_looks._say("fail 453: Infinity should be > Infinity", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 454: Infinity should be < banana",}, b0, false, false, "D#", null);
+runtime.ext_scratch3_looks._say("fail 454: Infinity should be < banana", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 455: Infinity should be = banana",}, b0, false, false, "D(", null);
+runtime.ext_scratch3_looks._say("fail 455: Infinity should be = banana", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 456: Infinity should be > banana",}, b0, false, false, "D*", null);
+runtime.ext_scratch3_looks._say("fail 456: Infinity should be > banana", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 457: Infinity should be < 🎉",}, b0, false, false, "D,", null);
+runtime.ext_scratch3_looks._say("fail 457: Infinity should be < 🎉", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 458: Infinity should be = 🎉",}, b0, false, false, "D.", null);
+runtime.ext_scratch3_looks._say("fail 458: Infinity should be = 🎉", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 459: Infinity should be > 🎉",}, b0, false, false, "D:", null);
+runtime.ext_scratch3_looks._say("fail 459: Infinity should be > 🎉", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 460: Infinity should be < ",}, b0, false, false, "D=", null);
+runtime.ext_scratch3_looks._say("fail 460: Infinity should be < ", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 461: Infinity should be = ",}, b0, false, false, "D@", null);
+runtime.ext_scratch3_looks._say("fail 461: Infinity should be = ", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 462: Infinity should be > ",}, b0, false, false, "D]", null);
+runtime.ext_scratch3_looks._say("fail 462: Infinity should be > ", target);
 }
 if (!(("" + ("banana".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 463: banana should be < 0",}, b0, false, false, "D_", null);
+runtime.ext_scratch3_looks._say("fail 463: banana should be < 0", target);
 }
 if (!(("" + ("banana".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 464: banana should be = 0",}, b0, false, false, "D{", null);
+runtime.ext_scratch3_looks._say("fail 464: banana should be = 0", target);
 }
 if (!(("" + ("banana".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 465: banana should be > 0",}, b0, false, false, "D}", null);
+runtime.ext_scratch3_looks._say("fail 465: banana should be > 0", target);
 }
 if (!(("" + ("banana".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 466: banana should be < 0.0",}, b0, false, false, "Ea", null);
+runtime.ext_scratch3_looks._say("fail 466: banana should be < 0.0", target);
 }
 if (!(("" + ("banana".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 467: banana should be = 0.0",}, b0, false, false, "Ec", null);
+runtime.ext_scratch3_looks._say("fail 467: banana should be = 0.0", target);
 }
 if (!(("" + ("banana".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 468: banana should be > 0.0",}, b0, false, false, "Ee", null);
+runtime.ext_scratch3_looks._say("fail 468: banana should be > 0.0", target);
 }
 if (!(("" + ("banana".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 469: banana should be < 1.23",}, b0, false, false, "Eg", null);
+runtime.ext_scratch3_looks._say("fail 469: banana should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 470: banana should be = 1.23",}, b0, false, false, "Ei", null);
+runtime.ext_scratch3_looks._say("fail 470: banana should be = 1.23", target);
 }
 if (!(("" + ("banana".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 471: banana should be > 1.23",}, b0, false, false, "Ek", null);
+runtime.ext_scratch3_looks._say("fail 471: banana should be > 1.23", target);
 }
 if (!(("" + ("banana".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 472: banana should be < .23",}, b0, false, false, "Em", null);
+runtime.ext_scratch3_looks._say("fail 472: banana should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 473: banana should be = .23",}, b0, false, false, "Eo", null);
+runtime.ext_scratch3_looks._say("fail 473: banana should be = .23", target);
 }
 if (!(("" + ("banana".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 474: banana should be > .23",}, b0, false, false, "Eq", null);
+runtime.ext_scratch3_looks._say("fail 474: banana should be > .23", target);
 }
 if (!(("" + ("banana".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 475: banana should be < 0.123",}, b0, false, false, "Es", null);
+runtime.ext_scratch3_looks._say("fail 475: banana should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 476: banana should be = 0.123",}, b0, false, false, "Eu", null);
+runtime.ext_scratch3_looks._say("fail 476: banana should be = 0.123", target);
 }
 if (!(("" + ("banana".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 477: banana should be > 0.123",}, b0, false, false, "Ew", null);
+runtime.ext_scratch3_looks._say("fail 477: banana should be > 0.123", target);
 }
 if (!(("" + ("banana".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 478: banana should be < -0",}, b0, false, false, "Ey", null);
+runtime.ext_scratch3_looks._say("fail 478: banana should be < -0", target);
 }
 if (!(("" + ("banana".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 479: banana should be = -0",}, b0, false, false, "EA", null);
+runtime.ext_scratch3_looks._say("fail 479: banana should be = -0", target);
 }
 if (!(("" + ("banana".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 480: banana should be > -0",}, b0, false, false, "EC", null);
+runtime.ext_scratch3_looks._say("fail 480: banana should be > -0", target);
 }
 if (!(("" + ("banana".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 481: banana should be < -1",}, b0, false, false, "EE", null);
+runtime.ext_scratch3_looks._say("fail 481: banana should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 482: banana should be = -1",}, b0, false, false, "EG", null);
+runtime.ext_scratch3_looks._say("fail 482: banana should be = -1", target);
 }
 if (!(("" + ("banana".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 483: banana should be > -1",}, b0, false, false, "EI", null);
+runtime.ext_scratch3_looks._say("fail 483: banana should be > -1", target);
 }
 if (!(("" + ("banana".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 484: banana should be < true",}, b0, false, false, "EK", null);
+runtime.ext_scratch3_looks._say("fail 484: banana should be < true", target);
 }
 if (!(("" + ("banana".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 485: banana should be = true",}, b0, false, false, "EM", null);
+runtime.ext_scratch3_looks._say("fail 485: banana should be = true", target);
 }
 if (!(("" + ("banana".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 486: banana should be > true",}, b0, false, false, "EO", null);
+runtime.ext_scratch3_looks._say("fail 486: banana should be > true", target);
 }
 if (!(("" + ("banana".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 487: banana should be < false",}, b0, false, false, "EQ", null);
+runtime.ext_scratch3_looks._say("fail 487: banana should be < false", target);
 }
 if (!(("" + ("banana".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 488: banana should be = false",}, b0, false, false, "ES", null);
+runtime.ext_scratch3_looks._say("fail 488: banana should be = false", target);
 }
 if (!(("" + ("banana".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 489: banana should be > false",}, b0, false, false, "EU", null);
+runtime.ext_scratch3_looks._say("fail 489: banana should be > false", target);
 }
 if (!(("" + ("banana".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 490: banana should be < NaN",}, b0, false, false, "EW", null);
+runtime.ext_scratch3_looks._say("fail 490: banana should be < NaN", target);
 }
 if (!(("" + ("banana".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 491: banana should be = NaN",}, b0, false, false, "EY", null);
+runtime.ext_scratch3_looks._say("fail 491: banana should be = NaN", target);
 }
 if (!(("" + ("banana".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 492: banana should be > NaN",}, b0, false, false, "E0", null);
+runtime.ext_scratch3_looks._say("fail 492: banana should be > NaN", target);
 }
 if (!(("" + ("banana".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 493: banana should be < Infinity",}, b0, false, false, "E2", null);
+runtime.ext_scratch3_looks._say("fail 493: banana should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 494: banana should be = Infinity",}, b0, false, false, "E4", null);
+runtime.ext_scratch3_looks._say("fail 494: banana should be = Infinity", target);
 }
 if (!(("" + ("banana".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 495: banana should be > Infinity",}, b0, false, false, "E6", null);
+runtime.ext_scratch3_looks._say("fail 495: banana should be > Infinity", target);
 }
 if (!(("" + ("banana".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 496: banana should be < banana",}, b0, false, false, "E8", null);
+runtime.ext_scratch3_looks._say("fail 496: banana should be < banana", target);
 }
 if (!(("" + ("banana".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 497: banana should be = banana",}, b0, false, false, "E!", null);
+runtime.ext_scratch3_looks._say("fail 497: banana should be = banana", target);
 }
 if (!(("" + ("banana".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 498: banana should be > banana",}, b0, false, false, "E%", null);
+runtime.ext_scratch3_looks._say("fail 498: banana should be > banana", target);
 }
 if (!(("" + ("banana".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 499: banana should be < 🎉",}, b0, false, false, "E)", null);
+runtime.ext_scratch3_looks._say("fail 499: banana should be < 🎉", target);
 }
 if (!(("" + ("banana".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 500: banana should be = 🎉",}, b0, false, false, "E+", null);
+runtime.ext_scratch3_looks._say("fail 500: banana should be = 🎉", target);
 }
 if (!(("" + ("banana".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 501: banana should be > 🎉",}, b0, false, false, "E-", null);
+runtime.ext_scratch3_looks._say("fail 501: banana should be > 🎉", target);
 }
 if (!(("" + ("banana".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 502: banana should be < ",}, b0, false, false, "E/", null);
+runtime.ext_scratch3_looks._say("fail 502: banana should be < ", target);
 }
 if (!(("" + ("banana".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 503: banana should be = ",}, b0, false, false, "E;", null);
+runtime.ext_scratch3_looks._say("fail 503: banana should be = ", target);
 }
 if (!(("" + ("banana".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 504: banana should be > ",}, b0, false, false, "E?", null);
+runtime.ext_scratch3_looks._say("fail 504: banana should be > ", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 505: 🎉 should be < 0",}, b0, false, false, "E[", null);
+runtime.ext_scratch3_looks._say("fail 505: 🎉 should be < 0", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 506: 🎉 should be = 0",}, b0, false, false, "E^", null);
+runtime.ext_scratch3_looks._say("fail 506: 🎉 should be = 0", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 507: 🎉 should be > 0",}, b0, false, false, "E`", null);
+runtime.ext_scratch3_looks._say("fail 507: 🎉 should be > 0", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 508: 🎉 should be < 0.0",}, b0, false, false, "E|", null);
+runtime.ext_scratch3_looks._say("fail 508: 🎉 should be < 0.0", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 509: 🎉 should be = 0.0",}, b0, false, false, "E~", null);
+runtime.ext_scratch3_looks._say("fail 509: 🎉 should be = 0.0", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 510: 🎉 should be > 0.0",}, b0, false, false, "Fb", null);
+runtime.ext_scratch3_looks._say("fail 510: 🎉 should be > 0.0", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 511: 🎉 should be < 1.23",}, b0, false, false, "Fd", null);
+runtime.ext_scratch3_looks._say("fail 511: 🎉 should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 512: 🎉 should be = 1.23",}, b0, false, false, "Ff", null);
+runtime.ext_scratch3_looks._say("fail 512: 🎉 should be = 1.23", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 513: 🎉 should be > 1.23",}, b0, false, false, "Fh", null);
+runtime.ext_scratch3_looks._say("fail 513: 🎉 should be > 1.23", target);
 }
 if (!(("" + ("🎉".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 514: 🎉 should be < .23",}, b0, false, false, "Fj", null);
+runtime.ext_scratch3_looks._say("fail 514: 🎉 should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 515: 🎉 should be = .23",}, b0, false, false, "Fl", null);
+runtime.ext_scratch3_looks._say("fail 515: 🎉 should be = .23", target);
 }
 if (!(("" + ("🎉".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 516: 🎉 should be > .23",}, b0, false, false, "Fn", null);
+runtime.ext_scratch3_looks._say("fail 516: 🎉 should be > .23", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 517: 🎉 should be < 0.123",}, b0, false, false, "Fp", null);
+runtime.ext_scratch3_looks._say("fail 517: 🎉 should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 518: 🎉 should be = 0.123",}, b0, false, false, "Fr", null);
+runtime.ext_scratch3_looks._say("fail 518: 🎉 should be = 0.123", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 519: 🎉 should be > 0.123",}, b0, false, false, "Ft", null);
+runtime.ext_scratch3_looks._say("fail 519: 🎉 should be > 0.123", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 520: 🎉 should be < -0",}, b0, false, false, "Fv", null);
+runtime.ext_scratch3_looks._say("fail 520: 🎉 should be < -0", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 521: 🎉 should be = -0",}, b0, false, false, "Fx", null);
+runtime.ext_scratch3_looks._say("fail 521: 🎉 should be = -0", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 522: 🎉 should be > -0",}, b0, false, false, "Fz", null);
+runtime.ext_scratch3_looks._say("fail 522: 🎉 should be > -0", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 523: 🎉 should be < -1",}, b0, false, false, "FB", null);
+runtime.ext_scratch3_looks._say("fail 523: 🎉 should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 524: 🎉 should be = -1",}, b0, false, false, "FD", null);
+runtime.ext_scratch3_looks._say("fail 524: 🎉 should be = -1", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 525: 🎉 should be > -1",}, b0, false, false, "FF", null);
+runtime.ext_scratch3_looks._say("fail 525: 🎉 should be > -1", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 526: 🎉 should be < true",}, b0, false, false, "FH", null);
+runtime.ext_scratch3_looks._say("fail 526: 🎉 should be < true", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 527: 🎉 should be = true",}, b0, false, false, "FJ", null);
+runtime.ext_scratch3_looks._say("fail 527: 🎉 should be = true", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 528: 🎉 should be > true",}, b0, false, false, "FL", null);
+runtime.ext_scratch3_looks._say("fail 528: 🎉 should be > true", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 529: 🎉 should be < false",}, b0, false, false, "FN", null);
+runtime.ext_scratch3_looks._say("fail 529: 🎉 should be < false", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 530: 🎉 should be = false",}, b0, false, false, "FP", null);
+runtime.ext_scratch3_looks._say("fail 530: 🎉 should be = false", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 531: 🎉 should be > false",}, b0, false, false, "FR", null);
+runtime.ext_scratch3_looks._say("fail 531: 🎉 should be > false", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 532: 🎉 should be < NaN",}, b0, false, false, "FT", null);
+runtime.ext_scratch3_looks._say("fail 532: 🎉 should be < NaN", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 533: 🎉 should be = NaN",}, b0, false, false, "FV", null);
+runtime.ext_scratch3_looks._say("fail 533: 🎉 should be = NaN", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 534: 🎉 should be > NaN",}, b0, false, false, "FX", null);
+runtime.ext_scratch3_looks._say("fail 534: 🎉 should be > NaN", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 535: 🎉 should be < Infinity",}, b0, false, false, "FZ", null);
+runtime.ext_scratch3_looks._say("fail 535: 🎉 should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 536: 🎉 should be = Infinity",}, b0, false, false, "F1", null);
+runtime.ext_scratch3_looks._say("fail 536: 🎉 should be = Infinity", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 537: 🎉 should be > Infinity",}, b0, false, false, "F3", null);
+runtime.ext_scratch3_looks._say("fail 537: 🎉 should be > Infinity", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 538: 🎉 should be < banana",}, b0, false, false, "F5", null);
+runtime.ext_scratch3_looks._say("fail 538: 🎉 should be < banana", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 539: 🎉 should be = banana",}, b0, false, false, "F7", null);
+runtime.ext_scratch3_looks._say("fail 539: 🎉 should be = banana", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 540: 🎉 should be > banana",}, b0, false, false, "F9", null);
+runtime.ext_scratch3_looks._say("fail 540: 🎉 should be > banana", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 541: 🎉 should be < 🎉",}, b0, false, false, "F#", null);
+runtime.ext_scratch3_looks._say("fail 541: 🎉 should be < 🎉", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 542: 🎉 should be = 🎉",}, b0, false, false, "F(", null);
+runtime.ext_scratch3_looks._say("fail 542: 🎉 should be = 🎉", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 543: 🎉 should be > 🎉",}, b0, false, false, "F*", null);
+runtime.ext_scratch3_looks._say("fail 543: 🎉 should be > 🎉", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 544: 🎉 should be < ",}, b0, false, false, "F,", null);
+runtime.ext_scratch3_looks._say("fail 544: 🎉 should be < ", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 545: 🎉 should be = ",}, b0, false, false, "F.", null);
+runtime.ext_scratch3_looks._say("fail 545: 🎉 should be = ", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 546: 🎉 should be > ",}, b0, false, false, "F:", null);
+runtime.ext_scratch3_looks._say("fail 546: 🎉 should be > ", target);
 }
 if (!(("" + ("".toLowerCase() < "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 547:  should be < 0",}, b0, false, false, "F=", null);
+runtime.ext_scratch3_looks._say("fail 547:  should be < 0", target);
 }
 if (!(("" + ("".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 548:  should be = 0",}, b0, false, false, "F@", null);
+runtime.ext_scratch3_looks._say("fail 548:  should be = 0", target);
 }
 if (!(("" + ("".toLowerCase() > "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 549:  should be > 0",}, b0, false, false, "F]", null);
+runtime.ext_scratch3_looks._say("fail 549:  should be > 0", target);
 }
 if (!(("" + ("".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 550:  should be < 0.0",}, b0, false, false, "F_", null);
+runtime.ext_scratch3_looks._say("fail 550:  should be < 0.0", target);
 }
 if (!(("" + ("".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 551:  should be = 0.0",}, b0, false, false, "F{", null);
+runtime.ext_scratch3_looks._say("fail 551:  should be = 0.0", target);
 }
 if (!(("" + ("".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 552:  should be > 0.0",}, b0, false, false, "F}", null);
+runtime.ext_scratch3_looks._say("fail 552:  should be > 0.0", target);
 }
 if (!(("" + ("".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 553:  should be < 1.23",}, b0, false, false, "Ga", null);
+runtime.ext_scratch3_looks._say("fail 553:  should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 554:  should be = 1.23",}, b0, false, false, "Gc", null);
+runtime.ext_scratch3_looks._say("fail 554:  should be = 1.23", target);
 }
 if (!(("" + ("".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 555:  should be > 1.23",}, b0, false, false, "Ge", null);
+runtime.ext_scratch3_looks._say("fail 555:  should be > 1.23", target);
 }
 if (!(("" + ("".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 556:  should be < .23",}, b0, false, false, "Gg", null);
+runtime.ext_scratch3_looks._say("fail 556:  should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 557:  should be = .23",}, b0, false, false, "Gi", null);
+runtime.ext_scratch3_looks._say("fail 557:  should be = .23", target);
 }
 if (!(("" + ("".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 558:  should be > .23",}, b0, false, false, "Gk", null);
+runtime.ext_scratch3_looks._say("fail 558:  should be > .23", target);
 }
 if (!(("" + ("".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 559:  should be < 0.123",}, b0, false, false, "Gm", null);
+runtime.ext_scratch3_looks._say("fail 559:  should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 560:  should be = 0.123",}, b0, false, false, "Go", null);
+runtime.ext_scratch3_looks._say("fail 560:  should be = 0.123", target);
 }
 if (!(("" + ("".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 561:  should be > 0.123",}, b0, false, false, "Gq", null);
+runtime.ext_scratch3_looks._say("fail 561:  should be > 0.123", target);
 }
 if (!(("" + ("".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 562:  should be < -0",}, b0, false, false, "Gs", null);
+runtime.ext_scratch3_looks._say("fail 562:  should be < -0", target);
 }
 if (!(("" + ("".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 563:  should be = -0",}, b0, false, false, "Gu", null);
+runtime.ext_scratch3_looks._say("fail 563:  should be = -0", target);
 }
 if (!(("" + ("".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 564:  should be > -0",}, b0, false, false, "Gw", null);
+runtime.ext_scratch3_looks._say("fail 564:  should be > -0", target);
 }
 if (!(("" + ("".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 565:  should be < -1",}, b0, false, false, "Gy", null);
+runtime.ext_scratch3_looks._say("fail 565:  should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 566:  should be = -1",}, b0, false, false, "GA", null);
+runtime.ext_scratch3_looks._say("fail 566:  should be = -1", target);
 }
 if (!(("" + ("".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 567:  should be > -1",}, b0, false, false, "GC", null);
+runtime.ext_scratch3_looks._say("fail 567:  should be > -1", target);
 }
 if (!(("" + ("".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 568:  should be < true",}, b0, false, false, "GE", null);
+runtime.ext_scratch3_looks._say("fail 568:  should be < true", target);
 }
 if (!(("" + ("".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 569:  should be = true",}, b0, false, false, "GG", null);
+runtime.ext_scratch3_looks._say("fail 569:  should be = true", target);
 }
 if (!(("" + ("".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 570:  should be > true",}, b0, false, false, "GI", null);
+runtime.ext_scratch3_looks._say("fail 570:  should be > true", target);
 }
 if (!(("" + ("".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 571:  should be < false",}, b0, false, false, "GK", null);
+runtime.ext_scratch3_looks._say("fail 571:  should be < false", target);
 }
 if (!(("" + ("".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 572:  should be = false",}, b0, false, false, "GM", null);
+runtime.ext_scratch3_looks._say("fail 572:  should be = false", target);
 }
 if (!(("" + ("".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 573:  should be > false",}, b0, false, false, "GO", null);
+runtime.ext_scratch3_looks._say("fail 573:  should be > false", target);
 }
 if (!(("" + ("".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 574:  should be < NaN",}, b0, false, false, "GQ", null);
+runtime.ext_scratch3_looks._say("fail 574:  should be < NaN", target);
 }
 if (!(("" + ("".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 575:  should be = NaN",}, b0, false, false, "GS", null);
+runtime.ext_scratch3_looks._say("fail 575:  should be = NaN", target);
 }
 if (!(("" + ("".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 576:  should be > NaN",}, b0, false, false, "GU", null);
+runtime.ext_scratch3_looks._say("fail 576:  should be > NaN", target);
 }
 if (!(("" + ("".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 577:  should be < Infinity",}, b0, false, false, "GW", null);
+runtime.ext_scratch3_looks._say("fail 577:  should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 578:  should be = Infinity",}, b0, false, false, "GY", null);
+runtime.ext_scratch3_looks._say("fail 578:  should be = Infinity", target);
 }
 if (!(("" + ("".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 579:  should be > Infinity",}, b0, false, false, "G0", null);
+runtime.ext_scratch3_looks._say("fail 579:  should be > Infinity", target);
 }
 if (!(("" + ("".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 580:  should be < banana",}, b0, false, false, "G2", null);
+runtime.ext_scratch3_looks._say("fail 580:  should be < banana", target);
 }
 if (!(("" + ("".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 581:  should be = banana",}, b0, false, false, "G4", null);
+runtime.ext_scratch3_looks._say("fail 581:  should be = banana", target);
 }
 if (!(("" + ("".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 582:  should be > banana",}, b0, false, false, "G6", null);
+runtime.ext_scratch3_looks._say("fail 582:  should be > banana", target);
 }
 if (!(("" + ("".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 583:  should be < 🎉",}, b0, false, false, "G8", null);
+runtime.ext_scratch3_looks._say("fail 583:  should be < 🎉", target);
 }
 if (!(("" + ("".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 584:  should be = 🎉",}, b0, false, false, "G!", null);
+runtime.ext_scratch3_looks._say("fail 584:  should be = 🎉", target);
 }
 if (!(("" + ("".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 585:  should be > 🎉",}, b0, false, false, "G%", null);
+runtime.ext_scratch3_looks._say("fail 585:  should be > 🎉", target);
 }
 if (!(("" + ("".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 586:  should be < ",}, b0, false, false, "G)", null);
+runtime.ext_scratch3_looks._say("fail 586:  should be < ", target);
 }
 if (!(("" + ("".toLowerCase() === "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 587:  should be = ",}, b0, false, false, "G+", null);
+runtime.ext_scratch3_looks._say("fail 587:  should be = ", target);
 }
 if (!(("" + ("".toLowerCase() > "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 588:  should be > ",}, b0, false, false, "G.", null);
+runtime.ext_scratch3_looks._say("fail 588:  should be > ", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "G-", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-comparison-matrix-runtime.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-comparison-matrix-runtime.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "ae", null);
-yield* thread.procedures["Wrun test"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "aZ", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
+thread.procedures["Wrun test"]();
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -18,28 +17,26 @@ const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 const b2 = stage.variables["n^wm8jw#b24sggt.S^tD"];
 const b3 = stage.variables["_]6^lq+-%H0{ov`tKt7$"];
 const b4 = stage.variables["3lyKRepBc$tx)EWlpr!y"];
-const b5 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_run_test () {
+return function funXYZ_run_test () {
 thread.procedures["Wsetup values"]();
 b0.value = 0;
 b1.value = 0;
 for (var a0 = b2.value.length; a0 > 0; a0--) {
-b1.value = (toNotNaN(+b1.value) + 1);
+b1.value = (b1.value + 1);
 b3.value = 0;
 for (var a1 = b2.value.length; a1 > 0; a1--) {
-b3.value = (toNotNaN(+b3.value) + 1);
-b0.value = (toNotNaN(+b0.value) + 1);
-if (!compareEqual(compareGreaterThan(listGet(b2.value, b1.value), (b2.value[(b3.value | 0) - 1] ?? "")), (b4.value[(b0.value | 0) - 1] ?? ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be > " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))),}, b5, true, false, "]", null);
+b3.value = (b3.value + 1);
+b0.value = (b0.value + 1);
+if (!compareEqual(compareGreaterThan((b2.value[b1.value - 1] ?? ""), (b2.value[b3.value - 1] ?? "")), (b4.value[b0.value - 1] ?? ""))) {
+runtime.ext_scratch3_looks._say(("fail " + (("" + (b2.value[b1.value - 1] ?? "")) + (" should be > " + ("" + (b2.value[b3.value - 1] ?? ""))))), target);
 }
-b0.value = (toNotNaN(+b0.value) + 1);
-if (!compareEqual(compareEqual(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be = " + ("" + listGet(b2.value, b3.value))))),}, b5, true, false, "|", null);
+b0.value = (b0.value + 1);
+if (!compareEqual(compareEqual((b2.value[b1.value - 1] ?? ""), (b2.value[b3.value - 1] ?? "")), (b4.value[b0.value - 1] ?? ""))) {
+runtime.ext_scratch3_looks._say(("fail " + (("" + (b2.value[b1.value - 1] ?? "")) + (" should be = " + ("" + (b2.value[b3.value - 1] ?? ""))))), target);
 }
-b0.value = (toNotNaN(+b0.value) + 1);
-if (!compareEqual(compareLessThan(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be < " + ("" + listGet(b2.value, b3.value))))),}, b5, true, true, "ab", null);
-if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+b0.value = (b0.value + 1);
+if (!compareEqual(compareLessThan((b2.value[b1.value - 1] ?? ""), (b2.value[b3.value - 1] ?? "")), (b4.value[b0.value - 1] ?? ""))) {
+runtime.ext_scratch3_looks._say(("fail " + (("" + (b2.value[b1.value - 1] ?? "")) + (" should be < " + ("" + (b2.value[b3.value - 1] ?? ""))))), target);
 }
 }
 }

--- a/test/snapshot/__snapshots__/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
@@ -3,17 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("looks_sayforsecs");
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = runtime.getOpcodeFunction("looks_sayforsecs");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
-b1.value = (0 + 0);
-yield* executeInCompatibilityLayer({"MESSAGE":"Hello!","SECS":0.1,}, b2, false, false, "d", null);
-if (((toNotNaN(+b1.value) + 2) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "i", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (0 + 0);
+yield* executeInCompatibilityLayer({"MESSAGE":"Hello!","SECS":0.1,}, b1, false, false, "d", null);
+if (((toNotNaN(+b0.value) + 2) === 2)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-coordinate-precision.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-coordinate-precision.sb3.tw-snapshot
@@ -3,34 +3,33 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = runtime.getSpriteTargetByName("Sprite1");
+const b0 = runtime.getSpriteTargetByName("Sprite1");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, "`f)8`e7_V%]cmRy7eZ?*", null);
+runtime.ext_scratch3_looks._say("plan 6", target);
 target.setXY(1e-9, target.y);
 if ((limitPrecision(target.x) === 1e-9)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass much above x does not round",}, b0, false, false, "wnAyae772?^VZ]bq?#*p", null);
+runtime.ext_scratch3_looks._say("pass much above x does not round", target);
 }
-if (((b1 ? b1.x : 0) === 1e-9)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass initial 'of' test",}, b0, false, false, "${qf}t3_Wf_/sqC#i0WN", null);
+if (((b0 ? b0.x : 0) === 1e-9)) {
+runtime.ext_scratch3_looks._say("pass initial 'of' test", target);
 }
 target.setXY(target.x + 0, target.y);
 runtime.ext_scratch3_motion._moveSteps(0, target);
 target.setXY(target.x + -9e-10, target.y);
-if (((b1 ? b1.x : 0) === 1.0000000000000007e-10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 'of' never rounds - positive x",}, b0, false, false, "zt/Fd,i768/rohNq-OU/", null);
+if (((b0 ? b0.x : 0) === 1.0000000000000007e-10)) {
+runtime.ext_scratch3_looks._say("pass 'of' never rounds - positive x", target);
 }
 if ((limitPrecision(target.x) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass x slightly above 0 rounds",}, b0, false, false, "p5a6(?e#B|B(d.fe;b6F", null);
+runtime.ext_scratch3_looks._say("pass x slightly above 0 rounds", target);
 }
 target.setXY(target.x + -9e-10, target.y);
 target.setXY(target.x, target.y + 0);
-if (((b1 ? b1.x : 0) === -7.999999999999999e-10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 'of' never rounds and change x - negative x",}, b0, false, false, "![=|9E8]xp_9QR]fu}4M", null);
+if (((b0 ? b0.x : 0) === -7.999999999999999e-10)) {
+runtime.ext_scratch3_looks._say("pass 'of' never rounds and change x - negative x", target);
 }
 if ((limitPrecision(target.x) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass x slightly below 0 rounds",}, b0, false, false, "4o-vB]D}HJ1/*qW~k3Cd", null);
+runtime.ext_scratch3_looks._say("pass x slightly below 0 rounds", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "8We]d__[]7X;@+e*x~^@", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-counter.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-counter.sb3.tw-snapshot
@@ -3,34 +3,32 @@
 
 // 2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((runtime.ext_scratch3_control._counter === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass global",}, b0, false, false, "C", null);
+runtime.ext_scratch3_looks._say("pass global", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "B", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // 1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 5",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 5", target);
 if ((runtime.ext_scratch3_control._counter === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass initial value = 0",}, b0, false, false, "q", null);
+runtime.ext_scratch3_looks._say("pass initial value = 0", target);
 }
 runtime.ext_scratch3_control._counter++;
 if ((runtime.ext_scratch3_control._counter === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass incr 1",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("pass incr 1", target);
 }
 runtime.ext_scratch3_control._counter++;
 if ((runtime.ext_scratch3_control._counter === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass incr 2",}, b0, false, false, "u", null);
+runtime.ext_scratch3_looks._say("pass incr 2", target);
 }
 runtime.ext_scratch3_control._counter = 0;
 if ((runtime.ext_scratch3_control._counter === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass clear = 0",}, b0, false, false, "w", null);
+runtime.ext_scratch3_looks._say("pass clear = 0", target);
 }
 for (var a0 = 10; a0 > 0; a0--) {
 runtime.ext_scratch3_control._counter++;

--- a/test/snapshot/__snapshots__/tw-custom-report-repeat.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-custom-report-repeat.sb3.tw-snapshot
@@ -3,19 +3,18 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
-b1.value = 0;
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
 for (var a0 = toNotNaN(+thread.procedures["Zblock name"]()); a0 >= 0.5; a0--) {
-b1.value = (toNotNaN(+b1.value) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 yield;
 }
-if ((toNotNaN(+b1.value) === 40)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "n", null);
+if ((toNotNaN(+b0.value) === 40)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-exit-state-accounts-for-yields-in-procedures.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-exit-state-accounts-for-yields-in-procedures.sb3.tw-snapshot
@@ -3,17 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
-b1.value = (1 + 2);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (1 + 2);
 yield* thread.procedures["Zsomething that yields"]();
-if ((("" + listGet(b2.value, b1.value)).toLowerCase() === "the only thing".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "o", null);
+if ((("" + listGet(b1.value, b0.value)).toLowerCase() === "the only thing".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-boolean-number-comparison.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-boolean-number-comparison.sb3.tw-snapshot
@@ -3,21 +3,20 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 4",}, b0, false, false, "i", null);
+runtime.ext_scratch3_looks._say("plan 4", target);
 if (compareGreaterThan(("something".toLowerCase() === "something".toLowerCase()), ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (compareLessThan(("something".toLowerCase() === "else".toLowerCase()), ("1" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((+("something".toLowerCase() === "something".toLowerCase())) > (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((+("something".toLowerCase() === "else".toLowerCase())) < (1 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
@@ -3,26 +3,25 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = runtime.getOpcodeFunction("motion_pointtowards");
+const b0 = runtime.getOpcodeFunction("motion_pointtowards");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 4",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("plan 4", target);
 target.setDirection(95);
 if ((target.direction === 95)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 1",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("pass 1", target);
 }
 target.setDirection((1 / 0));
 if ((target.direction === 95)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, "r", null);
+runtime.ext_scratch3_looks._say("pass 2", target);
 }
 target.setDirection(toNotNaN((0 / 0)));
 if ((target.direction === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "u", null);
+runtime.ext_scratch3_looks._say("pass 3", target);
 }
-yield* executeInCompatibilityLayer({"TOWARDS":"Sprite2",}, b1, false, false, "g", null);
+yield* executeInCompatibilityLayer({"TOWARDS":"Sprite2",}, b0, false, false, "g", null);
 if ((target.direction === 90)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, "y", null);
+runtime.ext_scratch3_looks._say("pass 4", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "w", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-random-with-invalid-number-with-period.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-random-with-invalid-number-with-period.sb3.tw-snapshot
@@ -3,30 +3,29 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, "j", null);
-b1.value = runtime.ext_scratch3_operators._random(("an invalid number" + "."), 1);
-if (!(b1.value <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("plan 6", target);
+b0.value = runtime.ext_scratch3_operators._random(("an invalid number" + "."), 1);
+if (!(b0.value <= 0)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (compareLessThan(b1.value, 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "r", null);
+if ((b0.value < 1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + b1.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "s", null);
+if ((("" + b0.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-b1.value = runtime.ext_scratch3_operators._random(1, ("an invalid number" + "."));
-if (!(b1.value <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "v", null);
+b0.value = runtime.ext_scratch3_operators._random(1, ("an invalid number" + "."));
+if (!(b0.value <= 0)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (compareLessThan(b1.value, 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "x", null);
+if ((b0.value < 1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + b1.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "A", null);
+if ((("" + b0.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "y", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
@@ -3,21 +3,20 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = target.variables["gTtSj;o_E;Snkn620KF."];
-const b2 = target.variables["zShM`!CD?d_|Z,]5X}N6"];
+const b0 = target.variables["gTtSj;o_E;Snkn620KF."];
+const b1 = target.variables["zShM`!CD?d_|Z,]5X}N6"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "d", null);
-b1.value = 2;
-if ((b1.value === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass variable",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = 2;
+if ((b0.value === 2)) {
+runtime.ext_scratch3_looks._say("pass variable", target);
 }
-b2.value = [];
-b2.value.push(3);
-b2._monitorUpToDate = false;
-if ((toNotNaN(+(b2.value[1 - 1] ?? "")) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass list",}, b0, false, false, "m", null);
+b1.value = [];
+b1.value.push(3);
+b1._monitorUpToDate = false;
+if ((toNotNaN(+(b1.value[1 - 1] ?? "")) === 3)) {
+runtime.ext_scratch3_looks._say("pass list", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
@@ -5,17 +5,16 @@
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = runtime.getOpcodeFunction("sound_setvolumeto");
 const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"VOLUME":0,}, b0, false, false, "d", null);
 b1.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b2, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wno refresh"]();
 yield* thread.procedures["Wruns below with no refresh"]();
 if (compareEqual(b1.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "v", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, "f", null);
+runtime.ext_scratch3_looks._say("end", target);
 runtime.stopAll();
 retire(); return;
 retire(); return;

--- a/test/snapshot/__snapshots__/tw-gh-201-stop-script-does-not-reevaluate-arguments.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-gh-201-stop-script-does-not-reevaluate-arguments.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 thread.procedures["Zfoo %s"]("");
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-gh-249-quicksort.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-gh-249-quicksort.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "Z", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 thread.procedures["Wrun"]();
-yield* thread.procedures["Wvalidate"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "aw", null);
+thread.procedures["Wvalidate"]();
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -32,19 +31,18 @@ const b0 = stage.variables["7AH{dO^X;}C[{[l~g-7m"];
 const b1 = stage.variables["gPJ}c-PZz?Y+_L][iMU_"];
 const b2 = stage.variables["EF^k=u-t@S)w60;RP?dZ-list-list"];
 const b3 = stage.variables["FsKqV/2kid0gw0J+Jj(c"];
-const b4 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_validate () {
+return function funXYZ_validate () {
 b0.value = 1;
 b1.value = 1;
 for (var a0 = b2.value.length; a0 > 0; a0--) {
-if (!compareEqual((b2.value[(b1.value | 0) - 1] ?? ""), (b3.value[(b1.value | 0) - 1] ?? ""))) {
+if (!compareEqual((b2.value[b1.value - 1] ?? ""), (b3.value[b1.value - 1] ?? ""))) {
 b0.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":("fail mismatch at index " + ("" + b1.value)),}, b4, true, false, ",", null);
+runtime.ext_scratch3_looks._say(("fail mismatch at index " + ("" + b1.value)), target);
 }
-b1.value = (toNotNaN(+b1.value) + 1);
+b1.value = (b1.value + 1);
 }
-if ((toNotNaN(+b0.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass sorted",}, b4, true, false, "aE", null);
+if ((b0.value === 1)) {
+runtime.ext_scratch3_looks._say("pass sorted", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-list-any.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-list-any.sb3.tw-snapshot
@@ -3,36 +3,35 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["eFlmP1{XC+I1:h0Yln.K"];
+const b0 = stage.variables["eFlmP1{XC+I1:h0Yln.K"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 7",}, b0, false, false, "h", null);
-b1.value = [];
-listInsert(b1, "any", "a");
-listInsert(b1, "any", "b");
-listInsert(b1, "any", "c");
-if ((b1.value.length === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("plan 7", target);
+b0.value = [];
+listInsert(b0, "any", "a");
+listInsert(b0, "any", "b");
+listInsert(b0, "any", "c");
+if ((b0.value.length === 3)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, "a")) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "v", null);
+if (listContains(b0, "a")) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, "b")) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "x", null);
+if (listContains(b0, "b")) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, "c")) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "z", null);
+if (listContains(b0, "c")) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, listGet(b1.value, "any"))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "A", null);
+if (listContains(b0, listGet(b0.value, "any"))) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-listDelete(b1, "any");
-if ((b1.value.length === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "C", null);
+listDelete(b0, "any");
+if ((b0.value.length === 2)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + listGet(b1.value, "*")).toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "F", null);
+if ((("" + listGet(b0.value, "*")).toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "E", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 thread.procedures["Wtest %s"]("random");
-if ((("" + b1.value).toLowerCase() === "random".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "p", null);
+if ((("" + b0.value).toLowerCase() === "random".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -3,27 +3,26 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["%ehs:~!Y0l-5=!mnd-B?"];
-const b2 = stage.variables["=3aHfv[mKa)v,Wfpy:y?"];
-const b3 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["%ehs:~!Y0l-5=!mnd-B?"];
+const b1 = stage.variables["=3aHfv[mKa)v,Wfpy:y?"];
+const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
-b1.value = [];
-b1.value.push((1 + 2));
-b1._monitorUpToDate = false;
-b1.value.push("eof");
-b1._monitorUpToDate = false;
-b2.value = 0;
-b3.value = "bwah";
-while (!(("" + b3.value).toLowerCase() === "eof".toLowerCase())) {
-b2.value = (toNotNaN(+b2.value) + 1);
-b3.value = (b1.value[(b2.value | 0) - 1] ?? "");
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = [];
+b0.value.push((1 + 2));
+b0._monitorUpToDate = false;
+b0.value.push("eof");
+b0._monitorUpToDate = false;
+b1.value = 0;
+b2.value = "bwah";
+while (!(("" + b2.value).toLowerCase() === "eof".toLowerCase())) {
+b1.value = (toNotNaN(+b1.value) + 1);
+b2.value = (b0.value[(b1.value | 0) - 1] ?? "");
 yield;
 }
-if ((toNotNaN(+b2.value) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "q", null);
+if ((toNotNaN(+b1.value) === 2)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-obsolete-blocks.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-obsolete-blocks.sb3.tw-snapshot
@@ -3,31 +3,30 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("sensing_userid");
-const b3 = runtime.getOpcodeFunction("motion_xscroll");
-const b4 = runtime.getOpcodeFunction("motion_yscroll");
-const b5 = runtime.getOpcodeFunction("motion_scroll_right");
-const b6 = runtime.getOpcodeFunction("motion_scroll_up");
-const b7 = runtime.getOpcodeFunction("motion_align_scene");
-const b8 = runtime.getOpcodeFunction("looks_setstretchto");
-const b9 = runtime.getOpcodeFunction("looks_changestretchby");
-const b10 = runtime.getOpcodeFunction("looks_hideallsprites");
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = runtime.getOpcodeFunction("sensing_userid");
+const b2 = runtime.getOpcodeFunction("motion_xscroll");
+const b3 = runtime.getOpcodeFunction("motion_yscroll");
+const b4 = runtime.getOpcodeFunction("motion_scroll_right");
+const b5 = runtime.getOpcodeFunction("motion_scroll_up");
+const b6 = runtime.getOpcodeFunction("motion_align_scene");
+const b7 = runtime.getOpcodeFunction("looks_setstretchto");
+const b8 = runtime.getOpcodeFunction("looks_changestretchby");
+const b9 = runtime.getOpcodeFunction("looks_hideallsprites");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "pW2KnJW$%KXFoppMJBAi", null);
-b1.value = (yield* executeInCompatibilityLayer({}, b2, false, false, "X[|X;C.(v[|^i|@0Eqy4", null));
-b1.value = (yield* executeInCompatibilityLayer({}, b3, false, false, "z;H$hVK7X;MZSyO9U/#1", null));
-b1.value = (yield* executeInCompatibilityLayer({}, b4, false, false, ";Q94_J}Jv36TqTll;ji*", null));
-yield* executeInCompatibilityLayer({"DISTANCE":10,}, b5, false, false, "_TLJeW5hG9gAtYO2c*D9", null);
-yield* executeInCompatibilityLayer({"DISTANCE":10,}, b6, false, false, "o=l#1WJR!L37RN`q:`8E", null);
-yield* executeInCompatibilityLayer({"ALIGNMENT":"bottom-left",}, b7, false, false, "idkZ9I+=Q:@xXm;N-2Oy", null);
-yield* executeInCompatibilityLayer({"STRETCH":100,}, b8, false, false, "AMs-%pRGK*v6a[.XifN1", null);
-yield* executeInCompatibilityLayer({"STRETCH":100,}, b8, false, false, "g+bBVCHp+A[-X2E7-7#|", null);
-yield* executeInCompatibilityLayer({"CHANGE":10,}, b9, false, false, "ZN24~,cX56Dc2k4vt}HB", null);
-yield* executeInCompatibilityLayer({"CHANGE":10,}, b9, false, false, "Zjds+5Is*:nb7wnX{rYN", null);
-yield* executeInCompatibilityLayer({}, b10, false, false, "8X_d`@6,B7%wzr7.xE}t", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "C/%^M/1/S`iX8*M~Q;!3", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "(C;YJ2L~?zR[Y)Wti?3m", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (yield* executeInCompatibilityLayer({}, b1, false, false, "X[|X;C.(v[|^i|@0Eqy4", null));
+b0.value = (yield* executeInCompatibilityLayer({}, b2, false, false, "z;H$hVK7X;MZSyO9U/#1", null));
+b0.value = (yield* executeInCompatibilityLayer({}, b3, false, false, ";Q94_J}Jv36TqTll;ji*", null));
+yield* executeInCompatibilityLayer({"DISTANCE":10,}, b4, false, false, "_TLJeW5hG9gAtYO2c*D9", null);
+yield* executeInCompatibilityLayer({"DISTANCE":10,}, b5, false, false, "o=l#1WJR!L37RN`q:`8E", null);
+yield* executeInCompatibilityLayer({"ALIGNMENT":"bottom-left",}, b6, false, false, "idkZ9I+=Q:@xXm;N-2Oy", null);
+yield* executeInCompatibilityLayer({"STRETCH":100,}, b7, false, false, "AMs-%pRGK*v6a[.XifN1", null);
+yield* executeInCompatibilityLayer({"STRETCH":100,}, b7, false, false, "g+bBVCHp+A[-X2E7-7#|", null);
+yield* executeInCompatibilityLayer({"CHANGE":10,}, b8, false, false, "ZN24~,cX56Dc2k4vt}HB", null);
+yield* executeInCompatibilityLayer({"CHANGE":10,}, b8, false, false, "Zjds+5Is*:nb7wnX{rYN", null);
+yield* executeInCompatibilityLayer({}, b9, false, false, "8X_d`@6,B7%wzr7.xE}t", null);
+runtime.ext_scratch3_looks._say("pass", target);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-one-divide-negative-zero.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-one-divide-negative-zero.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "@|B*yJ0zKh!acN`7L-N5", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (((1 / -0) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "=enYDFG11Nj/0BL:y56w", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ",Cpv8W0RH0RgNky[1xb:", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-preciseProjectTimer-drift-453118719.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-preciseProjectTimer-drift-453118719.sb3.tw-snapshot
@@ -4,13 +4,12 @@
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["PsY$$vp$IVH;dDAr[q2h"];
-const b1 = runtime.getOpcodeFunction("looks_say");
-const b2 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
+const b1 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
 return function* genXYZ () {
 b0.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b1, false, false, "}fY]VN(X|v/[G`P0?@s2", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 for (var a0 = 30; a0 > 0; a0--) {
-b2.value = runtime.ioDevices.clock.projectTimer();
+b1.value = runtime.ioDevices.clock.projectTimer();
 thread.timer = timer();
 var a1 = Math.max(0, 1000 * 0);
 runtime.requestRedraw();
@@ -22,7 +21,7 @@ thread.timer = null;
 yield;
 }
 b0.value = 1;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, "mDG0BTTG/wwr;/Uz~u^c", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -31,7 +30,6 @@ retire(); return;
 const b0 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
 const b1 = runtime.getOpcodeFunction("event_whengreaterthan");
 const b2 = stage.variables["PsY$$vp$IVH;dDAr[q2h"];
-const b3 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 {
 const resolvedValue = toBoolean((yield* executeInCompatibilityLayer({"VALUE":b0.value,"WHENGREATERTHANMENU":"TIMER",}, b1, false, false, "iNmua~6veGey6O-_UB9.", null)));
@@ -45,7 +43,7 @@ retire(); return;
 yield;
 }
 if (compareEqual(b2.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b3, false, false, "JE9*Ms@I!EKJ-|Bcga#W", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-prefers-first-occurence-of-procedure-387608267.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-prefers-first-occurence-of-procedure-387608267.sb3.tw-snapshot
@@ -3,18 +3,16 @@
 
 // Player script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "#0F2+kcgu;or|hdwuT9{", null);
-yield* thread.procedures["ZSet Costume"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "Q^(MKge)QH2e:WH6b6g@", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+thread.procedures["ZSet Costume"]();
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Player ZSet Costume
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_Set_Costume () {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "Z$W^@c(f)rHu:DL/SGuQ", null);
+return function funXYZ_Set_Costume () {
+runtime.ext_scratch3_looks._say("pass", target);
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-procedure-arguments-with-same-name.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-arguments-with-same-name.sb3.tw-snapshot
@@ -3,31 +3,28 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "J#qm1yA(@Z6mj%Mgh;0X", null);
-yield* thread.procedures["Znumber or text %s %s"]("bad","ok");
-yield* thread.procedures["Zboolean %b %b"]("false",!false);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "$R-1lb(Mu?gdTIH^;kC_", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
+thread.procedures["Znumber or text %s %s"]("bad","ok");
+thread.procedures["Zboolean %b %b"]("false",!false);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Znumber or text %s %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_number_or_text__ (p0,p1) {
+return function funXYZ_number_or_text__ (p0,p1) {
 if ((("" + p1).toLowerCase() === "ok".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "HH`yRe9(x5%D:eV@EmkE", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 return "";
 }; })
 
 // Sprite1 Zboolean %b %b
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_boolean__ (p0,p1) {
+return function funXYZ_boolean__ (p0,p1) {
 if (toBoolean(p1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "M^!cgco]B(V)je$a6lF7", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-procedure-call-resets-variable-input-types-430811055.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-call-resets-variable-input-types-430811055.sb3.tw-snapshot
@@ -3,16 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "qf{MD}-f+l?U+)KA#Vnm", null);
-b1.value = "";
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "";
 thread.procedures["Zdo something"]();
-if (!(b1.value.toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "Sgf_#7|GOpx!R]?Q3]$s", null);
+if (!(b0.value.toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ",vD-ZG7f{]FoJ`,))JWh", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-procedure-prototype-exists-but-not-definition-549160843.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-prototype-exists-but-not-definition-549160843.sb3.tw-snapshot
@@ -3,9 +3,8 @@
 
 // Apple script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "a", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "f", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-procedure-return-non-existant.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-non-existant.sb3.tw-snapshot
@@ -23,19 +23,18 @@ retire(); return;
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
+const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "o", null);
-b1.value = 0;
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = 0;
 if (compareEqual(thread.procedures["Zinvalid params - reporter"](), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass invalid params reporter",}, b0, false, false, "L", null);
+runtime.ext_scratch3_looks._say("pass invalid params reporter", target);
 }
 if (compareEqual(thread.procedures["Zinvalid params - boolean"](), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass invalid params boolean",}, b0, false, false, "N", null);
+runtime.ext_scratch3_looks._say("pass invalid params boolean", target);
 }
 runtime.stopForTarget(target, thread);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "P", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-procedure-return-non-existent.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-non-existent.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
-b1.value = "discard me";
-b1.value = "";
-if ((("" + b1.value).toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent procedure returned empty string",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "discard me";
+b0.value = "";
+if ((("" + b0.value).toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass non existent procedure returned empty string", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-procedure-return-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-recursion.sb3.tw-snapshot
@@ -3,30 +3,29 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 18",}, b0, false, false, "G", null);
-b1.value = 0;
-b2.value = (yield* thread.procedures["Znon warp recursion should yield %s"](8));
-if ((toNotNaN(+b1.value) === 4)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp recursion yields",}, b0, false, false, "ao", null);
+runtime.ext_scratch3_looks._say("plan 18", target);
+b0.value = 0;
+b1.value = (yield* thread.procedures["Znon warp recursion should yield %s"](8));
+if ((toNotNaN(+b0.value) === 4)) {
+runtime.ext_scratch3_looks._say("pass non warp recursion yields", target);
 }
-b1.value = 0;
-b2.value = thread.procedures["Wwarp recursion should not yield %s"](8);
-if ((b1.value === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass warp recursion does not yield",}, b0, false, false, "ar", null);
+b0.value = 0;
+b1.value = thread.procedures["Wwarp recursion should not yield %s"](8);
+if ((b0.value === 0)) {
+runtime.ext_scratch3_looks._say("pass warp recursion does not yield", target);
 }
-b1.value = 0;
-b2.value = (yield* thread.procedures["Zfib %s"](7));
-if ((toNotNaN(+b1.value) === 20)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp fib yielded",}, b0, false, false, "au", null);
+b0.value = 0;
+b1.value = (yield* thread.procedures["Zfib %s"](7));
+if ((toNotNaN(+b0.value) === 20)) {
+runtime.ext_scratch3_looks._say("pass non warp fib yielded", target);
 }
 yield* thread.procedures["Zrecursing yields between each %s"]("initial");
 yield* thread.procedures["Zrecursing arguments eval order %s %s %s %s"]("initial","","","");
 runtime.stopForTarget(target, thread);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "av", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -63,21 +62,20 @@ return "";
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_recursing_yields_bet (p0) {
 if ((("" + p0).toLowerCase() === "initial".toLowerCase())) {
 b0.value = 0;
 b1.value = (toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))) + toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))))))))))));
 if ((toNotNaN(+b0.value) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recursing between calls yields final",}, b2, false, false, "aK", null);
+runtime.ext_scratch3_looks._say("pass recursing between calls yields final", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail recursing between calls yields final",}, b2, false, false, "aL", null);
+runtime.ext_scratch3_looks._say("fail recursing between calls yields final", target);
 }
 } else {
 if (compareEqual(b0.value, p0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":("pass recursing between calls yields " + ("" + p0)),}, b2, false, false, "#", null);
+runtime.ext_scratch3_looks._say(("pass recursing between calls yields " + ("" + p0)), target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail recursing between calls yields " + ("" + p0)),}, b2, false, false, "%", null);
+runtime.ext_scratch3_looks._say(("fail recursing between calls yields " + ("" + p0)), target);
 }
 }
 return "";
@@ -88,35 +86,34 @@ return "";
 const b0 = stage.variables["4HH82mPlVMOONdl(Ot*7"];
 const b1 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b3 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_recursing_arguments_ (p0,p1,p2,p3) {
 if ((("" + p0).toLowerCase() === "initial".toLowerCase())) {
 b0.value = [];
 b1.value = 0;
 b2.value = (yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 1",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 2",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 3",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 4","","","")),(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 5","","","")),(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 6","","","")))),"","")),"",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 7","","",""))));
 if ((("" + (b0.value[1 - 1] ?? "")).toLowerCase() === "1/child 4".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 1",}, b3, false, false, "aZ", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 1", target);
 }
 if ((("" + (b0.value[2 - 1] ?? "")).toLowerCase() === "1/child 5".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 2",}, b3, false, false, "a#", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 2", target);
 }
 if ((("" + (b0.value[3 - 1] ?? "")).toLowerCase() === "2/child 6".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 3",}, b3, false, false, "a(", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 3", target);
 }
 if ((("" + (b0.value[4 - 1] ?? "")).toLowerCase() === "2/child 3".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 4",}, b3, false, false, "a*", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 4", target);
 }
 if ((("" + (b0.value[5 - 1] ?? "")).toLowerCase() === "3/child 2".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 5",}, b3, false, false, "a,", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 5", target);
 }
 if ((("" + (b0.value[6 - 1] ?? "")).toLowerCase() === "3/child 7".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 6",}, b3, false, false, "a.", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 6", target);
 }
 if ((("" + (b0.value[7 - 1] ?? "")).toLowerCase() === "4/child 1".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 7",}, b3, false, false, "a:", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 7", target);
 }
 if ((b0.value.length === 7)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - length is correct",}, b3, false, false, "a=", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - length is correct", target);
 }
 } else {
 b0.value.push((("" + b1.value) + ("/" + ("" + p0))));

--- a/test/snapshot/__snapshots__/tw-procedure-return-simple.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-simple.sb3.tw-snapshot
@@ -3,27 +3,26 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 8",}, b0, false, false, "x", null);
+runtime.ext_scratch3_looks._say("plan 8", target);
 if ((("" + thread.procedures["Zsimplest"]()).toLowerCase() === "It works!".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass simplest",}, b0, false, false, ":", null);
+runtime.ext_scratch3_looks._say("pass simplest", target);
 }
 if ((("" + thread.procedures["Znesting 1"]()).toLowerCase() === "42-54".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass nesting1",}, b0, false, false, "=", null);
+runtime.ext_scratch3_looks._say("pass nesting1", target);
 }
 if ((toNotNaN(+thread.procedures["Wwarp fib %s"](12)) === 144)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass fib 12",}, b0, false, false, "@", null);
+runtime.ext_scratch3_looks._say("pass fib 12", target);
 }
 if ((toNotNaN(+thread.procedures["Wfactorial %s"](12)) === 479001600)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass factorial 12",}, b0, false, false, "]", null);
+runtime.ext_scratch3_looks._say("pass factorial 12", target);
 }
-b1.value = (yield* thread.procedures["Zno shadowing 1 %s %s"]("f","g"));
-if ((("" + b1.value).toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass default return value",}, b0, false, false, "|", null);
+b0.value = thread.procedures["Zno shadowing 1 %s %s"]("f","g");
+if ((("" + b0.value).toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass default return value", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "`", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -61,19 +60,18 @@ return "";
 
 // Sprite1 Zno shadowing 1 %s %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-return function* genXYZ_no_shadowing_1__ (p0,p1) {
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function funXYZ_no_shadowing_1__ (p0,p1) {
 if (((("" + p0).toLowerCase() === "f".toLowerCase()) && (("" + p1).toLowerCase() === "g".toLowerCase()))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass shadow check 1",}, b0, false, false, "aq", null);
+runtime.ext_scratch3_looks._say("pass shadow check 1", target);
 }
-b1.value = thread.procedures["Zno shadowing 2 %s %s"](1,2);
+b0.value = thread.procedures["Zno shadowing 2 %s %s"](1,2);
 if (((("" + p0).toLowerCase() === "f".toLowerCase()) && (("" + p1).toLowerCase() === "g".toLowerCase()))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass shadow check 2",}, b0, false, false, "au", null);
+runtime.ext_scratch3_looks._say("pass shadow check 2", target);
 }
-b1.value = thread.procedures["Zno shadowing 2 %s %s"](3,4);
+b0.value = thread.procedures["Zno shadowing 2 %s %s"](3,4);
 if (((("" + p0).toLowerCase() === "f".toLowerCase()) && (("" + p1).toLowerCase() === "g".toLowerCase()))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass shadow check 3",}, b0, false, false, "ax", null);
+runtime.ext_scratch3_looks._say("pass shadow check 3", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-procedure-return-stops-scripts.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-stops-scripts.sb3.tw-snapshot
@@ -3,27 +3,25 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
+const b0 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "f", null);
-yield* thread.procedures["Wreturn stops the script immediately"]();
-if ((toNotNaN(+b1.value) === 25)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass return stopped the script immediately",}, b0, false, false, "u", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
+thread.procedures["Wreturn stops the script immediately"]();
+if ((b0.value === 25)) {
+runtime.ext_scratch3_looks._say("pass return stopped the script immediately", target);
 }
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test return outside of custom block" }));
-if ((toNotNaN(+b1.value) === 18)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass return worked to stop outside of custom block",}, b0, false, false, "x", null);
+if ((toNotNaN(+b0.value) === 18)) {
+runtime.ext_scratch3_looks._say("pass return worked to stop outside of custom block", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "v", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Wreturn stops the script immediately
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
-const b1 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_return_stops_the_scr () {
+return function funXYZ_return_stops_the_scr () {
 b0.value = 0;
 for (var a0 = 100; a0 > 0; a0--) {
 b0.value = (b0.value + 1);
@@ -31,7 +29,7 @@ if ((b0.value === 25)) {
 return "stopped!";
 }
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"fail return did not stop the script immediately",}, b1, true, false, "z", null);
+runtime.ext_scratch3_looks._say("fail return did not stop the script immediately", target);
 return "";
 }; })
 

--- a/test/snapshot/__snapshots__/tw-procedure-return-warp.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-procedure-return-warp.sb3.tw-snapshot
@@ -23,19 +23,17 @@ retire(); return;
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 3",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("plan 3", target);
 yield* thread.procedures["Znon warp"]();
 runtime.stopForTarget(target, thread);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "N", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Znon warp
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_non_warp () {
 b0.value = 0;
 for (var a0 = 5; a0 > 0; a0--) {
@@ -50,10 +48,10 @@ thread.timer = null;
 yield;
 }
 if ((toNotNaN(+b0.value) === 5)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 1",}, b1, false, false, "R", null);
+runtime.ext_scratch3_looks._say("pass non warp 1", target);
 }
 if ((("" + (yield* thread.procedures["Wverify runs warp %s"]((yield* thread.procedures["Zverify runs non warp %s"]((yield* thread.procedures["Wverify runs warp %s"]("abc"))))))).toLowerCase() === "warp: non warp: warp: abc".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp and warp mix",}, b1, false, false, "S", null);
+runtime.ext_scratch3_looks._say("pass non warp and warp mix", target);
 }
 b0.value = 0;
 for (var a2 = 5; a2 > 0; a2--) {
@@ -68,7 +66,7 @@ thread.timer = null;
 yield;
 }
 if ((toNotNaN(+b0.value) === 5)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 2",}, b1, false, false, "W", null);
+runtime.ext_scratch3_looks._say("pass non warp 2", target);
 }
 return "";
 }; })
@@ -76,7 +74,6 @@ return "";
 // Sprite1 Wverify runs warp %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_verify_runs_warp_ (p0) {
 b0.value = 0;
 for (var a0 = 5; a0 > 0; a0--) {
@@ -89,7 +86,7 @@ if (isStuck()) yield;
 thread.timer = null;
 }
 if (!compareEqual(b0.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail did not run warp",}, b1, true, false, "Z", null);
+runtime.ext_scratch3_looks._say("fail did not run warp", target);
 }
 return ("warp: " + ("" + p0));
 return "";
@@ -98,7 +95,6 @@ return "";
 // Sprite1 Zverify runs non warp %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_verify_runs_non_warp (p0) {
 b0.value = 0;
 for (var a0 = 5; a0 > 0; a0--) {
@@ -113,7 +109,7 @@ thread.timer = null;
 yield;
 }
 if (compareEqual(b0.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail ran warp",}, b1, false, false, "L", null);
+runtime.ext_scratch3_looks._say("fail ran warp", target);
 }
 return ("non warp: " + ("" + p0));
 return "";

--- a/test/snapshot/__snapshots__/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
@@ -5,15 +5,14 @@
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["JbF5exWEi*m?-UEmkASS"];
 const b1 = stage.variables["[G/@.KGc-4y[(GZ(bt7o"];
-const b2 = runtime.getOpcodeFunction("looks_say");
-const b3 = runtime.getOpcodeFunction("sound_seteffectto");
+const b2 = runtime.getOpcodeFunction("sound_seteffectto");
 return function* genXYZ () {
 while (true) {
 if (compareEqual(b0.value, b1.value)) {
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "89/dl$1dp$~nj81:jj@H", null);
+runtime.ext_scratch3_looks._say("pass", target);
 b1.value = b0.value;
-yield* executeInCompatibilityLayer({"VALUE":b0.value,"EFFECT":"pitch",}, b3, false, true, "*=8r,g4Pzvxo?aSMcpfX", null);
+yield* executeInCompatibilityLayer({"VALUE":b0.value,"EFFECT":"pitch",}, b2, false, true, "*=8r,g4Pzvxo?aSMcpfX", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
 }
 yield;
@@ -24,16 +23,15 @@ retire(); return;
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["[G/@.KGc-4y[(GZ(bt7o"];
-const b1 = runtime.getOpcodeFunction("looks_say");
-const b2 = stage.variables["JbF5exWEi*m?-UEmkASS"];
+const b1 = stage.variables["JbF5exWEi*m?-UEmkASS"];
 return function* genXYZ () {
 b0.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b1, false, false, "0/2-)Gp^^=haQ1OMD.xb", null);
+runtime.ext_scratch3_looks._say("plan 15", target);
 for (var a0 = 15; a0 > 0; a0--) {
-if ((toNotNaN(+b2.value) === 200)) {
-b2.value = 50;
+if ((toNotNaN(+b1.value) === 200)) {
+b1.value = 50;
 } else {
-b2.value = 200;
+b1.value = 200;
 }
 thread.timer = timer();
 var a1 = Math.max(0, 1000 * 0);
@@ -45,7 +43,7 @@ yield;
 thread.timer = null;
 yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, "--nBRXyJfqS0MM9`#S3}", null);
+runtime.ext_scratch3_looks._say("end", target);
 runtime.stopAll();
 retire(); return;
 retire(); return;

--- a/test/snapshot/__snapshots__/tw-repeat-analysis-doesnt-reanalyze.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-repeat-analysis-doesnt-reanalyze.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 thread.procedures["Wa"]();
-if ((("" + b1.value).toLowerCase() === "bwah".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "l", null);
+if ((("" + b0.value).toLowerCase() === "bwah".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Text script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "a~", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 thread.procedures["Wtest 1"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "dh", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-restart-broadcast-threads.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-restart-broadcast-threads.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "aQ(Y!Bs3;[rV^Q%AQ,NX", null);
-b1.value = 0;
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 thread.timer = timer();
@@ -18,10 +17,10 @@ while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-if ((toNotNaN(+b1.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "`SX*FG*Lwo*0_T=box-@", null);
+if ((toNotNaN(+b0.value) === 1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "|#`zzPA_x%{`FyIAQhb4", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-rotate-by-decimal-without-leading-zero.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-rotate-by-decimal-without-leading-zero.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 target.setDirection(90);
 target.setDirection((target.direction + 0.25));
 target.setDirection((target.direction + 0.25));
 if ((target.direction === 90.5)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "i", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-safe-procedure-argument-casting.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-safe-procedure-argument-casting.sb3.tw-snapshot
@@ -3,18 +3,17 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "J#qm1yA(@Z6mj%Mgh;0X", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 thread.procedures["Zswitch %s"]("1");
 if ((((target.currentCostume + 1) === 2) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 1))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ";DM$.QW6o-O+T/oBdqt!", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 thread.procedures["Zswitch %s"]("2");
 if ((((target.currentCostume + 1) === 1) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 2))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "71a9Slk0w=^~x;5T@nw,", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "$R-1lb(Mu?gdTIH^;kC_", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
@@ -3,13 +3,12 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["G{NQ*NXG*qzywe1Q3?FM"];
-const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["G{NQ*NXG*qzywe1Q3?FM"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
 b1.value = 0;
-b2.value = 0;
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 retire(); return;
 }; })
@@ -18,7 +17,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 const b1 = stage.variables["G{NQ*NXG*qzywe1Q3?FM"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if (compareEqual(b0.value, 0)) {
 b0.value = 1;
@@ -30,9 +28,9 @@ yield;
 b1.value = 2;
 } else {
 if ((toNotNaN(+b1.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "p", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, "n", null);
+runtime.ext_scratch3_looks._say("end", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-sensing-of.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-sensing-of.sb3.tw-snapshot
@@ -3,112 +3,111 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage && stage.lookupVariableByNameAndType("Stage variable", "", true);
-const b2 = runtime.getSpriteTargetByName("Test sprite");
-const b3 = b2 && b2.lookupVariableByNameAndType("Private variable", "", true);
-const b4 = stage && stage.lookupVariableByNameAndType("This variable used to exist", "", true);
-const b5 = stage.variables["GTmK+*w8mNQP,z`4WG8#"];
-const b6 = runtime.getSpriteTargetByName("Sprite that doesn't exist");
+const b0 = stage && stage.lookupVariableByNameAndType("Stage variable", "", true);
+const b1 = runtime.getSpriteTargetByName("Test sprite");
+const b2 = b1 && b1.lookupVariableByNameAndType("Private variable", "", true);
+const b3 = stage && stage.lookupVariableByNameAndType("This variable used to exist", "", true);
+const b4 = stage.variables["GTmK+*w8mNQP,z`4WG8#"];
+const b5 = runtime.getSpriteTargetByName("Sprite that doesn't exist");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 32",}, b0, false, false, "oX(r}qUQo7fd[u~D_4@T", null);
+runtime.ext_scratch3_looks._say("plan 32", target);
 if (((stage.currentCostume + 1) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass backdrop #",}, b0, false, false, "T9..K[5LEO1f~{%eoPU;", null);
+runtime.ext_scratch3_looks._say("pass backdrop #", target);
 }
 if ((stage.getCostumes()[stage.currentCostume].name.toLowerCase() === "Backdrop name test".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass backdrop name",}, b0, false, false, "q63|^NKAu?OMK%W-s}+~", null);
+runtime.ext_scratch3_looks._say("pass backdrop name", target);
 }
 if (((stage ? stage.volume : 0) === 45)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass stage volume",}, b0, false, false, "9Coi(uM:DG!WPZ($,SnY", null);
+runtime.ext_scratch3_looks._say("pass stage volume", target);
 }
-if ((("" + (b1 ? b1.value : 0)).toLowerCase() === "Variable in stage".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass stage variable",}, b0, false, false, "D_EA]xN%|[NsTKqc4up9", null);
+if ((("" + (b0 ? b0.value : 0)).toLowerCase() === "Variable in stage".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass stage variable", target);
 }
-if (((b2 ? b2.x : 0) === 19)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass x",}, b0, false, false, "ek^n,6zjHyX;YOW;H@]?", null);
+if (((b1 ? b1.x : 0) === 19)) {
+runtime.ext_scratch3_looks._say("pass x", target);
 }
-if (((b2 ? b2.y : 0) === 20)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass y",}, b0, false, false, "-DZ%ny~~x.m12l9I64~W", null);
+if (((b1 ? b1.y : 0) === 20)) {
+runtime.ext_scratch3_looks._say("pass y", target);
 }
-if (((b2 ? b2.direction : 0) === 89)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass direction",}, b0, false, false, "$Y=E2o@3oa-^OHt5v:-b", null);
+if (((b1 ? b1.direction : 0) === 89)) {
+runtime.ext_scratch3_looks._say("pass direction", target);
 }
-if (((b2 ? b2.currentCostume + 1 : 0) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass costume #",}, b0, false, false, "+zO[+f?c7F`ZGTbD.oqI", null);
+if (((b1 ? b1.currentCostume + 1 : 0) === 3)) {
+runtime.ext_scratch3_looks._say("pass costume #", target);
 }
-if (((b2 ? b2.getCostumes()[b2.currentCostume].name : 0).toLowerCase() === "Costume name test".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass costume name",}, b0, false, false, "Y6L|T0Pvwsct2gq+HGvv", null);
+if (((b1 ? b1.getCostumes()[b1.currentCostume].name : 0).toLowerCase() === "Costume name test".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass costume name", target);
 }
-if (((b2 ? b2.size : 0) === 76.01)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass size",}, b0, false, false, "IBZv@o)qX~r6)!;hqaWa", null);
+if (((b1 ? b1.size : 0) === 76.01)) {
+runtime.ext_scratch3_looks._say("pass size", target);
 }
-if (((b2 ? b2.volume : 0) === 14.3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass volume",}, b0, false, false, "JBHJ,)N)@]~;;yFTY`RG", null);
+if (((b1 ? b1.volume : 0) === 14.3)) {
+runtime.ext_scratch3_looks._say("pass volume", target);
 }
-if ((("" + (b3 ? b3.value : 0)).toLowerCase() === "Private variable value".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass private variable",}, b0, false, false, "#jYbx])r8^`95~ZgPtZD", null);
+if ((("" + (b2 ? b2.value : 0)).toLowerCase() === "Private variable value".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass private variable", target);
 }
-if (compareEqual((b4 ? b4.value : 0), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent variable",}, b0, false, false, ")nnN?*l+E)dC(fT5(_@q", null);
+if (compareEqual((b3 ? b3.value : 0), 0)) {
+runtime.ext_scratch3_looks._say("pass non existent variable", target);
 }
-b5.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b5.value, PROPERTY: "backdrop #" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, "UFr{fbR3@a.u_paq:r]F", null);
+b4.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "backdrop #" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop #", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop name" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop name",}, b0, false, false, "wzVsIitt0^t(wDS-V3?Z", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "backdrop name" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop name", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "volume" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, ":SZx%]xR5t`;;@M~:jT:", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "volume" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE volume", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "Stage variable" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE stage variable",}, b0, false, false, "!eEjdEJj!yYb{buag^M[", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "Stage variable" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE stage variable", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "x position" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE x",}, b0, false, false, "!6!o,FiLV=w2bS~{R|AK", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "x position" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE x", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "y position" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE y",}, b0, false, false, "5K7_7*adzRDbfFjxanQF", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "y position" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE y", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "direction" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE direction",}, b0, false, false, "D{z)e;(*H|.gAykbuSkE", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "direction" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE direction", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "costume #" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE costume #",}, b0, false, false, "WgCH3j9ObHA,;P3T=now", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "costume #" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE costume #", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "costume name" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE costume name",}, b0, false, false, "qhxQy$^wiOTOEu.=2^i)", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "costume name" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE costume name", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "size" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE size",}, b0, false, false, "+6V.t=]xZ=Gl?%-OWbFy", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "size" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE size", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "volume" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, "*E:B}?C@H2ce2uRr9.9=", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "volume" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE volume", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "Private variable" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE private variable",}, b0, false, false, "B6r;3{7R7g4Z.pzeGiCM", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "Private variable" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE private variable", target);
 }
-if (((b6 ? b6.x : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, "q[X%xv.u6==Riu20?y{I", null);
+if (((b5 ? b5.x : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop #", target);
 }
-if (((b6 ? b6.y : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop name",}, b0, false, false, "?M4CH@e3~]30+$4[brH[", null);
+if (((b5 ? b5.y : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop name", target);
 }
-if (((b6 ? b6.direction : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, "H:D~v_)nZ?oJ8X|qHag#", null);
+if (((b5 ? b5.direction : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE volume", target);
 }
-if (((b6 ? b6.currentCostume + 1 : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE stage variable",}, b0, false, false, "lqwZ[26e,$PwYz,OlO0X", null);
+if (((b5 ? b5.currentCostume + 1 : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE stage variable", target);
 }
-if (compareEqual((b6 ? b6.getCostumes()[b6.currentCostume].name : 0), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE x",}, b0, false, false, "I@zdHi0kl|{:ze_J.}S_", null);
+if (compareEqual((b5 ? b5.getCostumes()[b5.currentCostume].name : 0), 0)) {
+runtime.ext_scratch3_looks._say("pass NE x", target);
 }
-if (((b6 ? b6.size : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE y",}, b0, false, false, "qD{Ni|{SL:`04:Gj/A7B", null);
+if (((b5 ? b5.size : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE y", target);
 }
-if (((b6 ? b6.volume : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE direction",}, b0, false, false, "vvB(iq@jjvj{=_{:6DXZ", null);
+if (((b5 ? b5.volume : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE direction", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "dJRK.)mKX6,r26Jy]5qr", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-simple-string-operations.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-simple-string-operations.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["PJl9-2GypE.OstQk*B_*"];
+const b0 = stage.variables["PJl9-2GypE.OstQk*B_*"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 thread.procedures["Wa"]();
-if ((b1.value.toLowerCase() === "babab".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "s", null);
+if ((b0.value.toLowerCase() === "babab".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "q", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-sound-menu-avoids-number-literal-if-name-conflict.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-sound-menu-avoids-number-literal-if-name-conflict.sb3.tw-snapshot
@@ -3,19 +3,18 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "f", null);
-b1.value = "5";
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = "5";
 runtime.ext_scratch3_looks._setCostume(target, "costume1");
 if (((target.currentCostume + 1) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass initial costume",}, b0, false, false, "p", null);
+runtime.ext_scratch3_looks._say("pass initial costume", target);
 }
-runtime.ext_scratch3_looks._setCostume(target, b1.value);
+runtime.ext_scratch3_looks._setCostume(target, b0.value);
 if (((target.currentCostume + 1) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass costume \"5\"",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass costume \"5\"", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-stage-cannot-move-layers.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-stage-cannot-move-layers.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "5,snC%48IW(1ZVM(k0l2", null);
-b1.value = "Initial";
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "Initial";
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * 0);
 runtime.requestRedraw();
@@ -17,17 +16,16 @@ yield;
 }
 thread.timer = null;
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test 1" }));
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "5.$W?rkoLYkKo1qX@%@?", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((("" + b0.value).toLowerCase() === "Initial".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b1, false, false, "eR%8T)3MQjkbQkAh~L0%", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-state-analysis-understands-stop-this-script.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-state-analysis-understands-stop-this-script.sb3.tw-snapshot
@@ -3,16 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["KMKx1gRubgLz,!L]^TBS"];
-const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["KMKx1gRubgLz,!L]^TBS"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 thread.procedures["Wtest"]();
-if ((("" + listGet(b1.value, b2.value)).toLowerCase() === "thing".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "m", null);
+if ((("" + listGet(b0.value, b1.value)).toLowerCase() === "thing".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-subtract-can-return-nan.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-subtract-can-return-nan.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "6_?4sPB-|g:DtjdOm5Q-", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (!((Infinity - Infinity) <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ")-u2YbbMb;gXMPOidjPj", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "zqE}hdaes.b)@mO1{R;X", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-tab-equals-zero.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-tab-equals-zero.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["Kl,Own0m6{^v3$E{Wsc="];
+const b0 = stage.variables["Kl,Own0m6{^v3$E{Wsc="];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, "i", null);
-b1.value = "\t";
+runtime.ext_scratch3_looks._say("plan 6", target);
+b0.value = "\t";
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 retire(); return;
 }; })
@@ -15,26 +14,25 @@ retire(); return;
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Kl,Own0m6{^v3$E{Wsc="];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if (compareEqual(b0.value, ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t in a variable = string 0",}, b1, false, false, "q", null);
+runtime.ext_scratch3_looks._say("pass \\t in a variable = string 0", target);
 }
 if (compareEqual("\t", ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass literal \\t = string 0",}, b1, false, false, "u", null);
+runtime.ext_scratch3_looks._say("pass literal \\t = string 0", target);
 }
 if (compareEqual(("    " + ("" + b0.value)), ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t and other spaces = string 0",}, b1, false, false, "w", null);
+runtime.ext_scratch3_looks._say("pass \\t and other spaces = string 0", target);
 }
 if (compareEqual(b0.value, (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t in a variable = number 0",}, b1, false, false, "z", null);
+runtime.ext_scratch3_looks._say("pass \\t in a variable = number 0", target);
 }
 if ((0 === (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass literal \\t = number 0",}, b1, false, false, "B", null);
+runtime.ext_scratch3_looks._say("pass literal \\t = number 0", target);
 }
 if (compareEqual(("    " + ("" + b0.value)), (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t and other spaces = number 0",}, b1, false, false, "E", null);
+runtime.ext_scratch3_looks._say("pass \\t and other spaces = number 0", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, "D", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-tangent.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-tangent.sb3.tw-snapshot
@@ -3,54 +3,53 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b0, false, false, "p", null);
+runtime.ext_scratch3_looks._say("plan 15", target);
 if (compareEqual(tan(0), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 0",}, b0, false, false, "O", null);
+runtime.ext_scratch3_looks._say("pass 0", target);
 }
 if ((toNotNaN(tan(90)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 90",}, b0, false, false, "G", null);
+runtime.ext_scratch3_looks._say("pass 90", target);
 }
 if (compareEqual(tan(180), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 180",}, b0, false, false, "I", null);
+runtime.ext_scratch3_looks._say("pass 180", target);
 }
 if ((toNotNaN(tan(270)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 270",}, b0, false, false, "K", null);
+runtime.ext_scratch3_looks._say("pass 270", target);
 }
 if (compareEqual(tan(360), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 360",}, b0, false, false, "M", null);
+runtime.ext_scratch3_looks._say("pass 360", target);
 }
 if ((toNotNaN(tan(450)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 450",}, b0, false, false, "Q", null);
+runtime.ext_scratch3_looks._say("pass 450", target);
 }
 if (compareEqual(tan(540), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 540",}, b0, false, false, "S", null);
+runtime.ext_scratch3_looks._say("pass 540", target);
 }
 if ((toNotNaN(tan(630)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 630",}, b0, false, false, "U", null);
+runtime.ext_scratch3_looks._say("pass 630", target);
 }
 if (compareEqual(tan(720), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 720",}, b0, false, false, "W", null);
+runtime.ext_scratch3_looks._say("pass 720", target);
 }
 if ((toNotNaN(tan(810)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 810",}, b0, false, false, "Y", null);
+runtime.ext_scratch3_looks._say("pass 810", target);
 }
 if ((toNotNaN(tan(-90)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -90",}, b0, false, false, "0", null);
+runtime.ext_scratch3_looks._say("pass -90", target);
 }
 if (compareEqual(tan(-180), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -180",}, b0, false, false, "2", null);
+runtime.ext_scratch3_looks._say("pass -180", target);
 }
 if ((toNotNaN(tan(-270)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -270",}, b0, false, false, "4", null);
+runtime.ext_scratch3_looks._say("pass -270", target);
 }
 if (compareEqual(tan(-360), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -360",}, b0, false, false, "6", null);
+runtime.ext_scratch3_looks._say("pass -360", target);
 }
 if ((toNotNaN(tan(-450)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -450",}, b0, false, false, "9", null);
+runtime.ext_scratch3_looks._say("pass -450", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "8", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-unsafe-equals.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-unsafe-equals.sb3.tw-snapshot
@@ -3,84 +3,81 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables[",OktMIwz{~bdgWnPEa8u"];
-const b2 = stage.variables["yfy(G`K5K^fJcXAfiN4i"];
+const b0 = stage.variables[",OktMIwz{~bdgWnPEa8u"];
+const b1 = stage.variables["yfy(G`K5K^fJcXAfiN4i"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 14",}, b0, false, false, "S8W[CSRh5A:[y8s/Ridj", null);
+runtime.ext_scratch3_looks._say("plan 14", target);
 if ((10 === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 1",}, b0, false, false, "1ove2a-$DQw7qy5PGdgq", null);
+runtime.ext_scratch3_looks._say("pass 1", target);
 }
 if ((10 === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, "@A5}x{mm-Gk?CVz3o0Yn", null);
+runtime.ext_scratch3_looks._say("pass 2", target);
 }
-b1.value = 10;
-if ((b1.value === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "Ul:BCck-}Fvdux~x#$${", null);
+b0.value = 10;
+if ((b0.value === 10)) {
+runtime.ext_scratch3_looks._say("pass 3", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, "8]2$7P)o#+#Lo]mFSBbx", null);
+if ((b0.value === 10)) {
+runtime.ext_scratch3_looks._say("pass 4", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 5",}, b0, false, false, "ZU^{OfKTg|+Au$$q0[]u", null);
+if ((b0.value === 10)) {
+runtime.ext_scratch3_looks._say("pass 5", target);
 }
 for (var a0 = 1; a0 > 0; a0--) {
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 6",}, b0, false, false, "HB+_IN}6=K[*ksxKXH0`", null);
+if ((toNotNaN(+b0.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 6", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 7",}, b0, false, false, ";73ODiwcp8IthYURTX;S", null);
+if ((toNotNaN(+b0.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 7", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 8",}, b0, false, true, "${[MFmBL-D*1rbas9Q89", null);
-if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+if ((toNotNaN(+b0.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 8", target);
 }
 yield;
 }
-b2.value = "010";
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 9",}, b0, false, false, "#.`@SBj!g-c0:_q/tMZo", null);
+b1.value = "010";
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 9", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 10",}, b0, false, false, "B`o?V6/q6g),/2w};a#y", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 10", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 11",}, b0, false, false, "TJ:#TkYBys*!RYiKLXb)", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 11", target);
 }
 for (var a1 = 1; a1 > 0; a1--) {
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 12",}, b0, false, false, ",Z,~10Qo~j;(+VL+I3q:", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 12", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 13",}, b0, false, false, "|Mqx([(26M%#ggW9)U0s", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 13", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 14",}, b0, false, true, "YvtiKF231lU8p5Qd97RP", null);
-if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 14", target);
 }
 yield;
 }
 if ((0 === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "yO!,nQodLC}uqIc?212+", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if ((1 === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "XzQt!.^A,SV?q0`Ui)wG", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if ((0 === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "rxZqw7cv8g;PDM4B%{`?", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if ((" ".toLowerCase() === "0".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "3G|)eVw1mQm;O~cRy`}0", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if (("0".toLowerCase() === " ".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "sd5xXX*tsW/~A_Q!0;^w", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if (("".toLowerCase() === "0".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "7**baE=].WD9OoY1+IEu", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if (("0".toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "7!IB!=o/2H.Jqj-8Vwhz", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "df{tf!WhfRwXgQ?SN_dj", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-wait-until-condition-gh-277.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-wait-until-condition-gh-277.sb3.tw-snapshot
@@ -3,16 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
-b1.value = "bwah";
-while (!(("" + b1.value).toLowerCase() === "bleh".toLowerCase())) {
+b0.value = "bwah";
+while (!(("" + b0.value).toLowerCase() === "bleh".toLowerCase())) {
 yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -3,23 +3,22 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables[";~q(!vt3c.Jrz2M]ZMy]"];
-const b2 = stage.variables[",23fjp~KN1aMG|;66K@Z"];
+const b0 = stage.variables[";~q(!vt3c.Jrz2M]ZMy]"];
+const b1 = stage.variables[",23fjp~KN1aMG|;66K@Z"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "j", null);
-b1.value = [];
-b1.value.push((1 + 2));
-b1._monitorUpToDate = false;
-b1.value.push((3 + 4));
-b1._monitorUpToDate = false;
-b1.value.push("final");
-b1._monitorUpToDate = false;
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = [];
+b0.value.push((1 + 2));
+b0._monitorUpToDate = false;
+b0.value.push((3 + 4));
+b0._monitorUpToDate = false;
+b0.value.push("final");
+b0._monitorUpToDate = false;
 thread.procedures["Wtest"]();
-if ((b2.value === 4)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "u", null);
+if ((b1.value === 4)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "t", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/tw-warp-repeat-until-timer-greater-than.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-warp-repeat-until-timer-greater-than.sb3.tw-snapshot
@@ -3,18 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wrun without screen refresh"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Wrun without screen refresh
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["F?*}X,`9XBpN_[piGRrz"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_run_without_screen_r () {
 b0.value = ((daysSince2000() * 86400) + 3);
 runtime.ioDevices.clock.resetProjectTimer();
@@ -22,7 +20,7 @@ while (!((runtime.ioDevices.clock.projectTimer() > 0.1) || compareGreaterThan((d
 if (isStuck()) yield;
 }
 if (compareLessThan((daysSince2000() * 86400), b0.value)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b1, true, false, "u", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/tw-when-backdrop-switches-to-next-backdrop.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-when-backdrop-switches-to-next-backdrop.sb3.tw-snapshot
@@ -3,17 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "Ny4npe`j3|CTeaIS.:6O", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "2T.vCF,K}vA=XNZ=kY+v", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 runtime.ext_scratch3_looks._setBackdrop(stage, stage.currentCostume + 1, true);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-when-backdrop-switches-to-switch-backdrop-to.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-when-backdrop-switches-to-switch-backdrop-to.sb3.tw-snapshot
@@ -3,17 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "Ny4npe`j3|CTeaIS.:6O", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "2T.vCF,K}vA=XNZ=kY+v", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 runtime.ext_scratch3_looks._setBackdrop(stage, "backdrop2");
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
@@ -3,19 +3,18 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
-const b2 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
+const b0 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
+const b1 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, ",a.euo_AgQTxR+D^x0M0", null);
-b1.value = 0;
-b2.value = "";
-while (!(("" + b2.value).toLowerCase() > "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
+b1.value = "";
+while (!(("" + b1.value).toLowerCase() > "".toLowerCase())) {
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "step" });
 yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "miAC8JZ$@akv[+}KR*@B", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "gXJU#lhy3A3XA_s[-Xs$", null);
+runtime.ext_scratch3_looks._say("pass", target);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/order-library-reverse.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/order-library-reverse.sb3.tw-snapshot
@@ -5,7 +5,6 @@
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-order"];
 const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -18,21 +17,20 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "]4hbk*5ix]V00h|!x1oy", null);
+runtime.ext_scratch3_looks._say("pass order is correct (1)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 1 != " + ("" + b0.value)),}, b2, false, false, "H=x@7SpNJeX|!}8x5y4,", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 1 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })
 
 // Sprite3 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
+const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "1Ba%a0GIK#hwJ46y=WVt", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a0 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -40,7 +38,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a1 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -48,14 +46,14 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a2 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
 yield;
 }
 thread.timer = null;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "}-I/zE+.RSi`:h[RxMvQ", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -63,7 +61,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["p]KODv+)+:l=%NT~j3/d-order"];
 const b1 = stage.variables["p]KODv+)+:l=%NT~j3/d-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -76,9 +73,9 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "0i[-T:vYTt=bi47@byUE", null);
+runtime.ext_scratch3_looks._say("pass order is correct (2)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 2 != " + ("" + b0.value)),}, b2, false, false, "Coc1aZ;L9M-RyEt`syps", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 2 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/order-library.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/order-library.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite3 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
+const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "s+@:|^WPr8]N1Y9Hk2f5", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 thread.timer = timer();
-var a0 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a0 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a0) {
@@ -16,7 +15,7 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a1 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a1 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a1) {
@@ -24,14 +23,14 @@ yield;
 }
 thread.timer = null;
 thread.timer = timer();
-var a2 = Math.max(0, 1000 * toNotNaN(+b1.value));
+var a2 = Math.max(0, 1000 * toNotNaN(+b0.value));
 runtime.requestRedraw();
 yield;
 while (thread.timer.timeElapsed() < a2) {
 yield;
 }
 thread.timer = null;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "7e7aA!PF-sxf1uka+sh2", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -39,7 +38,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-order"];
 const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -52,9 +50,9 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (1)",}, b2, false, false, "RSQ{nVCc)6E)(`KlnFCF", null);
+runtime.ext_scratch3_looks._say("pass order is correct (1)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 1 != " + ("" + b0.value)),}, b2, false, false, "8k^j~`c^|YO@hkFd?~2d", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 1 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })
@@ -63,7 +61,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["):/PVGTvoVRvq(ikGwRE-order"];
 const b1 = stage.variables["):/PVGTvoVRvq(ikGwRE-wait"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 b0.value = 0;
 thread.timer = timer();
@@ -76,9 +73,9 @@ yield;
 thread.timer = null;
 b0.value = (toNotNaN(+b0.value) + 1);
 if ((b0.value === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass order is correct (2)",}, b2, false, false, "KP?op(=Vg2#;@]!,C#.~", null);
+runtime.ext_scratch3_looks._say("pass order is correct (2)", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail order is incorrect 2 != " + ("" + b0.value)),}, b2, false, false, "=]|}L~4uQXTNtwJKw_;R", null);
+runtime.ext_scratch3_looks._say(("fail order is incorrect 2 != " + ("" + b0.value)), target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-NaN.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-NaN.sb3.tw-snapshot
@@ -3,72 +3,71 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 21",}, b0, false, false, "B", null);
+runtime.ext_scratch3_looks._say("plan 21", target);
 if (!(("" + (0 / 0)).toLowerCase() === "0".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aA", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + (0 * Infinity)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "/", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((0 * Infinity)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "?", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + ((Math.acos(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "=", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(((Math.acos(1.01) * 180) / Math.PI)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "]", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + ((Math.asin(1.01) * 180) / Math.PI)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "_", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(((Math.asin(1.01) * 180) / Math.PI)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "{", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + (0 / 0)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "}", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((0 / 0)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aa", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + Math.sqrt(-1)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ac", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(Math.sqrt(-1)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ae", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ag", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(mod(0, 0)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ai", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ak", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(Math.log(-1)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "am", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + (Math.log(-1) / Math.LN10)).toLowerCase() === "NaN".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ao", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((Math.log(-1) / Math.LN10)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aq", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((Math.round(Math.sin((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "as", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN((Math.round(Math.cos((Math.PI * (1 / 0)) / 180) * 1e10) / 1e10)) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "au", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(tan((1 / 0))) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "aw", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((toNotNaN(runtime.ext_scratch3_operators._random((-1 / 0), (1 / 0))) * 1) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "ax", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ":", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-add-can-return-nan.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-add-can-return-nan.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "6_?4sPB-|g:DtjdOm5Q-", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (!((Infinity + -Infinity) <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ")-u2YbbMb;gXMPOidjPj", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "zqE}hdaes.b)@mO1{R;X", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-all-at-once.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-all-at-once.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "1TRvh{mBarwY!BX8`o$R", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (true) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "K|r`QjC126S.93lMawiD", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "QaZ%(g:;bB~D+24z:U?l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-analyze-yields-due-to-direct-recursion.sb3.tw-snapshot
@@ -3,17 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "j", null);
-b1.value = (1 + 2);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (1 + 2);
 yield* thread.procedures["Znon-warp recursion %s"](2);
-if ((("" + listGet(b2.value, b1.value)).toLowerCase() === "the only thing".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "t", null);
+if ((("" + listGet(b1.value, b0.value)).toLowerCase() === "the only thing".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-automatic-variable-creation-literal-null-id.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-automatic-variable-creation-literal-null-id.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = target.variables["null"];
+const b0 = target.variables["null"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "a", null);
-b1.value = 5;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
+b0.value = 5;
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-block-with-null-for-variable-id.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-block-with-null-for-variable-id.sb3.tw-snapshot
@@ -3,26 +3,24 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "c", null);
-b1.value = 1;
-b2.value = 2;
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = 1;
+b1.value = 2;
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "check 1" }));
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "check 2" }));
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((toNotNaN(+b0.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 1",}, b1, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass variable 1", target);
 }
 retire(); return;
 }; })
@@ -30,10 +28,9 @@ retire(); return;
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables[")|GMR5fz;%F_H,c0wGVM"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((toNotNaN(+b0.value) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass variable 2",}, b1, false, false, "q", null);
+runtime.ext_scratch3_looks._say("pass variable 2", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-boolean-arguments-are-not-cast.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-boolean-arguments-are-not-cast.sb3.tw-snapshot
@@ -3,22 +3,20 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "f", null);
-yield* thread.procedures["ZBlock A %s"]("Hai!!!");
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+thread.procedures["ZBlock A %s"]("Hai!!!");
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 ZBlock A %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_Block_A_ (p0) {
+return function funXYZ_Block_A_ (p0) {
 if ((("" + p0).toLowerCase() === "Hai!!!".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass did not cast",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass did not cast", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail was casted",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("fail was casted", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-broadcast-id-and-name-desync.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-broadcast-id-and-name-desync.sb3.tw-snapshot
@@ -3,18 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "?@x?KlY[GHB#^le;O^;Z", null);
+runtime.ext_scratch3_looks._say("pass", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "*S!`s:/sOEm#Bd%7=h7E", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" }));
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "g#w*ISI)$Wi.45AszY|1", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-change-size-does-not-use-rounded-size.sb3.tw-snapshot
@@ -3,20 +3,19 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "()*H*UE)$Jc!c}qb{,O)", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 target.setSize(96);
-b1.value = 0;
+b0.value = 0;
 while (!(100 === Math.round(target.size))) {
-b1.value = (toNotNaN(+b1.value) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 target.setSize(target.size + ((100 - Math.round(target.size)) / 10));
 yield;
 }
-if ((toNotNaN(+b1.value) === 20)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "FPDFR?Wwq)kLj0A$0D{@", null);
+if ((toNotNaN(+b0.value) === 20)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "1,vLoJ4OQBv+Q#$VoYf=", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-color-input-returns-hex.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-color-input-returns-hex.sb3.tw-snapshot
@@ -3,14 +3,13 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
-b1.value = "#22388a";
-if ((b1.value.toLowerCase() === "#22388a".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "f", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "#22388a";
+if ((b0.value.toLowerCase() === "#22388a".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-comparison-matrix-inline.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-comparison-matrix-inline.sb3.tw-snapshot
@@ -3,1773 +3,1772 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "f)", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 1: 0 should be < 0",}, b0, false, false, "tB", null);
+runtime.ext_scratch3_looks._say("fail 1: 0 should be < 0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 2: 0 should be = 0",}, b0, false, false, "tD", null);
+runtime.ext_scratch3_looks._say("fail 2: 0 should be = 0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 3: 0 should be > 0",}, b0, false, false, "tF", null);
+runtime.ext_scratch3_looks._say("fail 3: 0 should be > 0", target);
 }
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 4: 0 should be < 0.0",}, b0, false, false, "tH", null);
+runtime.ext_scratch3_looks._say("fail 4: 0 should be < 0.0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 5: 0 should be = 0.0",}, b0, false, false, "tJ", null);
+runtime.ext_scratch3_looks._say("fail 5: 0 should be = 0.0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 6: 0 should be > 0.0",}, b0, false, false, "tL", null);
+runtime.ext_scratch3_looks._say("fail 6: 0 should be > 0.0", target);
 }
 if (!(("" + (0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 7: 0 should be < 1.23",}, b0, false, false, "tN", null);
+runtime.ext_scratch3_looks._say("fail 7: 0 should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 8: 0 should be = 1.23",}, b0, false, false, "tP", null);
+runtime.ext_scratch3_looks._say("fail 8: 0 should be = 1.23", target);
 }
 if (!(("" + (0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 9: 0 should be > 1.23",}, b0, false, false, "tR", null);
+runtime.ext_scratch3_looks._say("fail 9: 0 should be > 1.23", target);
 }
 if (!(("" + (0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 10: 0 should be < .23",}, b0, false, false, "tT", null);
+runtime.ext_scratch3_looks._say("fail 10: 0 should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 11: 0 should be = .23",}, b0, false, false, "tV", null);
+runtime.ext_scratch3_looks._say("fail 11: 0 should be = .23", target);
 }
 if (!(("" + (0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 12: 0 should be > .23",}, b0, false, false, "tX", null);
+runtime.ext_scratch3_looks._say("fail 12: 0 should be > .23", target);
 }
 if (!(("" + (0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 13: 0 should be < 0.123",}, b0, false, false, "tZ", null);
+runtime.ext_scratch3_looks._say("fail 13: 0 should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 14: 0 should be = 0.123",}, b0, false, false, "t1", null);
+runtime.ext_scratch3_looks._say("fail 14: 0 should be = 0.123", target);
 }
 if (!(("" + (0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 15: 0 should be > 0.123",}, b0, false, false, "t3", null);
+runtime.ext_scratch3_looks._say("fail 15: 0 should be > 0.123", target);
 }
 if (!(("" + (0 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 16: 0 should be < -0",}, b0, false, false, "t5", null);
+runtime.ext_scratch3_looks._say("fail 16: 0 should be < -0", target);
 }
 if (!(("" + (0 === -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 17: 0 should be = -0",}, b0, false, false, "t7", null);
+runtime.ext_scratch3_looks._say("fail 17: 0 should be = -0", target);
 }
 if (!(("" + (0 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 18: 0 should be > -0",}, b0, false, false, "t9", null);
+runtime.ext_scratch3_looks._say("fail 18: 0 should be > -0", target);
 }
 if (!(("" + (0 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 19: 0 should be < -1",}, b0, false, false, "t#", null);
+runtime.ext_scratch3_looks._say("fail 19: 0 should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 20: 0 should be = -1",}, b0, false, false, "t(", null);
+runtime.ext_scratch3_looks._say("fail 20: 0 should be = -1", target);
 }
 if (!(("" + (0 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 21: 0 should be > -1",}, b0, false, false, "t*", null);
+runtime.ext_scratch3_looks._say("fail 21: 0 should be > -1", target);
 }
 if (!(("" + ("0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 22: 0 should be < true",}, b0, false, false, "t,", null);
+runtime.ext_scratch3_looks._say("fail 22: 0 should be < true", target);
 }
 if (!(("" + ("0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 23: 0 should be = true",}, b0, false, false, "t.", null);
+runtime.ext_scratch3_looks._say("fail 23: 0 should be = true", target);
 }
 if (!(("" + ("0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 24: 0 should be > true",}, b0, false, false, "t:", null);
+runtime.ext_scratch3_looks._say("fail 24: 0 should be > true", target);
 }
 if (!(("" + ("0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 25: 0 should be < false",}, b0, false, false, "t=", null);
+runtime.ext_scratch3_looks._say("fail 25: 0 should be < false", target);
 }
 if (!(("" + ("0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 26: 0 should be = false",}, b0, false, false, "t@", null);
+runtime.ext_scratch3_looks._say("fail 26: 0 should be = false", target);
 }
 if (!(("" + ("0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 27: 0 should be > false",}, b0, false, false, "t]", null);
+runtime.ext_scratch3_looks._say("fail 27: 0 should be > false", target);
 }
 if (!(("" + ("0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 28: 0 should be < NaN",}, b0, false, false, "t_", null);
+runtime.ext_scratch3_looks._say("fail 28: 0 should be < NaN", target);
 }
 if (!(("" + ("0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 29: 0 should be = NaN",}, b0, false, false, "t{", null);
+runtime.ext_scratch3_looks._say("fail 29: 0 should be = NaN", target);
 }
 if (!(("" + ("0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 30: 0 should be > NaN",}, b0, false, false, "t}", null);
+runtime.ext_scratch3_looks._say("fail 30: 0 should be > NaN", target);
 }
 if (!(("" + (0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 31: 0 should be < Infinity",}, b0, false, false, "ua", null);
+runtime.ext_scratch3_looks._say("fail 31: 0 should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 32: 0 should be = Infinity",}, b0, false, false, "uc", null);
+runtime.ext_scratch3_looks._say("fail 32: 0 should be = Infinity", target);
 }
 if (!(("" + (0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 33: 0 should be > Infinity",}, b0, false, false, "ue", null);
+runtime.ext_scratch3_looks._say("fail 33: 0 should be > Infinity", target);
 }
 if (!(("" + ("0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 34: 0 should be < banana",}, b0, false, false, "ug", null);
+runtime.ext_scratch3_looks._say("fail 34: 0 should be < banana", target);
 }
 if (!(("" + ("0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 35: 0 should be = banana",}, b0, false, false, "ui", null);
+runtime.ext_scratch3_looks._say("fail 35: 0 should be = banana", target);
 }
 if (!(("" + ("0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 36: 0 should be > banana",}, b0, false, false, "uk", null);
+runtime.ext_scratch3_looks._say("fail 36: 0 should be > banana", target);
 }
 if (!(("" + ("0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 37: 0 should be < 🎉",}, b0, false, false, "um", null);
+runtime.ext_scratch3_looks._say("fail 37: 0 should be < 🎉", target);
 }
 if (!(("" + ("0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 38: 0 should be = 🎉",}, b0, false, false, "uo", null);
+runtime.ext_scratch3_looks._say("fail 38: 0 should be = 🎉", target);
 }
 if (!(("" + ("0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 39: 0 should be > 🎉",}, b0, false, false, "uq", null);
+runtime.ext_scratch3_looks._say("fail 39: 0 should be > 🎉", target);
 }
 if (!(("" + ("0".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 40: 0 should be < ",}, b0, false, false, "us", null);
+runtime.ext_scratch3_looks._say("fail 40: 0 should be < ", target);
 }
 if (!(("" + ("0".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 41: 0 should be = ",}, b0, false, false, "uu", null);
+runtime.ext_scratch3_looks._say("fail 41: 0 should be = ", target);
 }
 if (!(("" + ("0".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 42: 0 should be > ",}, b0, false, false, "uw", null);
+runtime.ext_scratch3_looks._say("fail 42: 0 should be > ", target);
 }
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 43: 0.0 should be < 0",}, b0, false, false, "uy", null);
+runtime.ext_scratch3_looks._say("fail 43: 0.0 should be < 0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 44: 0.0 should be = 0",}, b0, false, false, "uA", null);
+runtime.ext_scratch3_looks._say("fail 44: 0.0 should be = 0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 45: 0.0 should be > 0",}, b0, false, false, "uC", null);
+runtime.ext_scratch3_looks._say("fail 45: 0.0 should be > 0", target);
 }
 if (!(("" + (0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 46: 0.0 should be < 0.0",}, b0, false, false, "uE", null);
+runtime.ext_scratch3_looks._say("fail 46: 0.0 should be < 0.0", target);
 }
 if (!(("" + (0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 47: 0.0 should be = 0.0",}, b0, false, false, "uG", null);
+runtime.ext_scratch3_looks._say("fail 47: 0.0 should be = 0.0", target);
 }
 if (!(("" + (0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 48: 0.0 should be > 0.0",}, b0, false, false, "uI", null);
+runtime.ext_scratch3_looks._say("fail 48: 0.0 should be > 0.0", target);
 }
 if (!(("" + (0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 49: 0.0 should be < 1.23",}, b0, false, false, "uK", null);
+runtime.ext_scratch3_looks._say("fail 49: 0.0 should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 50: 0.0 should be = 1.23",}, b0, false, false, "uM", null);
+runtime.ext_scratch3_looks._say("fail 50: 0.0 should be = 1.23", target);
 }
 if (!(("" + (0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 51: 0.0 should be > 1.23",}, b0, false, false, "uO", null);
+runtime.ext_scratch3_looks._say("fail 51: 0.0 should be > 1.23", target);
 }
 if (!(("" + (0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 52: 0.0 should be < .23",}, b0, false, false, "uQ", null);
+runtime.ext_scratch3_looks._say("fail 52: 0.0 should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 53: 0.0 should be = .23",}, b0, false, false, "uS", null);
+runtime.ext_scratch3_looks._say("fail 53: 0.0 should be = .23", target);
 }
 if (!(("" + (0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 54: 0.0 should be > .23",}, b0, false, false, "uU", null);
+runtime.ext_scratch3_looks._say("fail 54: 0.0 should be > .23", target);
 }
 if (!(("" + (0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 55: 0.0 should be < 0.123",}, b0, false, false, "uW", null);
+runtime.ext_scratch3_looks._say("fail 55: 0.0 should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 56: 0.0 should be = 0.123",}, b0, false, false, "uY", null);
+runtime.ext_scratch3_looks._say("fail 56: 0.0 should be = 0.123", target);
 }
 if (!(("" + (0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 57: 0.0 should be > 0.123",}, b0, false, false, "u0", null);
+runtime.ext_scratch3_looks._say("fail 57: 0.0 should be > 0.123", target);
 }
 if (!(("" + (0 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 58: 0.0 should be < -0",}, b0, false, false, "u2", null);
+runtime.ext_scratch3_looks._say("fail 58: 0.0 should be < -0", target);
 }
 if (!(("" + (0 === -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 59: 0.0 should be = -0",}, b0, false, false, "u4", null);
+runtime.ext_scratch3_looks._say("fail 59: 0.0 should be = -0", target);
 }
 if (!(("" + (0 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 60: 0.0 should be > -0",}, b0, false, false, "u6", null);
+runtime.ext_scratch3_looks._say("fail 60: 0.0 should be > -0", target);
 }
 if (!(("" + (0 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 61: 0.0 should be < -1",}, b0, false, false, "u8", null);
+runtime.ext_scratch3_looks._say("fail 61: 0.0 should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 62: 0.0 should be = -1",}, b0, false, false, "u!", null);
+runtime.ext_scratch3_looks._say("fail 62: 0.0 should be = -1", target);
 }
 if (!(("" + (0 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 63: 0.0 should be > -1",}, b0, false, false, "u%", null);
+runtime.ext_scratch3_looks._say("fail 63: 0.0 should be > -1", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 64: 0.0 should be < true",}, b0, false, false, "u)", null);
+runtime.ext_scratch3_looks._say("fail 64: 0.0 should be < true", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 65: 0.0 should be = true",}, b0, false, false, "u+", null);
+runtime.ext_scratch3_looks._say("fail 65: 0.0 should be = true", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 66: 0.0 should be > true",}, b0, false, false, "u-", null);
+runtime.ext_scratch3_looks._say("fail 66: 0.0 should be > true", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 67: 0.0 should be < false",}, b0, false, false, "u/", null);
+runtime.ext_scratch3_looks._say("fail 67: 0.0 should be < false", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 68: 0.0 should be = false",}, b0, false, false, "u;", null);
+runtime.ext_scratch3_looks._say("fail 68: 0.0 should be = false", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 69: 0.0 should be > false",}, b0, false, false, "u?", null);
+runtime.ext_scratch3_looks._say("fail 69: 0.0 should be > false", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 70: 0.0 should be < NaN",}, b0, false, false, "u[", null);
+runtime.ext_scratch3_looks._say("fail 70: 0.0 should be < NaN", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 71: 0.0 should be = NaN",}, b0, false, false, "u^", null);
+runtime.ext_scratch3_looks._say("fail 71: 0.0 should be = NaN", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 72: 0.0 should be > NaN",}, b0, false, false, "u`", null);
+runtime.ext_scratch3_looks._say("fail 72: 0.0 should be > NaN", target);
 }
 if (!(("" + (0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 73: 0.0 should be < Infinity",}, b0, false, false, "u|", null);
+runtime.ext_scratch3_looks._say("fail 73: 0.0 should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 74: 0.0 should be = Infinity",}, b0, false, false, "u~", null);
+runtime.ext_scratch3_looks._say("fail 74: 0.0 should be = Infinity", target);
 }
 if (!(("" + (0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 75: 0.0 should be > Infinity",}, b0, false, false, "vb", null);
+runtime.ext_scratch3_looks._say("fail 75: 0.0 should be > Infinity", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 76: 0.0 should be < banana",}, b0, false, false, "vd", null);
+runtime.ext_scratch3_looks._say("fail 76: 0.0 should be < banana", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 77: 0.0 should be = banana",}, b0, false, false, "vf", null);
+runtime.ext_scratch3_looks._say("fail 77: 0.0 should be = banana", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 78: 0.0 should be > banana",}, b0, false, false, "vh", null);
+runtime.ext_scratch3_looks._say("fail 78: 0.0 should be > banana", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 79: 0.0 should be < 🎉",}, b0, false, false, "vj", null);
+runtime.ext_scratch3_looks._say("fail 79: 0.0 should be < 🎉", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 80: 0.0 should be = 🎉",}, b0, false, false, "vl", null);
+runtime.ext_scratch3_looks._say("fail 80: 0.0 should be = 🎉", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 81: 0.0 should be > 🎉",}, b0, false, false, "vn", null);
+runtime.ext_scratch3_looks._say("fail 81: 0.0 should be > 🎉", target);
 }
 if (!(("" + ("0.0".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 82: 0.0 should be < ",}, b0, false, false, "vp", null);
+runtime.ext_scratch3_looks._say("fail 82: 0.0 should be < ", target);
 }
 if (!(("" + ("0.0".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 83: 0.0 should be = ",}, b0, false, false, "vr", null);
+runtime.ext_scratch3_looks._say("fail 83: 0.0 should be = ", target);
 }
 if (!(("" + ("0.0".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 84: 0.0 should be > ",}, b0, false, false, "vt", null);
+runtime.ext_scratch3_looks._say("fail 84: 0.0 should be > ", target);
 }
 if (!(("" + (1.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 85: 1.23 should be < 0",}, b0, false, false, "vv", null);
+runtime.ext_scratch3_looks._say("fail 85: 1.23 should be < 0", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 86: 1.23 should be = 0",}, b0, false, false, "vx", null);
+runtime.ext_scratch3_looks._say("fail 86: 1.23 should be = 0", target);
 }
 if (!(("" + (1.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 87: 1.23 should be > 0",}, b0, false, false, "vz", null);
+runtime.ext_scratch3_looks._say("fail 87: 1.23 should be > 0", target);
 }
 if (!(("" + (1.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 88: 1.23 should be < 0.0",}, b0, false, false, "vB", null);
+runtime.ext_scratch3_looks._say("fail 88: 1.23 should be < 0.0", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 89: 1.23 should be = 0.0",}, b0, false, false, "vD", null);
+runtime.ext_scratch3_looks._say("fail 89: 1.23 should be = 0.0", target);
 }
 if (!(("" + (1.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 90: 1.23 should be > 0.0",}, b0, false, false, "vF", null);
+runtime.ext_scratch3_looks._say("fail 90: 1.23 should be > 0.0", target);
 }
 if (!(("" + (1.23 < 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 91: 1.23 should be < 1.23",}, b0, false, false, "vH", null);
+runtime.ext_scratch3_looks._say("fail 91: 1.23 should be < 1.23", target);
 }
 if (!(("" + (1.23 === 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 92: 1.23 should be = 1.23",}, b0, false, false, "vJ", null);
+runtime.ext_scratch3_looks._say("fail 92: 1.23 should be = 1.23", target);
 }
 if (!(("" + (1.23 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 93: 1.23 should be > 1.23",}, b0, false, false, "vL", null);
+runtime.ext_scratch3_looks._say("fail 93: 1.23 should be > 1.23", target);
 }
 if (!(("" + (1.23 < 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 94: 1.23 should be < .23",}, b0, false, false, "vN", null);
+runtime.ext_scratch3_looks._say("fail 94: 1.23 should be < .23", target);
 }
 if (!(("" + (1.23 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 95: 1.23 should be = .23",}, b0, false, false, "vP", null);
+runtime.ext_scratch3_looks._say("fail 95: 1.23 should be = .23", target);
 }
 if (!(("" + (1.23 > 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 96: 1.23 should be > .23",}, b0, false, false, "vR", null);
+runtime.ext_scratch3_looks._say("fail 96: 1.23 should be > .23", target);
 }
 if (!(("" + (1.23 < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 97: 1.23 should be < 0.123",}, b0, false, false, "vT", null);
+runtime.ext_scratch3_looks._say("fail 97: 1.23 should be < 0.123", target);
 }
 if (!(("" + (1.23 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 98: 1.23 should be = 0.123",}, b0, false, false, "vV", null);
+runtime.ext_scratch3_looks._say("fail 98: 1.23 should be = 0.123", target);
 }
 if (!(("" + (1.23 > 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 99: 1.23 should be > 0.123",}, b0, false, false, "vX", null);
+runtime.ext_scratch3_looks._say("fail 99: 1.23 should be > 0.123", target);
 }
 if (!(("" + (1.23 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 100: 1.23 should be < -0",}, b0, false, false, "vZ", null);
+runtime.ext_scratch3_looks._say("fail 100: 1.23 should be < -0", target);
 }
 if (!(("" + (1.23 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 101: 1.23 should be = -0",}, b0, false, false, "v1", null);
+runtime.ext_scratch3_looks._say("fail 101: 1.23 should be = -0", target);
 }
 if (!(("" + (1.23 > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 102: 1.23 should be > -0",}, b0, false, false, "v3", null);
+runtime.ext_scratch3_looks._say("fail 102: 1.23 should be > -0", target);
 }
 if (!(("" + (1.23 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 103: 1.23 should be < -1",}, b0, false, false, "v5", null);
+runtime.ext_scratch3_looks._say("fail 103: 1.23 should be < -1", target);
 }
 if (!(("" + (1.23 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 104: 1.23 should be = -1",}, b0, false, false, "v7", null);
+runtime.ext_scratch3_looks._say("fail 104: 1.23 should be = -1", target);
 }
 if (!(("" + (1.23 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 105: 1.23 should be > -1",}, b0, false, false, "v9", null);
+runtime.ext_scratch3_looks._say("fail 105: 1.23 should be > -1", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 106: 1.23 should be < true",}, b0, false, false, "v#", null);
+runtime.ext_scratch3_looks._say("fail 106: 1.23 should be < true", target);
 }
 if (!(("" + (1.23 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 107: 1.23 should be = true",}, b0, false, false, "v(", null);
+runtime.ext_scratch3_looks._say("fail 107: 1.23 should be = true", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 108: 1.23 should be > true",}, b0, false, false, "v*", null);
+runtime.ext_scratch3_looks._say("fail 108: 1.23 should be > true", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 109: 1.23 should be < false",}, b0, false, false, "v,", null);
+runtime.ext_scratch3_looks._say("fail 109: 1.23 should be < false", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 110: 1.23 should be = false",}, b0, false, false, "v.", null);
+runtime.ext_scratch3_looks._say("fail 110: 1.23 should be = false", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 111: 1.23 should be > false",}, b0, false, false, "v:", null);
+runtime.ext_scratch3_looks._say("fail 111: 1.23 should be > false", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 112: 1.23 should be < NaN",}, b0, false, false, "v=", null);
+runtime.ext_scratch3_looks._say("fail 112: 1.23 should be < NaN", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 113: 1.23 should be = NaN",}, b0, false, false, "v@", null);
+runtime.ext_scratch3_looks._say("fail 113: 1.23 should be = NaN", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 114: 1.23 should be > NaN",}, b0, false, false, "v]", null);
+runtime.ext_scratch3_looks._say("fail 114: 1.23 should be > NaN", target);
 }
 if (!(("" + (1.23 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 115: 1.23 should be < Infinity",}, b0, false, false, "v_", null);
+runtime.ext_scratch3_looks._say("fail 115: 1.23 should be < Infinity", target);
 }
 if (!(("" + (1.23 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 116: 1.23 should be = Infinity",}, b0, false, false, "v{", null);
+runtime.ext_scratch3_looks._say("fail 116: 1.23 should be = Infinity", target);
 }
 if (!(("" + (1.23 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 117: 1.23 should be > Infinity",}, b0, false, false, "v}", null);
+runtime.ext_scratch3_looks._say("fail 117: 1.23 should be > Infinity", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 118: 1.23 should be < banana",}, b0, false, false, "wa", null);
+runtime.ext_scratch3_looks._say("fail 118: 1.23 should be < banana", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 119: 1.23 should be = banana",}, b0, false, false, "wc", null);
+runtime.ext_scratch3_looks._say("fail 119: 1.23 should be = banana", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 120: 1.23 should be > banana",}, b0, false, false, "we", null);
+runtime.ext_scratch3_looks._say("fail 120: 1.23 should be > banana", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 121: 1.23 should be < 🎉",}, b0, false, false, "wg", null);
+runtime.ext_scratch3_looks._say("fail 121: 1.23 should be < 🎉", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 122: 1.23 should be = 🎉",}, b0, false, false, "wi", null);
+runtime.ext_scratch3_looks._say("fail 122: 1.23 should be = 🎉", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 123: 1.23 should be > 🎉",}, b0, false, false, "wk", null);
+runtime.ext_scratch3_looks._say("fail 123: 1.23 should be > 🎉", target);
 }
 if (!(("" + ("1.23".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 124: 1.23 should be < ",}, b0, false, false, "wm", null);
+runtime.ext_scratch3_looks._say("fail 124: 1.23 should be < ", target);
 }
 if (!(("" + (1.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 125: 1.23 should be = ",}, b0, false, false, "wo", null);
+runtime.ext_scratch3_looks._say("fail 125: 1.23 should be = ", target);
 }
 if (!(("" + ("1.23".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 126: 1.23 should be > ",}, b0, false, false, "wq", null);
+runtime.ext_scratch3_looks._say("fail 126: 1.23 should be > ", target);
 }
 if (!(("" + (0.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 127: .23 should be < 0",}, b0, false, false, "ws", null);
+runtime.ext_scratch3_looks._say("fail 127: .23 should be < 0", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 128: .23 should be = 0",}, b0, false, false, "wu", null);
+runtime.ext_scratch3_looks._say("fail 128: .23 should be = 0", target);
 }
 if (!(("" + (0.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 129: .23 should be > 0",}, b0, false, false, "ww", null);
+runtime.ext_scratch3_looks._say("fail 129: .23 should be > 0", target);
 }
 if (!(("" + (0.23 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 130: .23 should be < 0.0",}, b0, false, false, "wy", null);
+runtime.ext_scratch3_looks._say("fail 130: .23 should be < 0.0", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 131: .23 should be = 0.0",}, b0, false, false, "wA", null);
+runtime.ext_scratch3_looks._say("fail 131: .23 should be = 0.0", target);
 }
 if (!(("" + (0.23 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 132: .23 should be > 0.0",}, b0, false, false, "wC", null);
+runtime.ext_scratch3_looks._say("fail 132: .23 should be > 0.0", target);
 }
 if (!(("" + (0.23 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 133: .23 should be < 1.23",}, b0, false, false, "wE", null);
+runtime.ext_scratch3_looks._say("fail 133: .23 should be < 1.23", target);
 }
 if (!(("" + (0.23 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 134: .23 should be = 1.23",}, b0, false, false, "wG", null);
+runtime.ext_scratch3_looks._say("fail 134: .23 should be = 1.23", target);
 }
 if (!(("" + (0.23 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 135: .23 should be > 1.23",}, b0, false, false, "wI", null);
+runtime.ext_scratch3_looks._say("fail 135: .23 should be > 1.23", target);
 }
 if (!(("" + (0.23 < 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 136: .23 should be < .23",}, b0, false, false, "wK", null);
+runtime.ext_scratch3_looks._say("fail 136: .23 should be < .23", target);
 }
 if (!(("" + (0.23 === 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 137: .23 should be = .23",}, b0, false, false, "wM", null);
+runtime.ext_scratch3_looks._say("fail 137: .23 should be = .23", target);
 }
 if (!(("" + (0.23 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 138: .23 should be > .23",}, b0, false, false, "wO", null);
+runtime.ext_scratch3_looks._say("fail 138: .23 should be > .23", target);
 }
 if (!(("" + (0.23 < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 139: .23 should be < 0.123",}, b0, false, false, "wQ", null);
+runtime.ext_scratch3_looks._say("fail 139: .23 should be < 0.123", target);
 }
 if (!(("" + (0.23 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 140: .23 should be = 0.123",}, b0, false, false, "wS", null);
+runtime.ext_scratch3_looks._say("fail 140: .23 should be = 0.123", target);
 }
 if (!(("" + (0.23 > 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 141: .23 should be > 0.123",}, b0, false, false, "wU", null);
+runtime.ext_scratch3_looks._say("fail 141: .23 should be > 0.123", target);
 }
 if (!(("" + (0.23 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 142: .23 should be < -0",}, b0, false, false, "wW", null);
+runtime.ext_scratch3_looks._say("fail 142: .23 should be < -0", target);
 }
 if (!(("" + (0.23 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 143: .23 should be = -0",}, b0, false, false, "wY", null);
+runtime.ext_scratch3_looks._say("fail 143: .23 should be = -0", target);
 }
 if (!(("" + (0.23 > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 144: .23 should be > -0",}, b0, false, false, "w0", null);
+runtime.ext_scratch3_looks._say("fail 144: .23 should be > -0", target);
 }
 if (!(("" + (0.23 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 145: .23 should be < -1",}, b0, false, false, "w2", null);
+runtime.ext_scratch3_looks._say("fail 145: .23 should be < -1", target);
 }
 if (!(("" + (0.23 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 146: .23 should be = -1",}, b0, false, false, "w4", null);
+runtime.ext_scratch3_looks._say("fail 146: .23 should be = -1", target);
 }
 if (!(("" + (0.23 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 147: .23 should be > -1",}, b0, false, false, "w6", null);
+runtime.ext_scratch3_looks._say("fail 147: .23 should be > -1", target);
 }
 if (!(("" + (".23".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 148: .23 should be < true",}, b0, false, false, "w8", null);
+runtime.ext_scratch3_looks._say("fail 148: .23 should be < true", target);
 }
 if (!(("" + (0.23 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 149: .23 should be = true",}, b0, false, false, "w!", null);
+runtime.ext_scratch3_looks._say("fail 149: .23 should be = true", target);
 }
 if (!(("" + (".23".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 150: .23 should be > true",}, b0, false, false, "w%", null);
+runtime.ext_scratch3_looks._say("fail 150: .23 should be > true", target);
 }
 if (!(("" + (".23".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 151: .23 should be < false",}, b0, false, false, "w)", null);
+runtime.ext_scratch3_looks._say("fail 151: .23 should be < false", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 152: .23 should be = false",}, b0, false, false, "w+", null);
+runtime.ext_scratch3_looks._say("fail 152: .23 should be = false", target);
 }
 if (!(("" + (".23".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 153: .23 should be > false",}, b0, false, false, "w-", null);
+runtime.ext_scratch3_looks._say("fail 153: .23 should be > false", target);
 }
 if (!(("" + (".23".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 154: .23 should be < NaN",}, b0, false, false, "w/", null);
+runtime.ext_scratch3_looks._say("fail 154: .23 should be < NaN", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 155: .23 should be = NaN",}, b0, false, false, "w;", null);
+runtime.ext_scratch3_looks._say("fail 155: .23 should be = NaN", target);
 }
 if (!(("" + (".23".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 156: .23 should be > NaN",}, b0, false, false, "w?", null);
+runtime.ext_scratch3_looks._say("fail 156: .23 should be > NaN", target);
 }
 if (!(("" + (0.23 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 157: .23 should be < Infinity",}, b0, false, false, "w[", null);
+runtime.ext_scratch3_looks._say("fail 157: .23 should be < Infinity", target);
 }
 if (!(("" + (0.23 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 158: .23 should be = Infinity",}, b0, false, false, "w^", null);
+runtime.ext_scratch3_looks._say("fail 158: .23 should be = Infinity", target);
 }
 if (!(("" + (0.23 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 159: .23 should be > Infinity",}, b0, false, false, "w`", null);
+runtime.ext_scratch3_looks._say("fail 159: .23 should be > Infinity", target);
 }
 if (!(("" + (".23".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 160: .23 should be < banana",}, b0, false, false, "w|", null);
+runtime.ext_scratch3_looks._say("fail 160: .23 should be < banana", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 161: .23 should be = banana",}, b0, false, false, "w~", null);
+runtime.ext_scratch3_looks._say("fail 161: .23 should be = banana", target);
 }
 if (!(("" + (".23".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 162: .23 should be > banana",}, b0, false, false, "xb", null);
+runtime.ext_scratch3_looks._say("fail 162: .23 should be > banana", target);
 }
 if (!(("" + (".23".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 163: .23 should be < 🎉",}, b0, false, false, "xd", null);
+runtime.ext_scratch3_looks._say("fail 163: .23 should be < 🎉", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 164: .23 should be = 🎉",}, b0, false, false, "xf", null);
+runtime.ext_scratch3_looks._say("fail 164: .23 should be = 🎉", target);
 }
 if (!(("" + (".23".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 165: .23 should be > 🎉",}, b0, false, false, "xh", null);
+runtime.ext_scratch3_looks._say("fail 165: .23 should be > 🎉", target);
 }
 if (!(("" + (".23".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 166: .23 should be < ",}, b0, false, false, "xj", null);
+runtime.ext_scratch3_looks._say("fail 166: .23 should be < ", target);
 }
 if (!(("" + (0.23 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 167: .23 should be = ",}, b0, false, false, "xl", null);
+runtime.ext_scratch3_looks._say("fail 167: .23 should be = ", target);
 }
 if (!(("" + (".23".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 168: .23 should be > ",}, b0, false, false, "xn", null);
+runtime.ext_scratch3_looks._say("fail 168: .23 should be > ", target);
 }
 if (!(("" + (0.123 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 169: 0.123 should be < 0",}, b0, false, false, "xp", null);
+runtime.ext_scratch3_looks._say("fail 169: 0.123 should be < 0", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 170: 0.123 should be = 0",}, b0, false, false, "xr", null);
+runtime.ext_scratch3_looks._say("fail 170: 0.123 should be = 0", target);
 }
 if (!(("" + (0.123 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 171: 0.123 should be > 0",}, b0, false, false, "xt", null);
+runtime.ext_scratch3_looks._say("fail 171: 0.123 should be > 0", target);
 }
 if (!(("" + (0.123 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 172: 0.123 should be < 0.0",}, b0, false, false, "xv", null);
+runtime.ext_scratch3_looks._say("fail 172: 0.123 should be < 0.0", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 173: 0.123 should be = 0.0",}, b0, false, false, "xx", null);
+runtime.ext_scratch3_looks._say("fail 173: 0.123 should be = 0.0", target);
 }
 if (!(("" + (0.123 > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 174: 0.123 should be > 0.0",}, b0, false, false, "xz", null);
+runtime.ext_scratch3_looks._say("fail 174: 0.123 should be > 0.0", target);
 }
 if (!(("" + (0.123 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 175: 0.123 should be < 1.23",}, b0, false, false, "xB", null);
+runtime.ext_scratch3_looks._say("fail 175: 0.123 should be < 1.23", target);
 }
 if (!(("" + (0.123 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 176: 0.123 should be = 1.23",}, b0, false, false, "xD", null);
+runtime.ext_scratch3_looks._say("fail 176: 0.123 should be = 1.23", target);
 }
 if (!(("" + (0.123 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 177: 0.123 should be > 1.23",}, b0, false, false, "xF", null);
+runtime.ext_scratch3_looks._say("fail 177: 0.123 should be > 1.23", target);
 }
 if (!(("" + (0.123 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 178: 0.123 should be < .23",}, b0, false, false, "xH", null);
+runtime.ext_scratch3_looks._say("fail 178: 0.123 should be < .23", target);
 }
 if (!(("" + (0.123 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 179: 0.123 should be = .23",}, b0, false, false, "xJ", null);
+runtime.ext_scratch3_looks._say("fail 179: 0.123 should be = .23", target);
 }
 if (!(("" + (0.123 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 180: 0.123 should be > .23",}, b0, false, false, "xL", null);
+runtime.ext_scratch3_looks._say("fail 180: 0.123 should be > .23", target);
 }
 if (!(("" + (0.123 < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 181: 0.123 should be < 0.123",}, b0, false, false, "xN", null);
+runtime.ext_scratch3_looks._say("fail 181: 0.123 should be < 0.123", target);
 }
 if (!(("" + (0.123 === 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 182: 0.123 should be = 0.123",}, b0, false, false, "xP", null);
+runtime.ext_scratch3_looks._say("fail 182: 0.123 should be = 0.123", target);
 }
 if (!(("" + (0.123 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 183: 0.123 should be > 0.123",}, b0, false, false, "xR", null);
+runtime.ext_scratch3_looks._say("fail 183: 0.123 should be > 0.123", target);
 }
 if (!(("" + (0.123 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 184: 0.123 should be < -0",}, b0, false, false, "xT", null);
+runtime.ext_scratch3_looks._say("fail 184: 0.123 should be < -0", target);
 }
 if (!(("" + (0.123 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 185: 0.123 should be = -0",}, b0, false, false, "xV", null);
+runtime.ext_scratch3_looks._say("fail 185: 0.123 should be = -0", target);
 }
 if (!(("" + (0.123 > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 186: 0.123 should be > -0",}, b0, false, false, "xX", null);
+runtime.ext_scratch3_looks._say("fail 186: 0.123 should be > -0", target);
 }
 if (!(("" + (0.123 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 187: 0.123 should be < -1",}, b0, false, false, "xZ", null);
+runtime.ext_scratch3_looks._say("fail 187: 0.123 should be < -1", target);
 }
 if (!(("" + (0.123 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 188: 0.123 should be = -1",}, b0, false, false, "x1", null);
+runtime.ext_scratch3_looks._say("fail 188: 0.123 should be = -1", target);
 }
 if (!(("" + (0.123 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 189: 0.123 should be > -1",}, b0, false, false, "x3", null);
+runtime.ext_scratch3_looks._say("fail 189: 0.123 should be > -1", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 190: 0.123 should be < true",}, b0, false, false, "x5", null);
+runtime.ext_scratch3_looks._say("fail 190: 0.123 should be < true", target);
 }
 if (!(("" + (0.123 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 191: 0.123 should be = true",}, b0, false, false, "x7", null);
+runtime.ext_scratch3_looks._say("fail 191: 0.123 should be = true", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 192: 0.123 should be > true",}, b0, false, false, "x9", null);
+runtime.ext_scratch3_looks._say("fail 192: 0.123 should be > true", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 193: 0.123 should be < false",}, b0, false, false, "x#", null);
+runtime.ext_scratch3_looks._say("fail 193: 0.123 should be < false", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 194: 0.123 should be = false",}, b0, false, false, "x(", null);
+runtime.ext_scratch3_looks._say("fail 194: 0.123 should be = false", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 195: 0.123 should be > false",}, b0, false, false, "x*", null);
+runtime.ext_scratch3_looks._say("fail 195: 0.123 should be > false", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 196: 0.123 should be < NaN",}, b0, false, false, "x,", null);
+runtime.ext_scratch3_looks._say("fail 196: 0.123 should be < NaN", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 197: 0.123 should be = NaN",}, b0, false, false, "x.", null);
+runtime.ext_scratch3_looks._say("fail 197: 0.123 should be = NaN", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 198: 0.123 should be > NaN",}, b0, false, false, "x:", null);
+runtime.ext_scratch3_looks._say("fail 198: 0.123 should be > NaN", target);
 }
 if (!(("" + (0.123 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 199: 0.123 should be < Infinity",}, b0, false, false, "x=", null);
+runtime.ext_scratch3_looks._say("fail 199: 0.123 should be < Infinity", target);
 }
 if (!(("" + (0.123 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 200: 0.123 should be = Infinity",}, b0, false, false, "x@", null);
+runtime.ext_scratch3_looks._say("fail 200: 0.123 should be = Infinity", target);
 }
 if (!(("" + (0.123 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 201: 0.123 should be > Infinity",}, b0, false, false, "x]", null);
+runtime.ext_scratch3_looks._say("fail 201: 0.123 should be > Infinity", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 202: 0.123 should be < banana",}, b0, false, false, "x_", null);
+runtime.ext_scratch3_looks._say("fail 202: 0.123 should be < banana", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 203: 0.123 should be = banana",}, b0, false, false, "x{", null);
+runtime.ext_scratch3_looks._say("fail 203: 0.123 should be = banana", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 204: 0.123 should be > banana",}, b0, false, false, "x}", null);
+runtime.ext_scratch3_looks._say("fail 204: 0.123 should be > banana", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 205: 0.123 should be < 🎉",}, b0, false, false, "ya", null);
+runtime.ext_scratch3_looks._say("fail 205: 0.123 should be < 🎉", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 206: 0.123 should be = 🎉",}, b0, false, false, "yc", null);
+runtime.ext_scratch3_looks._say("fail 206: 0.123 should be = 🎉", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 207: 0.123 should be > 🎉",}, b0, false, false, "ye", null);
+runtime.ext_scratch3_looks._say("fail 207: 0.123 should be > 🎉", target);
 }
 if (!(("" + ("0.123".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 208: 0.123 should be < ",}, b0, false, false, "yg", null);
+runtime.ext_scratch3_looks._say("fail 208: 0.123 should be < ", target);
 }
 if (!(("" + (0.123 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 209: 0.123 should be = ",}, b0, false, false, "yi", null);
+runtime.ext_scratch3_looks._say("fail 209: 0.123 should be = ", target);
 }
 if (!(("" + ("0.123".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 210: 0.123 should be > ",}, b0, false, false, "yk", null);
+runtime.ext_scratch3_looks._say("fail 210: 0.123 should be > ", target);
 }
 if (!(("" + (-0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 211: -0 should be < 0",}, b0, false, false, "ym", null);
+runtime.ext_scratch3_looks._say("fail 211: -0 should be < 0", target);
 }
 if (!(("" + (-0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 212: -0 should be = 0",}, b0, false, false, "yo", null);
+runtime.ext_scratch3_looks._say("fail 212: -0 should be = 0", target);
 }
 if (!(("" + (-0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 213: -0 should be > 0",}, b0, false, false, "yq", null);
+runtime.ext_scratch3_looks._say("fail 213: -0 should be > 0", target);
 }
 if (!(("" + (-0 < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 214: -0 should be < 0.0",}, b0, false, false, "ys", null);
+runtime.ext_scratch3_looks._say("fail 214: -0 should be < 0.0", target);
 }
 if (!(("" + (-0 === 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 215: -0 should be = 0.0",}, b0, false, false, "yu", null);
+runtime.ext_scratch3_looks._say("fail 215: -0 should be = 0.0", target);
 }
 if (!(("" + (-0 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 216: -0 should be > 0.0",}, b0, false, false, "yw", null);
+runtime.ext_scratch3_looks._say("fail 216: -0 should be > 0.0", target);
 }
 if (!(("" + (-0 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 217: -0 should be < 1.23",}, b0, false, false, "yy", null);
+runtime.ext_scratch3_looks._say("fail 217: -0 should be < 1.23", target);
 }
 if (!(("" + (-0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 218: -0 should be = 1.23",}, b0, false, false, "yA", null);
+runtime.ext_scratch3_looks._say("fail 218: -0 should be = 1.23", target);
 }
 if (!(("" + (-0 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 219: -0 should be > 1.23",}, b0, false, false, "yC", null);
+runtime.ext_scratch3_looks._say("fail 219: -0 should be > 1.23", target);
 }
 if (!(("" + (-0 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 220: -0 should be < .23",}, b0, false, false, "yE", null);
+runtime.ext_scratch3_looks._say("fail 220: -0 should be < .23", target);
 }
 if (!(("" + (-0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 221: -0 should be = .23",}, b0, false, false, "yG", null);
+runtime.ext_scratch3_looks._say("fail 221: -0 should be = .23", target);
 }
 if (!(("" + (-0 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 222: -0 should be > .23",}, b0, false, false, "yI", null);
+runtime.ext_scratch3_looks._say("fail 222: -0 should be > .23", target);
 }
 if (!(("" + (-0 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 223: -0 should be < 0.123",}, b0, false, false, "yK", null);
+runtime.ext_scratch3_looks._say("fail 223: -0 should be < 0.123", target);
 }
 if (!(("" + (-0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 224: -0 should be = 0.123",}, b0, false, false, "yM", null);
+runtime.ext_scratch3_looks._say("fail 224: -0 should be = 0.123", target);
 }
 if (!(("" + (-0 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 225: -0 should be > 0.123",}, b0, false, false, "yO", null);
+runtime.ext_scratch3_looks._say("fail 225: -0 should be > 0.123", target);
 }
 if (!(("" + (-0 < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 226: -0 should be < -0",}, b0, false, false, "yQ", null);
+runtime.ext_scratch3_looks._say("fail 226: -0 should be < -0", target);
 }
 if (!(("" + (-0 === -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 227: -0 should be = -0",}, b0, false, false, "yS", null);
+runtime.ext_scratch3_looks._say("fail 227: -0 should be = -0", target);
 }
 if (!(("" + (-0 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 228: -0 should be > -0",}, b0, false, false, "yU", null);
+runtime.ext_scratch3_looks._say("fail 228: -0 should be > -0", target);
 }
 if (!(("" + (-0 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 229: -0 should be < -1",}, b0, false, false, "yW", null);
+runtime.ext_scratch3_looks._say("fail 229: -0 should be < -1", target);
 }
 if (!(("" + (-0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 230: -0 should be = -1",}, b0, false, false, "yY", null);
+runtime.ext_scratch3_looks._say("fail 230: -0 should be = -1", target);
 }
 if (!(("" + (-0 > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 231: -0 should be > -1",}, b0, false, false, "y0", null);
+runtime.ext_scratch3_looks._say("fail 231: -0 should be > -1", target);
 }
 if (!(("" + ("-0".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 232: -0 should be < true",}, b0, false, false, "y2", null);
+runtime.ext_scratch3_looks._say("fail 232: -0 should be < true", target);
 }
 if (!(("" + ("-0".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 233: -0 should be = true",}, b0, false, false, "y4", null);
+runtime.ext_scratch3_looks._say("fail 233: -0 should be = true", target);
 }
 if (!(("" + ("-0".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 234: -0 should be > true",}, b0, false, false, "y6", null);
+runtime.ext_scratch3_looks._say("fail 234: -0 should be > true", target);
 }
 if (!(("" + ("-0".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 235: -0 should be < false",}, b0, false, false, "y8", null);
+runtime.ext_scratch3_looks._say("fail 235: -0 should be < false", target);
 }
 if (!(("" + ("-0".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 236: -0 should be = false",}, b0, false, false, "y!", null);
+runtime.ext_scratch3_looks._say("fail 236: -0 should be = false", target);
 }
 if (!(("" + ("-0".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 237: -0 should be > false",}, b0, false, false, "y%", null);
+runtime.ext_scratch3_looks._say("fail 237: -0 should be > false", target);
 }
 if (!(("" + ("-0".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 238: -0 should be < NaN",}, b0, false, false, "y)", null);
+runtime.ext_scratch3_looks._say("fail 238: -0 should be < NaN", target);
 }
 if (!(("" + ("-0".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 239: -0 should be = NaN",}, b0, false, false, "y+", null);
+runtime.ext_scratch3_looks._say("fail 239: -0 should be = NaN", target);
 }
 if (!(("" + ("-0".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 240: -0 should be > NaN",}, b0, false, false, "y-", null);
+runtime.ext_scratch3_looks._say("fail 240: -0 should be > NaN", target);
 }
 if (!(("" + (-0 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 241: -0 should be < Infinity",}, b0, false, false, "y/", null);
+runtime.ext_scratch3_looks._say("fail 241: -0 should be < Infinity", target);
 }
 if (!(("" + (-0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 242: -0 should be = Infinity",}, b0, false, false, "y;", null);
+runtime.ext_scratch3_looks._say("fail 242: -0 should be = Infinity", target);
 }
 if (!(("" + (-0 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 243: -0 should be > Infinity",}, b0, false, false, "y?", null);
+runtime.ext_scratch3_looks._say("fail 243: -0 should be > Infinity", target);
 }
 if (!(("" + ("-0".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 244: -0 should be < banana",}, b0, false, false, "y[", null);
+runtime.ext_scratch3_looks._say("fail 244: -0 should be < banana", target);
 }
 if (!(("" + ("-0".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 245: -0 should be = banana",}, b0, false, false, "y^", null);
+runtime.ext_scratch3_looks._say("fail 245: -0 should be = banana", target);
 }
 if (!(("" + ("-0".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 246: -0 should be > banana",}, b0, false, false, "y`", null);
+runtime.ext_scratch3_looks._say("fail 246: -0 should be > banana", target);
 }
 if (!(("" + ("-0".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 247: -0 should be < 🎉",}, b0, false, false, "y|", null);
+runtime.ext_scratch3_looks._say("fail 247: -0 should be < 🎉", target);
 }
 if (!(("" + ("-0".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 248: -0 should be = 🎉",}, b0, false, false, "y~", null);
+runtime.ext_scratch3_looks._say("fail 248: -0 should be = 🎉", target);
 }
 if (!(("" + ("-0".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 249: -0 should be > 🎉",}, b0, false, false, "zb", null);
+runtime.ext_scratch3_looks._say("fail 249: -0 should be > 🎉", target);
 }
 if (!(("" + ("-0".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 250: -0 should be < ",}, b0, false, false, "zd", null);
+runtime.ext_scratch3_looks._say("fail 250: -0 should be < ", target);
 }
 if (!(("" + ("-0".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 251: -0 should be = ",}, b0, false, false, "zf", null);
+runtime.ext_scratch3_looks._say("fail 251: -0 should be = ", target);
 }
 if (!(("" + ("-0".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 252: -0 should be > ",}, b0, false, false, "zh", null);
+runtime.ext_scratch3_looks._say("fail 252: -0 should be > ", target);
 }
 if (!(("" + (-1 < 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 253: -1 should be < 0",}, b0, false, false, "zj", null);
+runtime.ext_scratch3_looks._say("fail 253: -1 should be < 0", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 254: -1 should be = 0",}, b0, false, false, "zl", null);
+runtime.ext_scratch3_looks._say("fail 254: -1 should be = 0", target);
 }
 if (!(("" + (-1 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 255: -1 should be > 0",}, b0, false, false, "zn", null);
+runtime.ext_scratch3_looks._say("fail 255: -1 should be > 0", target);
 }
 if (!(("" + (-1 < 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 256: -1 should be < 0.0",}, b0, false, false, "zp", null);
+runtime.ext_scratch3_looks._say("fail 256: -1 should be < 0.0", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 257: -1 should be = 0.0",}, b0, false, false, "zr", null);
+runtime.ext_scratch3_looks._say("fail 257: -1 should be = 0.0", target);
 }
 if (!(("" + (-1 > 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 258: -1 should be > 0.0",}, b0, false, false, "zt", null);
+runtime.ext_scratch3_looks._say("fail 258: -1 should be > 0.0", target);
 }
 if (!(("" + (-1 < 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 259: -1 should be < 1.23",}, b0, false, false, "zv", null);
+runtime.ext_scratch3_looks._say("fail 259: -1 should be < 1.23", target);
 }
 if (!(("" + (-1 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 260: -1 should be = 1.23",}, b0, false, false, "zx", null);
+runtime.ext_scratch3_looks._say("fail 260: -1 should be = 1.23", target);
 }
 if (!(("" + (-1 > 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 261: -1 should be > 1.23",}, b0, false, false, "zz", null);
+runtime.ext_scratch3_looks._say("fail 261: -1 should be > 1.23", target);
 }
 if (!(("" + (-1 < 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 262: -1 should be < .23",}, b0, false, false, "zB", null);
+runtime.ext_scratch3_looks._say("fail 262: -1 should be < .23", target);
 }
 if (!(("" + (-1 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 263: -1 should be = .23",}, b0, false, false, "zD", null);
+runtime.ext_scratch3_looks._say("fail 263: -1 should be = .23", target);
 }
 if (!(("" + (-1 > 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 264: -1 should be > .23",}, b0, false, false, "zF", null);
+runtime.ext_scratch3_looks._say("fail 264: -1 should be > .23", target);
 }
 if (!(("" + (-1 < 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 265: -1 should be < 0.123",}, b0, false, false, "zH", null);
+runtime.ext_scratch3_looks._say("fail 265: -1 should be < 0.123", target);
 }
 if (!(("" + (-1 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 266: -1 should be = 0.123",}, b0, false, false, "zJ", null);
+runtime.ext_scratch3_looks._say("fail 266: -1 should be = 0.123", target);
 }
 if (!(("" + (-1 > 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 267: -1 should be > 0.123",}, b0, false, false, "zL", null);
+runtime.ext_scratch3_looks._say("fail 267: -1 should be > 0.123", target);
 }
 if (!(("" + (-1 < -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 268: -1 should be < -0",}, b0, false, false, "zN", null);
+runtime.ext_scratch3_looks._say("fail 268: -1 should be < -0", target);
 }
 if (!(("" + (-1 === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 269: -1 should be = -0",}, b0, false, false, "zP", null);
+runtime.ext_scratch3_looks._say("fail 269: -1 should be = -0", target);
 }
 if (!(("" + (-1 > -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 270: -1 should be > -0",}, b0, false, false, "zR", null);
+runtime.ext_scratch3_looks._say("fail 270: -1 should be > -0", target);
 }
 if (!(("" + (-1 < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 271: -1 should be < -1",}, b0, false, false, "zT", null);
+runtime.ext_scratch3_looks._say("fail 271: -1 should be < -1", target);
 }
 if (!(("" + (-1 === -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 272: -1 should be = -1",}, b0, false, false, "zV", null);
+runtime.ext_scratch3_looks._say("fail 272: -1 should be = -1", target);
 }
 if (!(("" + (-1 > -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 273: -1 should be > -1",}, b0, false, false, "zX", null);
+runtime.ext_scratch3_looks._say("fail 273: -1 should be > -1", target);
 }
 if (!(("" + ("-1".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 274: -1 should be < true",}, b0, false, false, "zZ", null);
+runtime.ext_scratch3_looks._say("fail 274: -1 should be < true", target);
 }
 if (!(("" + (-1 === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 275: -1 should be = true",}, b0, false, false, "z1", null);
+runtime.ext_scratch3_looks._say("fail 275: -1 should be = true", target);
 }
 if (!(("" + ("-1".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 276: -1 should be > true",}, b0, false, false, "z3", null);
+runtime.ext_scratch3_looks._say("fail 276: -1 should be > true", target);
 }
 if (!(("" + ("-1".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 277: -1 should be < false",}, b0, false, false, "z5", null);
+runtime.ext_scratch3_looks._say("fail 277: -1 should be < false", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 278: -1 should be = false",}, b0, false, false, "z7", null);
+runtime.ext_scratch3_looks._say("fail 278: -1 should be = false", target);
 }
 if (!(("" + ("-1".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 279: -1 should be > false",}, b0, false, false, "z9", null);
+runtime.ext_scratch3_looks._say("fail 279: -1 should be > false", target);
 }
 if (!(("" + ("-1".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 280: -1 should be < NaN",}, b0, false, false, "z#", null);
+runtime.ext_scratch3_looks._say("fail 280: -1 should be < NaN", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 281: -1 should be = NaN",}, b0, false, false, "z(", null);
+runtime.ext_scratch3_looks._say("fail 281: -1 should be = NaN", target);
 }
 if (!(("" + ("-1".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 282: -1 should be > NaN",}, b0, false, false, "z*", null);
+runtime.ext_scratch3_looks._say("fail 282: -1 should be > NaN", target);
 }
 if (!(("" + (-1 < Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 283: -1 should be < Infinity",}, b0, false, false, "z,", null);
+runtime.ext_scratch3_looks._say("fail 283: -1 should be < Infinity", target);
 }
 if (!(("" + (-1 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 284: -1 should be = Infinity",}, b0, false, false, "z.", null);
+runtime.ext_scratch3_looks._say("fail 284: -1 should be = Infinity", target);
 }
 if (!(("" + (-1 > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 285: -1 should be > Infinity",}, b0, false, false, "z:", null);
+runtime.ext_scratch3_looks._say("fail 285: -1 should be > Infinity", target);
 }
 if (!(("" + ("-1".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 286: -1 should be < banana",}, b0, false, false, "z=", null);
+runtime.ext_scratch3_looks._say("fail 286: -1 should be < banana", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 287: -1 should be = banana",}, b0, false, false, "z@", null);
+runtime.ext_scratch3_looks._say("fail 287: -1 should be = banana", target);
 }
 if (!(("" + ("-1".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 288: -1 should be > banana",}, b0, false, false, "z]", null);
+runtime.ext_scratch3_looks._say("fail 288: -1 should be > banana", target);
 }
 if (!(("" + ("-1".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 289: -1 should be < 🎉",}, b0, false, false, "z_", null);
+runtime.ext_scratch3_looks._say("fail 289: -1 should be < 🎉", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 290: -1 should be = 🎉",}, b0, false, false, "z{", null);
+runtime.ext_scratch3_looks._say("fail 290: -1 should be = 🎉", target);
 }
 if (!(("" + ("-1".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 291: -1 should be > 🎉",}, b0, false, false, "z}", null);
+runtime.ext_scratch3_looks._say("fail 291: -1 should be > 🎉", target);
 }
 if (!(("" + ("-1".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 292: -1 should be < ",}, b0, false, false, "Aa", null);
+runtime.ext_scratch3_looks._say("fail 292: -1 should be < ", target);
 }
 if (!(("" + (-1 === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 293: -1 should be = ",}, b0, false, false, "Ac", null);
+runtime.ext_scratch3_looks._say("fail 293: -1 should be = ", target);
 }
 if (!(("" + ("-1".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 294: -1 should be > ",}, b0, false, false, "Ae", null);
+runtime.ext_scratch3_looks._say("fail 294: -1 should be > ", target);
 }
 if (!(("" + ("true".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 295: true should be < 0",}, b0, false, false, "Ag", null);
+runtime.ext_scratch3_looks._say("fail 295: true should be < 0", target);
 }
 if (!(("" + ("true".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 296: true should be = 0",}, b0, false, false, "Ai", null);
+runtime.ext_scratch3_looks._say("fail 296: true should be = 0", target);
 }
 if (!(("" + ("true".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 297: true should be > 0",}, b0, false, false, "Ak", null);
+runtime.ext_scratch3_looks._say("fail 297: true should be > 0", target);
 }
 if (!(("" + ("true".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 298: true should be < 0.0",}, b0, false, false, "Am", null);
+runtime.ext_scratch3_looks._say("fail 298: true should be < 0.0", target);
 }
 if (!(("" + ("true".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 299: true should be = 0.0",}, b0, false, false, "Ao", null);
+runtime.ext_scratch3_looks._say("fail 299: true should be = 0.0", target);
 }
 if (!(("" + ("true".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 300: true should be > 0.0",}, b0, false, false, "Aq", null);
+runtime.ext_scratch3_looks._say("fail 300: true should be > 0.0", target);
 }
 if (!(("" + ("true".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 301: true should be < 1.23",}, b0, false, false, "As", null);
+runtime.ext_scratch3_looks._say("fail 301: true should be < 1.23", target);
 }
 if (!(("" + (1 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 302: true should be = 1.23",}, b0, false, false, "Au", null);
+runtime.ext_scratch3_looks._say("fail 302: true should be = 1.23", target);
 }
 if (!(("" + ("true".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 303: true should be > 1.23",}, b0, false, false, "Aw", null);
+runtime.ext_scratch3_looks._say("fail 303: true should be > 1.23", target);
 }
 if (!(("" + ("true".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 304: true should be < .23",}, b0, false, false, "Ay", null);
+runtime.ext_scratch3_looks._say("fail 304: true should be < .23", target);
 }
 if (!(("" + (1 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 305: true should be = .23",}, b0, false, false, "AA", null);
+runtime.ext_scratch3_looks._say("fail 305: true should be = .23", target);
 }
 if (!(("" + ("true".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 306: true should be > .23",}, b0, false, false, "AC", null);
+runtime.ext_scratch3_looks._say("fail 306: true should be > .23", target);
 }
 if (!(("" + ("true".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 307: true should be < 0.123",}, b0, false, false, "AE", null);
+runtime.ext_scratch3_looks._say("fail 307: true should be < 0.123", target);
 }
 if (!(("" + (1 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 308: true should be = 0.123",}, b0, false, false, "AG", null);
+runtime.ext_scratch3_looks._say("fail 308: true should be = 0.123", target);
 }
 if (!(("" + ("true".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 309: true should be > 0.123",}, b0, false, false, "AI", null);
+runtime.ext_scratch3_looks._say("fail 309: true should be > 0.123", target);
 }
 if (!(("" + ("true".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 310: true should be < -0",}, b0, false, false, "AK", null);
+runtime.ext_scratch3_looks._say("fail 310: true should be < -0", target);
 }
 if (!(("" + ("true".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 311: true should be = -0",}, b0, false, false, "AM", null);
+runtime.ext_scratch3_looks._say("fail 311: true should be = -0", target);
 }
 if (!(("" + ("true".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 312: true should be > -0",}, b0, false, false, "AO", null);
+runtime.ext_scratch3_looks._say("fail 312: true should be > -0", target);
 }
 if (!(("" + ("true".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 313: true should be < -1",}, b0, false, false, "AQ", null);
+runtime.ext_scratch3_looks._say("fail 313: true should be < -1", target);
 }
 if (!(("" + (1 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 314: true should be = -1",}, b0, false, false, "AS", null);
+runtime.ext_scratch3_looks._say("fail 314: true should be = -1", target);
 }
 if (!(("" + ("true".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 315: true should be > -1",}, b0, false, false, "AU", null);
+runtime.ext_scratch3_looks._say("fail 315: true should be > -1", target);
 }
 if (!(("" + ("true".toLowerCase() < "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 316: true should be < true",}, b0, false, false, "AW", null);
+runtime.ext_scratch3_looks._say("fail 316: true should be < true", target);
 }
 if (!(("" + ("true".toLowerCase() === "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 317: true should be = true",}, b0, false, false, "AY", null);
+runtime.ext_scratch3_looks._say("fail 317: true should be = true", target);
 }
 if (!(("" + ("true".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 318: true should be > true",}, b0, false, false, "A0", null);
+runtime.ext_scratch3_looks._say("fail 318: true should be > true", target);
 }
 if (!(("" + ("true".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 319: true should be < false",}, b0, false, false, "A2", null);
+runtime.ext_scratch3_looks._say("fail 319: true should be < false", target);
 }
 if (!(("" + ("true".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 320: true should be = false",}, b0, false, false, "A4", null);
+runtime.ext_scratch3_looks._say("fail 320: true should be = false", target);
 }
 if (!(("" + ("true".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 321: true should be > false",}, b0, false, false, "A6", null);
+runtime.ext_scratch3_looks._say("fail 321: true should be > false", target);
 }
 if (!(("" + ("true".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 322: true should be < NaN",}, b0, false, false, "A8", null);
+runtime.ext_scratch3_looks._say("fail 322: true should be < NaN", target);
 }
 if (!(("" + ("true".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 323: true should be = NaN",}, b0, false, false, "A!", null);
+runtime.ext_scratch3_looks._say("fail 323: true should be = NaN", target);
 }
 if (!(("" + ("true".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 324: true should be > NaN",}, b0, false, false, "A%", null);
+runtime.ext_scratch3_looks._say("fail 324: true should be > NaN", target);
 }
 if (!(("" + ("true".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 325: true should be < Infinity",}, b0, false, false, "A)", null);
+runtime.ext_scratch3_looks._say("fail 325: true should be < Infinity", target);
 }
 if (!(("" + (1 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 326: true should be = Infinity",}, b0, false, false, "A+", null);
+runtime.ext_scratch3_looks._say("fail 326: true should be = Infinity", target);
 }
 if (!(("" + ("true".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 327: true should be > Infinity",}, b0, false, false, "A-", null);
+runtime.ext_scratch3_looks._say("fail 327: true should be > Infinity", target);
 }
 if (!(("" + ("true".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 328: true should be < banana",}, b0, false, false, "A/", null);
+runtime.ext_scratch3_looks._say("fail 328: true should be < banana", target);
 }
 if (!(("" + ("true".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 329: true should be = banana",}, b0, false, false, "A;", null);
+runtime.ext_scratch3_looks._say("fail 329: true should be = banana", target);
 }
 if (!(("" + ("true".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 330: true should be > banana",}, b0, false, false, "A?", null);
+runtime.ext_scratch3_looks._say("fail 330: true should be > banana", target);
 }
 if (!(("" + ("true".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 331: true should be < 🎉",}, b0, false, false, "A[", null);
+runtime.ext_scratch3_looks._say("fail 331: true should be < 🎉", target);
 }
 if (!(("" + ("true".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 332: true should be = 🎉",}, b0, false, false, "A^", null);
+runtime.ext_scratch3_looks._say("fail 332: true should be = 🎉", target);
 }
 if (!(("" + ("true".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 333: true should be > 🎉",}, b0, false, false, "A`", null);
+runtime.ext_scratch3_looks._say("fail 333: true should be > 🎉", target);
 }
 if (!(("" + ("true".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 334: true should be < ",}, b0, false, false, "A|", null);
+runtime.ext_scratch3_looks._say("fail 334: true should be < ", target);
 }
 if (!(("" + ("true".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 335: true should be = ",}, b0, false, false, "A~", null);
+runtime.ext_scratch3_looks._say("fail 335: true should be = ", target);
 }
 if (!(("" + ("true".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 336: true should be > ",}, b0, false, false, "Bb", null);
+runtime.ext_scratch3_looks._say("fail 336: true should be > ", target);
 }
 if (!(("" + ("false".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 337: false should be < 0",}, b0, false, false, "Bd", null);
+runtime.ext_scratch3_looks._say("fail 337: false should be < 0", target);
 }
 if (!(("" + ("false".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 338: false should be = 0",}, b0, false, false, "Bf", null);
+runtime.ext_scratch3_looks._say("fail 338: false should be = 0", target);
 }
 if (!(("" + ("false".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 339: false should be > 0",}, b0, false, false, "Bh", null);
+runtime.ext_scratch3_looks._say("fail 339: false should be > 0", target);
 }
 if (!(("" + ("false".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 340: false should be < 0.0",}, b0, false, false, "Bj", null);
+runtime.ext_scratch3_looks._say("fail 340: false should be < 0.0", target);
 }
 if (!(("" + ("false".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 341: false should be = 0.0",}, b0, false, false, "Bl", null);
+runtime.ext_scratch3_looks._say("fail 341: false should be = 0.0", target);
 }
 if (!(("" + ("false".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 342: false should be > 0.0",}, b0, false, false, "Bn", null);
+runtime.ext_scratch3_looks._say("fail 342: false should be > 0.0", target);
 }
 if (!(("" + ("false".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 343: false should be < 1.23",}, b0, false, false, "Bp", null);
+runtime.ext_scratch3_looks._say("fail 343: false should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 344: false should be = 1.23",}, b0, false, false, "Br", null);
+runtime.ext_scratch3_looks._say("fail 344: false should be = 1.23", target);
 }
 if (!(("" + ("false".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 345: false should be > 1.23",}, b0, false, false, "Bt", null);
+runtime.ext_scratch3_looks._say("fail 345: false should be > 1.23", target);
 }
 if (!(("" + ("false".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 346: false should be < .23",}, b0, false, false, "Bv", null);
+runtime.ext_scratch3_looks._say("fail 346: false should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 347: false should be = .23",}, b0, false, false, "Bx", null);
+runtime.ext_scratch3_looks._say("fail 347: false should be = .23", target);
 }
 if (!(("" + ("false".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 348: false should be > .23",}, b0, false, false, "Bz", null);
+runtime.ext_scratch3_looks._say("fail 348: false should be > .23", target);
 }
 if (!(("" + ("false".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 349: false should be < 0.123",}, b0, false, false, "BB", null);
+runtime.ext_scratch3_looks._say("fail 349: false should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 350: false should be = 0.123",}, b0, false, false, "BD", null);
+runtime.ext_scratch3_looks._say("fail 350: false should be = 0.123", target);
 }
 if (!(("" + ("false".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 351: false should be > 0.123",}, b0, false, false, "BF", null);
+runtime.ext_scratch3_looks._say("fail 351: false should be > 0.123", target);
 }
 if (!(("" + ("false".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 352: false should be < -0",}, b0, false, false, "BH", null);
+runtime.ext_scratch3_looks._say("fail 352: false should be < -0", target);
 }
 if (!(("" + ("false".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 353: false should be = -0",}, b0, false, false, "BJ", null);
+runtime.ext_scratch3_looks._say("fail 353: false should be = -0", target);
 }
 if (!(("" + ("false".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 354: false should be > -0",}, b0, false, false, "BL", null);
+runtime.ext_scratch3_looks._say("fail 354: false should be > -0", target);
 }
 if (!(("" + ("false".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 355: false should be < -1",}, b0, false, false, "BN", null);
+runtime.ext_scratch3_looks._say("fail 355: false should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 356: false should be = -1",}, b0, false, false, "BP", null);
+runtime.ext_scratch3_looks._say("fail 356: false should be = -1", target);
 }
 if (!(("" + ("false".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 357: false should be > -1",}, b0, false, false, "BR", null);
+runtime.ext_scratch3_looks._say("fail 357: false should be > -1", target);
 }
 if (!(("" + ("false".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 358: false should be < true",}, b0, false, false, "BT", null);
+runtime.ext_scratch3_looks._say("fail 358: false should be < true", target);
 }
 if (!(("" + ("false".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 359: false should be = true",}, b0, false, false, "BV", null);
+runtime.ext_scratch3_looks._say("fail 359: false should be = true", target);
 }
 if (!(("" + ("false".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 360: false should be > true",}, b0, false, false, "BX", null);
+runtime.ext_scratch3_looks._say("fail 360: false should be > true", target);
 }
 if (!(("" + ("false".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 361: false should be < false",}, b0, false, false, "BZ", null);
+runtime.ext_scratch3_looks._say("fail 361: false should be < false", target);
 }
 if (!(("" + ("false".toLowerCase() === "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 362: false should be = false",}, b0, false, false, "B1", null);
+runtime.ext_scratch3_looks._say("fail 362: false should be = false", target);
 }
 if (!(("" + ("false".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 363: false should be > false",}, b0, false, false, "B3", null);
+runtime.ext_scratch3_looks._say("fail 363: false should be > false", target);
 }
 if (!(("" + ("false".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 364: false should be < NaN",}, b0, false, false, "B5", null);
+runtime.ext_scratch3_looks._say("fail 364: false should be < NaN", target);
 }
 if (!(("" + ("false".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 365: false should be = NaN",}, b0, false, false, "B7", null);
+runtime.ext_scratch3_looks._say("fail 365: false should be = NaN", target);
 }
 if (!(("" + ("false".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 366: false should be > NaN",}, b0, false, false, "B9", null);
+runtime.ext_scratch3_looks._say("fail 366: false should be > NaN", target);
 }
 if (!(("" + ("false".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 367: false should be < Infinity",}, b0, false, false, "B#", null);
+runtime.ext_scratch3_looks._say("fail 367: false should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 368: false should be = Infinity",}, b0, false, false, "B(", null);
+runtime.ext_scratch3_looks._say("fail 368: false should be = Infinity", target);
 }
 if (!(("" + ("false".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 369: false should be > Infinity",}, b0, false, false, "B*", null);
+runtime.ext_scratch3_looks._say("fail 369: false should be > Infinity", target);
 }
 if (!(("" + ("false".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 370: false should be < banana",}, b0, false, false, "B,", null);
+runtime.ext_scratch3_looks._say("fail 370: false should be < banana", target);
 }
 if (!(("" + ("false".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 371: false should be = banana",}, b0, false, false, "B.", null);
+runtime.ext_scratch3_looks._say("fail 371: false should be = banana", target);
 }
 if (!(("" + ("false".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 372: false should be > banana",}, b0, false, false, "B:", null);
+runtime.ext_scratch3_looks._say("fail 372: false should be > banana", target);
 }
 if (!(("" + ("false".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 373: false should be < 🎉",}, b0, false, false, "B=", null);
+runtime.ext_scratch3_looks._say("fail 373: false should be < 🎉", target);
 }
 if (!(("" + ("false".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 374: false should be = 🎉",}, b0, false, false, "B@", null);
+runtime.ext_scratch3_looks._say("fail 374: false should be = 🎉", target);
 }
 if (!(("" + ("false".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 375: false should be > 🎉",}, b0, false, false, "B]", null);
+runtime.ext_scratch3_looks._say("fail 375: false should be > 🎉", target);
 }
 if (!(("" + ("false".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 376: false should be < ",}, b0, false, false, "B_", null);
+runtime.ext_scratch3_looks._say("fail 376: false should be < ", target);
 }
 if (!(("" + ("false".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 377: false should be = ",}, b0, false, false, "B{", null);
+runtime.ext_scratch3_looks._say("fail 377: false should be = ", target);
 }
 if (!(("" + ("false".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 378: false should be > ",}, b0, false, false, "B}", null);
+runtime.ext_scratch3_looks._say("fail 378: false should be > ", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 379: NaN should be < 0",}, b0, false, false, "Ca", null);
+runtime.ext_scratch3_looks._say("fail 379: NaN should be < 0", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 380: NaN should be = 0",}, b0, false, false, "Cc", null);
+runtime.ext_scratch3_looks._say("fail 380: NaN should be = 0", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 381: NaN should be > 0",}, b0, false, false, "Ce", null);
+runtime.ext_scratch3_looks._say("fail 381: NaN should be > 0", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 382: NaN should be < 0.0",}, b0, false, false, "Cg", null);
+runtime.ext_scratch3_looks._say("fail 382: NaN should be < 0.0", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 383: NaN should be = 0.0",}, b0, false, false, "Ci", null);
+runtime.ext_scratch3_looks._say("fail 383: NaN should be = 0.0", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 384: NaN should be > 0.0",}, b0, false, false, "Ck", null);
+runtime.ext_scratch3_looks._say("fail 384: NaN should be > 0.0", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 385: NaN should be < 1.23",}, b0, false, false, "Cm", null);
+runtime.ext_scratch3_looks._say("fail 385: NaN should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 386: NaN should be = 1.23",}, b0, false, false, "Co", null);
+runtime.ext_scratch3_looks._say("fail 386: NaN should be = 1.23", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 387: NaN should be > 1.23",}, b0, false, false, "Cq", null);
+runtime.ext_scratch3_looks._say("fail 387: NaN should be > 1.23", target);
 }
 if (!(("" + ("NaN".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 388: NaN should be < .23",}, b0, false, false, "Cs", null);
+runtime.ext_scratch3_looks._say("fail 388: NaN should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 389: NaN should be = .23",}, b0, false, false, "Cu", null);
+runtime.ext_scratch3_looks._say("fail 389: NaN should be = .23", target);
 }
 if (!(("" + ("NaN".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 390: NaN should be > .23",}, b0, false, false, "Cw", null);
+runtime.ext_scratch3_looks._say("fail 390: NaN should be > .23", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 391: NaN should be < 0.123",}, b0, false, false, "Cy", null);
+runtime.ext_scratch3_looks._say("fail 391: NaN should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 392: NaN should be = 0.123",}, b0, false, false, "CA", null);
+runtime.ext_scratch3_looks._say("fail 392: NaN should be = 0.123", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 393: NaN should be > 0.123",}, b0, false, false, "CC", null);
+runtime.ext_scratch3_looks._say("fail 393: NaN should be > 0.123", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 394: NaN should be < -0",}, b0, false, false, "CE", null);
+runtime.ext_scratch3_looks._say("fail 394: NaN should be < -0", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 395: NaN should be = -0",}, b0, false, false, "CG", null);
+runtime.ext_scratch3_looks._say("fail 395: NaN should be = -0", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 396: NaN should be > -0",}, b0, false, false, "CI", null);
+runtime.ext_scratch3_looks._say("fail 396: NaN should be > -0", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 397: NaN should be < -1",}, b0, false, false, "CK", null);
+runtime.ext_scratch3_looks._say("fail 397: NaN should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 398: NaN should be = -1",}, b0, false, false, "CM", null);
+runtime.ext_scratch3_looks._say("fail 398: NaN should be = -1", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 399: NaN should be > -1",}, b0, false, false, "CO", null);
+runtime.ext_scratch3_looks._say("fail 399: NaN should be > -1", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 400: NaN should be < true",}, b0, false, false, "CQ", null);
+runtime.ext_scratch3_looks._say("fail 400: NaN should be < true", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 401: NaN should be = true",}, b0, false, false, "CS", null);
+runtime.ext_scratch3_looks._say("fail 401: NaN should be = true", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 402: NaN should be > true",}, b0, false, false, "CU", null);
+runtime.ext_scratch3_looks._say("fail 402: NaN should be > true", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 403: NaN should be < false",}, b0, false, false, "CW", null);
+runtime.ext_scratch3_looks._say("fail 403: NaN should be < false", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 404: NaN should be = false",}, b0, false, false, "CY", null);
+runtime.ext_scratch3_looks._say("fail 404: NaN should be = false", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 405: NaN should be > false",}, b0, false, false, "C0", null);
+runtime.ext_scratch3_looks._say("fail 405: NaN should be > false", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 406: NaN should be < NaN",}, b0, false, false, "C2", null);
+runtime.ext_scratch3_looks._say("fail 406: NaN should be < NaN", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 407: NaN should be = NaN",}, b0, false, false, "C4", null);
+runtime.ext_scratch3_looks._say("fail 407: NaN should be = NaN", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 408: NaN should be > NaN",}, b0, false, false, "C6", null);
+runtime.ext_scratch3_looks._say("fail 408: NaN should be > NaN", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 409: NaN should be < Infinity",}, b0, false, false, "C8", null);
+runtime.ext_scratch3_looks._say("fail 409: NaN should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 410: NaN should be = Infinity",}, b0, false, false, "C!", null);
+runtime.ext_scratch3_looks._say("fail 410: NaN should be = Infinity", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 411: NaN should be > Infinity",}, b0, false, false, "C%", null);
+runtime.ext_scratch3_looks._say("fail 411: NaN should be > Infinity", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 412: NaN should be < banana",}, b0, false, false, "C)", null);
+runtime.ext_scratch3_looks._say("fail 412: NaN should be < banana", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 413: NaN should be = banana",}, b0, false, false, "C+", null);
+runtime.ext_scratch3_looks._say("fail 413: NaN should be = banana", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 414: NaN should be > banana",}, b0, false, false, "C-", null);
+runtime.ext_scratch3_looks._say("fail 414: NaN should be > banana", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 415: NaN should be < 🎉",}, b0, false, false, "C/", null);
+runtime.ext_scratch3_looks._say("fail 415: NaN should be < 🎉", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 416: NaN should be = 🎉",}, b0, false, false, "C;", null);
+runtime.ext_scratch3_looks._say("fail 416: NaN should be = 🎉", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 417: NaN should be > 🎉",}, b0, false, false, "C?", null);
+runtime.ext_scratch3_looks._say("fail 417: NaN should be > 🎉", target);
 }
 if (!(("" + ("NaN".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 418: NaN should be < ",}, b0, false, false, "C[", null);
+runtime.ext_scratch3_looks._say("fail 418: NaN should be < ", target);
 }
 if (!(("" + ("NaN".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 419: NaN should be = ",}, b0, false, false, "C^", null);
+runtime.ext_scratch3_looks._say("fail 419: NaN should be = ", target);
 }
 if (!(("" + ("NaN".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 420: NaN should be > ",}, b0, false, false, "C`", null);
+runtime.ext_scratch3_looks._say("fail 420: NaN should be > ", target);
 }
 if (!(("" + (Infinity < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 421: Infinity should be < 0",}, b0, false, false, "C|", null);
+runtime.ext_scratch3_looks._say("fail 421: Infinity should be < 0", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 422: Infinity should be = 0",}, b0, false, false, "C~", null);
+runtime.ext_scratch3_looks._say("fail 422: Infinity should be = 0", target);
 }
 if (!(("" + (Infinity > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 423: Infinity should be > 0",}, b0, false, false, "Db", null);
+runtime.ext_scratch3_looks._say("fail 423: Infinity should be > 0", target);
 }
 if (!(("" + (Infinity < 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 424: Infinity should be < 0.0",}, b0, false, false, "Dd", null);
+runtime.ext_scratch3_looks._say("fail 424: Infinity should be < 0.0", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 425: Infinity should be = 0.0",}, b0, false, false, "Df", null);
+runtime.ext_scratch3_looks._say("fail 425: Infinity should be = 0.0", target);
 }
 if (!(("" + (Infinity > 0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 426: Infinity should be > 0.0",}, b0, false, false, "Dh", null);
+runtime.ext_scratch3_looks._say("fail 426: Infinity should be > 0.0", target);
 }
 if (!(("" + (Infinity < 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 427: Infinity should be < 1.23",}, b0, false, false, "Dj", null);
+runtime.ext_scratch3_looks._say("fail 427: Infinity should be < 1.23", target);
 }
 if (!(("" + (Infinity === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 428: Infinity should be = 1.23",}, b0, false, false, "Dl", null);
+runtime.ext_scratch3_looks._say("fail 428: Infinity should be = 1.23", target);
 }
 if (!(("" + (Infinity > 1.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 429: Infinity should be > 1.23",}, b0, false, false, "Dn", null);
+runtime.ext_scratch3_looks._say("fail 429: Infinity should be > 1.23", target);
 }
 if (!(("" + (Infinity < 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 430: Infinity should be < .23",}, b0, false, false, "Dp", null);
+runtime.ext_scratch3_looks._say("fail 430: Infinity should be < .23", target);
 }
 if (!(("" + (Infinity === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 431: Infinity should be = .23",}, b0, false, false, "Dr", null);
+runtime.ext_scratch3_looks._say("fail 431: Infinity should be = .23", target);
 }
 if (!(("" + (Infinity > 0.23)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 432: Infinity should be > .23",}, b0, false, false, "Dt", null);
+runtime.ext_scratch3_looks._say("fail 432: Infinity should be > .23", target);
 }
 if (!(("" + (Infinity < 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 433: Infinity should be < 0.123",}, b0, false, false, "Dv", null);
+runtime.ext_scratch3_looks._say("fail 433: Infinity should be < 0.123", target);
 }
 if (!(("" + (Infinity === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 434: Infinity should be = 0.123",}, b0, false, false, "Dx", null);
+runtime.ext_scratch3_looks._say("fail 434: Infinity should be = 0.123", target);
 }
 if (!(("" + (Infinity > 0.123)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 435: Infinity should be > 0.123",}, b0, false, false, "Dz", null);
+runtime.ext_scratch3_looks._say("fail 435: Infinity should be > 0.123", target);
 }
 if (!(("" + (Infinity < -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 436: Infinity should be < -0",}, b0, false, false, "DB", null);
+runtime.ext_scratch3_looks._say("fail 436: Infinity should be < -0", target);
 }
 if (!(("" + (Infinity === -0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 437: Infinity should be = -0",}, b0, false, false, "DD", null);
+runtime.ext_scratch3_looks._say("fail 437: Infinity should be = -0", target);
 }
 if (!(("" + (Infinity > -0)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 438: Infinity should be > -0",}, b0, false, false, "DF", null);
+runtime.ext_scratch3_looks._say("fail 438: Infinity should be > -0", target);
 }
 if (!(("" + (Infinity < -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 439: Infinity should be < -1",}, b0, false, false, "DH", null);
+runtime.ext_scratch3_looks._say("fail 439: Infinity should be < -1", target);
 }
 if (!(("" + (Infinity === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 440: Infinity should be = -1",}, b0, false, false, "DJ", null);
+runtime.ext_scratch3_looks._say("fail 440: Infinity should be = -1", target);
 }
 if (!(("" + (Infinity > -1)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 441: Infinity should be > -1",}, b0, false, false, "DL", null);
+runtime.ext_scratch3_looks._say("fail 441: Infinity should be > -1", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 442: Infinity should be < true",}, b0, false, false, "DN", null);
+runtime.ext_scratch3_looks._say("fail 442: Infinity should be < true", target);
 }
 if (!(("" + (Infinity === 1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 443: Infinity should be = true",}, b0, false, false, "DP", null);
+runtime.ext_scratch3_looks._say("fail 443: Infinity should be = true", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 444: Infinity should be > true",}, b0, false, false, "DR", null);
+runtime.ext_scratch3_looks._say("fail 444: Infinity should be > true", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 445: Infinity should be < false",}, b0, false, false, "DT", null);
+runtime.ext_scratch3_looks._say("fail 445: Infinity should be < false", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 446: Infinity should be = false",}, b0, false, false, "DV", null);
+runtime.ext_scratch3_looks._say("fail 446: Infinity should be = false", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 447: Infinity should be > false",}, b0, false, false, "DX", null);
+runtime.ext_scratch3_looks._say("fail 447: Infinity should be > false", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 448: Infinity should be < NaN",}, b0, false, false, "DZ", null);
+runtime.ext_scratch3_looks._say("fail 448: Infinity should be < NaN", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 449: Infinity should be = NaN",}, b0, false, false, "D1", null);
+runtime.ext_scratch3_looks._say("fail 449: Infinity should be = NaN", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 450: Infinity should be > NaN",}, b0, false, false, "D3", null);
+runtime.ext_scratch3_looks._say("fail 450: Infinity should be > NaN", target);
 }
 if (!(("" + (Infinity < Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 451: Infinity should be < Infinity",}, b0, false, false, "D5", null);
+runtime.ext_scratch3_looks._say("fail 451: Infinity should be < Infinity", target);
 }
 if (!(("" + (Infinity === Infinity)).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 452: Infinity should be = Infinity",}, b0, false, false, "D7", null);
+runtime.ext_scratch3_looks._say("fail 452: Infinity should be = Infinity", target);
 }
 if (!(("" + (Infinity > Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 453: Infinity should be > Infinity",}, b0, false, false, "D9", null);
+runtime.ext_scratch3_looks._say("fail 453: Infinity should be > Infinity", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 454: Infinity should be < banana",}, b0, false, false, "D#", null);
+runtime.ext_scratch3_looks._say("fail 454: Infinity should be < banana", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 455: Infinity should be = banana",}, b0, false, false, "D(", null);
+runtime.ext_scratch3_looks._say("fail 455: Infinity should be = banana", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 456: Infinity should be > banana",}, b0, false, false, "D*", null);
+runtime.ext_scratch3_looks._say("fail 456: Infinity should be > banana", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 457: Infinity should be < 🎉",}, b0, false, false, "D,", null);
+runtime.ext_scratch3_looks._say("fail 457: Infinity should be < 🎉", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 458: Infinity should be = 🎉",}, b0, false, false, "D.", null);
+runtime.ext_scratch3_looks._say("fail 458: Infinity should be = 🎉", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 459: Infinity should be > 🎉",}, b0, false, false, "D:", null);
+runtime.ext_scratch3_looks._say("fail 459: Infinity should be > 🎉", target);
 }
 if (!(("" + ("Infinity".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 460: Infinity should be < ",}, b0, false, false, "D=", null);
+runtime.ext_scratch3_looks._say("fail 460: Infinity should be < ", target);
 }
 if (!(("" + (Infinity === 0)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 461: Infinity should be = ",}, b0, false, false, "D@", null);
+runtime.ext_scratch3_looks._say("fail 461: Infinity should be = ", target);
 }
 if (!(("" + ("Infinity".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 462: Infinity should be > ",}, b0, false, false, "D]", null);
+runtime.ext_scratch3_looks._say("fail 462: Infinity should be > ", target);
 }
 if (!(("" + ("banana".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 463: banana should be < 0",}, b0, false, false, "D_", null);
+runtime.ext_scratch3_looks._say("fail 463: banana should be < 0", target);
 }
 if (!(("" + ("banana".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 464: banana should be = 0",}, b0, false, false, "D{", null);
+runtime.ext_scratch3_looks._say("fail 464: banana should be = 0", target);
 }
 if (!(("" + ("banana".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 465: banana should be > 0",}, b0, false, false, "D}", null);
+runtime.ext_scratch3_looks._say("fail 465: banana should be > 0", target);
 }
 if (!(("" + ("banana".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 466: banana should be < 0.0",}, b0, false, false, "Ea", null);
+runtime.ext_scratch3_looks._say("fail 466: banana should be < 0.0", target);
 }
 if (!(("" + ("banana".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 467: banana should be = 0.0",}, b0, false, false, "Ec", null);
+runtime.ext_scratch3_looks._say("fail 467: banana should be = 0.0", target);
 }
 if (!(("" + ("banana".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 468: banana should be > 0.0",}, b0, false, false, "Ee", null);
+runtime.ext_scratch3_looks._say("fail 468: banana should be > 0.0", target);
 }
 if (!(("" + ("banana".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 469: banana should be < 1.23",}, b0, false, false, "Eg", null);
+runtime.ext_scratch3_looks._say("fail 469: banana should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 470: banana should be = 1.23",}, b0, false, false, "Ei", null);
+runtime.ext_scratch3_looks._say("fail 470: banana should be = 1.23", target);
 }
 if (!(("" + ("banana".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 471: banana should be > 1.23",}, b0, false, false, "Ek", null);
+runtime.ext_scratch3_looks._say("fail 471: banana should be > 1.23", target);
 }
 if (!(("" + ("banana".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 472: banana should be < .23",}, b0, false, false, "Em", null);
+runtime.ext_scratch3_looks._say("fail 472: banana should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 473: banana should be = .23",}, b0, false, false, "Eo", null);
+runtime.ext_scratch3_looks._say("fail 473: banana should be = .23", target);
 }
 if (!(("" + ("banana".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 474: banana should be > .23",}, b0, false, false, "Eq", null);
+runtime.ext_scratch3_looks._say("fail 474: banana should be > .23", target);
 }
 if (!(("" + ("banana".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 475: banana should be < 0.123",}, b0, false, false, "Es", null);
+runtime.ext_scratch3_looks._say("fail 475: banana should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 476: banana should be = 0.123",}, b0, false, false, "Eu", null);
+runtime.ext_scratch3_looks._say("fail 476: banana should be = 0.123", target);
 }
 if (!(("" + ("banana".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 477: banana should be > 0.123",}, b0, false, false, "Ew", null);
+runtime.ext_scratch3_looks._say("fail 477: banana should be > 0.123", target);
 }
 if (!(("" + ("banana".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 478: banana should be < -0",}, b0, false, false, "Ey", null);
+runtime.ext_scratch3_looks._say("fail 478: banana should be < -0", target);
 }
 if (!(("" + ("banana".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 479: banana should be = -0",}, b0, false, false, "EA", null);
+runtime.ext_scratch3_looks._say("fail 479: banana should be = -0", target);
 }
 if (!(("" + ("banana".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 480: banana should be > -0",}, b0, false, false, "EC", null);
+runtime.ext_scratch3_looks._say("fail 480: banana should be > -0", target);
 }
 if (!(("" + ("banana".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 481: banana should be < -1",}, b0, false, false, "EE", null);
+runtime.ext_scratch3_looks._say("fail 481: banana should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 482: banana should be = -1",}, b0, false, false, "EG", null);
+runtime.ext_scratch3_looks._say("fail 482: banana should be = -1", target);
 }
 if (!(("" + ("banana".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 483: banana should be > -1",}, b0, false, false, "EI", null);
+runtime.ext_scratch3_looks._say("fail 483: banana should be > -1", target);
 }
 if (!(("" + ("banana".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 484: banana should be < true",}, b0, false, false, "EK", null);
+runtime.ext_scratch3_looks._say("fail 484: banana should be < true", target);
 }
 if (!(("" + ("banana".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 485: banana should be = true",}, b0, false, false, "EM", null);
+runtime.ext_scratch3_looks._say("fail 485: banana should be = true", target);
 }
 if (!(("" + ("banana".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 486: banana should be > true",}, b0, false, false, "EO", null);
+runtime.ext_scratch3_looks._say("fail 486: banana should be > true", target);
 }
 if (!(("" + ("banana".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 487: banana should be < false",}, b0, false, false, "EQ", null);
+runtime.ext_scratch3_looks._say("fail 487: banana should be < false", target);
 }
 if (!(("" + ("banana".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 488: banana should be = false",}, b0, false, false, "ES", null);
+runtime.ext_scratch3_looks._say("fail 488: banana should be = false", target);
 }
 if (!(("" + ("banana".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 489: banana should be > false",}, b0, false, false, "EU", null);
+runtime.ext_scratch3_looks._say("fail 489: banana should be > false", target);
 }
 if (!(("" + ("banana".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 490: banana should be < NaN",}, b0, false, false, "EW", null);
+runtime.ext_scratch3_looks._say("fail 490: banana should be < NaN", target);
 }
 if (!(("" + ("banana".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 491: banana should be = NaN",}, b0, false, false, "EY", null);
+runtime.ext_scratch3_looks._say("fail 491: banana should be = NaN", target);
 }
 if (!(("" + ("banana".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 492: banana should be > NaN",}, b0, false, false, "E0", null);
+runtime.ext_scratch3_looks._say("fail 492: banana should be > NaN", target);
 }
 if (!(("" + ("banana".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 493: banana should be < Infinity",}, b0, false, false, "E2", null);
+runtime.ext_scratch3_looks._say("fail 493: banana should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 494: banana should be = Infinity",}, b0, false, false, "E4", null);
+runtime.ext_scratch3_looks._say("fail 494: banana should be = Infinity", target);
 }
 if (!(("" + ("banana".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 495: banana should be > Infinity",}, b0, false, false, "E6", null);
+runtime.ext_scratch3_looks._say("fail 495: banana should be > Infinity", target);
 }
 if (!(("" + ("banana".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 496: banana should be < banana",}, b0, false, false, "E8", null);
+runtime.ext_scratch3_looks._say("fail 496: banana should be < banana", target);
 }
 if (!(("" + ("banana".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 497: banana should be = banana",}, b0, false, false, "E!", null);
+runtime.ext_scratch3_looks._say("fail 497: banana should be = banana", target);
 }
 if (!(("" + ("banana".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 498: banana should be > banana",}, b0, false, false, "E%", null);
+runtime.ext_scratch3_looks._say("fail 498: banana should be > banana", target);
 }
 if (!(("" + ("banana".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 499: banana should be < 🎉",}, b0, false, false, "E)", null);
+runtime.ext_scratch3_looks._say("fail 499: banana should be < 🎉", target);
 }
 if (!(("" + ("banana".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 500: banana should be = 🎉",}, b0, false, false, "E+", null);
+runtime.ext_scratch3_looks._say("fail 500: banana should be = 🎉", target);
 }
 if (!(("" + ("banana".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 501: banana should be > 🎉",}, b0, false, false, "E-", null);
+runtime.ext_scratch3_looks._say("fail 501: banana should be > 🎉", target);
 }
 if (!(("" + ("banana".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 502: banana should be < ",}, b0, false, false, "E/", null);
+runtime.ext_scratch3_looks._say("fail 502: banana should be < ", target);
 }
 if (!(("" + ("banana".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 503: banana should be = ",}, b0, false, false, "E;", null);
+runtime.ext_scratch3_looks._say("fail 503: banana should be = ", target);
 }
 if (!(("" + ("banana".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 504: banana should be > ",}, b0, false, false, "E?", null);
+runtime.ext_scratch3_looks._say("fail 504: banana should be > ", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 505: 🎉 should be < 0",}, b0, false, false, "E[", null);
+runtime.ext_scratch3_looks._say("fail 505: 🎉 should be < 0", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 506: 🎉 should be = 0",}, b0, false, false, "E^", null);
+runtime.ext_scratch3_looks._say("fail 506: 🎉 should be = 0", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 507: 🎉 should be > 0",}, b0, false, false, "E`", null);
+runtime.ext_scratch3_looks._say("fail 507: 🎉 should be > 0", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 508: 🎉 should be < 0.0",}, b0, false, false, "E|", null);
+runtime.ext_scratch3_looks._say("fail 508: 🎉 should be < 0.0", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 509: 🎉 should be = 0.0",}, b0, false, false, "E~", null);
+runtime.ext_scratch3_looks._say("fail 509: 🎉 should be = 0.0", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 510: 🎉 should be > 0.0",}, b0, false, false, "Fb", null);
+runtime.ext_scratch3_looks._say("fail 510: 🎉 should be > 0.0", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 511: 🎉 should be < 1.23",}, b0, false, false, "Fd", null);
+runtime.ext_scratch3_looks._say("fail 511: 🎉 should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 512: 🎉 should be = 1.23",}, b0, false, false, "Ff", null);
+runtime.ext_scratch3_looks._say("fail 512: 🎉 should be = 1.23", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 513: 🎉 should be > 1.23",}, b0, false, false, "Fh", null);
+runtime.ext_scratch3_looks._say("fail 513: 🎉 should be > 1.23", target);
 }
 if (!(("" + ("🎉".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 514: 🎉 should be < .23",}, b0, false, false, "Fj", null);
+runtime.ext_scratch3_looks._say("fail 514: 🎉 should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 515: 🎉 should be = .23",}, b0, false, false, "Fl", null);
+runtime.ext_scratch3_looks._say("fail 515: 🎉 should be = .23", target);
 }
 if (!(("" + ("🎉".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 516: 🎉 should be > .23",}, b0, false, false, "Fn", null);
+runtime.ext_scratch3_looks._say("fail 516: 🎉 should be > .23", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 517: 🎉 should be < 0.123",}, b0, false, false, "Fp", null);
+runtime.ext_scratch3_looks._say("fail 517: 🎉 should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 518: 🎉 should be = 0.123",}, b0, false, false, "Fr", null);
+runtime.ext_scratch3_looks._say("fail 518: 🎉 should be = 0.123", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 519: 🎉 should be > 0.123",}, b0, false, false, "Ft", null);
+runtime.ext_scratch3_looks._say("fail 519: 🎉 should be > 0.123", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 520: 🎉 should be < -0",}, b0, false, false, "Fv", null);
+runtime.ext_scratch3_looks._say("fail 520: 🎉 should be < -0", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 521: 🎉 should be = -0",}, b0, false, false, "Fx", null);
+runtime.ext_scratch3_looks._say("fail 521: 🎉 should be = -0", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 522: 🎉 should be > -0",}, b0, false, false, "Fz", null);
+runtime.ext_scratch3_looks._say("fail 522: 🎉 should be > -0", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 523: 🎉 should be < -1",}, b0, false, false, "FB", null);
+runtime.ext_scratch3_looks._say("fail 523: 🎉 should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 524: 🎉 should be = -1",}, b0, false, false, "FD", null);
+runtime.ext_scratch3_looks._say("fail 524: 🎉 should be = -1", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 525: 🎉 should be > -1",}, b0, false, false, "FF", null);
+runtime.ext_scratch3_looks._say("fail 525: 🎉 should be > -1", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 526: 🎉 should be < true",}, b0, false, false, "FH", null);
+runtime.ext_scratch3_looks._say("fail 526: 🎉 should be < true", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 527: 🎉 should be = true",}, b0, false, false, "FJ", null);
+runtime.ext_scratch3_looks._say("fail 527: 🎉 should be = true", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 528: 🎉 should be > true",}, b0, false, false, "FL", null);
+runtime.ext_scratch3_looks._say("fail 528: 🎉 should be > true", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 529: 🎉 should be < false",}, b0, false, false, "FN", null);
+runtime.ext_scratch3_looks._say("fail 529: 🎉 should be < false", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 530: 🎉 should be = false",}, b0, false, false, "FP", null);
+runtime.ext_scratch3_looks._say("fail 530: 🎉 should be = false", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 531: 🎉 should be > false",}, b0, false, false, "FR", null);
+runtime.ext_scratch3_looks._say("fail 531: 🎉 should be > false", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 532: 🎉 should be < NaN",}, b0, false, false, "FT", null);
+runtime.ext_scratch3_looks._say("fail 532: 🎉 should be < NaN", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 533: 🎉 should be = NaN",}, b0, false, false, "FV", null);
+runtime.ext_scratch3_looks._say("fail 533: 🎉 should be = NaN", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 534: 🎉 should be > NaN",}, b0, false, false, "FX", null);
+runtime.ext_scratch3_looks._say("fail 534: 🎉 should be > NaN", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 535: 🎉 should be < Infinity",}, b0, false, false, "FZ", null);
+runtime.ext_scratch3_looks._say("fail 535: 🎉 should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 536: 🎉 should be = Infinity",}, b0, false, false, "F1", null);
+runtime.ext_scratch3_looks._say("fail 536: 🎉 should be = Infinity", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 537: 🎉 should be > Infinity",}, b0, false, false, "F3", null);
+runtime.ext_scratch3_looks._say("fail 537: 🎉 should be > Infinity", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 538: 🎉 should be < banana",}, b0, false, false, "F5", null);
+runtime.ext_scratch3_looks._say("fail 538: 🎉 should be < banana", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 539: 🎉 should be = banana",}, b0, false, false, "F7", null);
+runtime.ext_scratch3_looks._say("fail 539: 🎉 should be = banana", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 540: 🎉 should be > banana",}, b0, false, false, "F9", null);
+runtime.ext_scratch3_looks._say("fail 540: 🎉 should be > banana", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 541: 🎉 should be < 🎉",}, b0, false, false, "F#", null);
+runtime.ext_scratch3_looks._say("fail 541: 🎉 should be < 🎉", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 542: 🎉 should be = 🎉",}, b0, false, false, "F(", null);
+runtime.ext_scratch3_looks._say("fail 542: 🎉 should be = 🎉", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 543: 🎉 should be > 🎉",}, b0, false, false, "F*", null);
+runtime.ext_scratch3_looks._say("fail 543: 🎉 should be > 🎉", target);
 }
 if (!(("" + ("🎉".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 544: 🎉 should be < ",}, b0, false, false, "F,", null);
+runtime.ext_scratch3_looks._say("fail 544: 🎉 should be < ", target);
 }
 if (!(("" + ("🎉".toLowerCase() === "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 545: 🎉 should be = ",}, b0, false, false, "F.", null);
+runtime.ext_scratch3_looks._say("fail 545: 🎉 should be = ", target);
 }
 if (!(("" + ("🎉".toLowerCase() > "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 546: 🎉 should be > ",}, b0, false, false, "F:", null);
+runtime.ext_scratch3_looks._say("fail 546: 🎉 should be > ", target);
 }
 if (!(("" + ("".toLowerCase() < "0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 547:  should be < 0",}, b0, false, false, "F=", null);
+runtime.ext_scratch3_looks._say("fail 547:  should be < 0", target);
 }
 if (!(("" + ("".toLowerCase() === "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 548:  should be = 0",}, b0, false, false, "F@", null);
+runtime.ext_scratch3_looks._say("fail 548:  should be = 0", target);
 }
 if (!(("" + ("".toLowerCase() > "0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 549:  should be > 0",}, b0, false, false, "F]", null);
+runtime.ext_scratch3_looks._say("fail 549:  should be > 0", target);
 }
 if (!(("" + ("".toLowerCase() < "0.0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 550:  should be < 0.0",}, b0, false, false, "F_", null);
+runtime.ext_scratch3_looks._say("fail 550:  should be < 0.0", target);
 }
 if (!(("" + ("".toLowerCase() === "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 551:  should be = 0.0",}, b0, false, false, "F{", null);
+runtime.ext_scratch3_looks._say("fail 551:  should be = 0.0", target);
 }
 if (!(("" + ("".toLowerCase() > "0.0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 552:  should be > 0.0",}, b0, false, false, "F}", null);
+runtime.ext_scratch3_looks._say("fail 552:  should be > 0.0", target);
 }
 if (!(("" + ("".toLowerCase() < "1.23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 553:  should be < 1.23",}, b0, false, false, "Ga", null);
+runtime.ext_scratch3_looks._say("fail 553:  should be < 1.23", target);
 }
 if (!(("" + (0 === 1.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 554:  should be = 1.23",}, b0, false, false, "Gc", null);
+runtime.ext_scratch3_looks._say("fail 554:  should be = 1.23", target);
 }
 if (!(("" + ("".toLowerCase() > "1.23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 555:  should be > 1.23",}, b0, false, false, "Ge", null);
+runtime.ext_scratch3_looks._say("fail 555:  should be > 1.23", target);
 }
 if (!(("" + ("".toLowerCase() < ".23".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 556:  should be < .23",}, b0, false, false, "Gg", null);
+runtime.ext_scratch3_looks._say("fail 556:  should be < .23", target);
 }
 if (!(("" + (0 === 0.23)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 557:  should be = .23",}, b0, false, false, "Gi", null);
+runtime.ext_scratch3_looks._say("fail 557:  should be = .23", target);
 }
 if (!(("" + ("".toLowerCase() > ".23".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 558:  should be > .23",}, b0, false, false, "Gk", null);
+runtime.ext_scratch3_looks._say("fail 558:  should be > .23", target);
 }
 if (!(("" + ("".toLowerCase() < "0.123".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 559:  should be < 0.123",}, b0, false, false, "Gm", null);
+runtime.ext_scratch3_looks._say("fail 559:  should be < 0.123", target);
 }
 if (!(("" + (0 === 0.123)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 560:  should be = 0.123",}, b0, false, false, "Go", null);
+runtime.ext_scratch3_looks._say("fail 560:  should be = 0.123", target);
 }
 if (!(("" + ("".toLowerCase() > "0.123".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 561:  should be > 0.123",}, b0, false, false, "Gq", null);
+runtime.ext_scratch3_looks._say("fail 561:  should be > 0.123", target);
 }
 if (!(("" + ("".toLowerCase() < "-0".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 562:  should be < -0",}, b0, false, false, "Gs", null);
+runtime.ext_scratch3_looks._say("fail 562:  should be < -0", target);
 }
 if (!(("" + ("".toLowerCase() === "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 563:  should be = -0",}, b0, false, false, "Gu", null);
+runtime.ext_scratch3_looks._say("fail 563:  should be = -0", target);
 }
 if (!(("" + ("".toLowerCase() > "-0".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 564:  should be > -0",}, b0, false, false, "Gw", null);
+runtime.ext_scratch3_looks._say("fail 564:  should be > -0", target);
 }
 if (!(("" + ("".toLowerCase() < "-1".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 565:  should be < -1",}, b0, false, false, "Gy", null);
+runtime.ext_scratch3_looks._say("fail 565:  should be < -1", target);
 }
 if (!(("" + (0 === -1)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 566:  should be = -1",}, b0, false, false, "GA", null);
+runtime.ext_scratch3_looks._say("fail 566:  should be = -1", target);
 }
 if (!(("" + ("".toLowerCase() > "-1".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 567:  should be > -1",}, b0, false, false, "GC", null);
+runtime.ext_scratch3_looks._say("fail 567:  should be > -1", target);
 }
 if (!(("" + ("".toLowerCase() < "true".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 568:  should be < true",}, b0, false, false, "GE", null);
+runtime.ext_scratch3_looks._say("fail 568:  should be < true", target);
 }
 if (!(("" + ("".toLowerCase() === "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 569:  should be = true",}, b0, false, false, "GG", null);
+runtime.ext_scratch3_looks._say("fail 569:  should be = true", target);
 }
 if (!(("" + ("".toLowerCase() > "true".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 570:  should be > true",}, b0, false, false, "GI", null);
+runtime.ext_scratch3_looks._say("fail 570:  should be > true", target);
 }
 if (!(("" + ("".toLowerCase() < "false".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 571:  should be < false",}, b0, false, false, "GK", null);
+runtime.ext_scratch3_looks._say("fail 571:  should be < false", target);
 }
 if (!(("" + ("".toLowerCase() === "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 572:  should be = false",}, b0, false, false, "GM", null);
+runtime.ext_scratch3_looks._say("fail 572:  should be = false", target);
 }
 if (!(("" + ("".toLowerCase() > "false".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 573:  should be > false",}, b0, false, false, "GO", null);
+runtime.ext_scratch3_looks._say("fail 573:  should be > false", target);
 }
 if (!(("" + ("".toLowerCase() < "NaN".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 574:  should be < NaN",}, b0, false, false, "GQ", null);
+runtime.ext_scratch3_looks._say("fail 574:  should be < NaN", target);
 }
 if (!(("" + ("".toLowerCase() === "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 575:  should be = NaN",}, b0, false, false, "GS", null);
+runtime.ext_scratch3_looks._say("fail 575:  should be = NaN", target);
 }
 if (!(("" + ("".toLowerCase() > "NaN".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 576:  should be > NaN",}, b0, false, false, "GU", null);
+runtime.ext_scratch3_looks._say("fail 576:  should be > NaN", target);
 }
 if (!(("" + ("".toLowerCase() < "Infinity".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 577:  should be < Infinity",}, b0, false, false, "GW", null);
+runtime.ext_scratch3_looks._say("fail 577:  should be < Infinity", target);
 }
 if (!(("" + (0 === Infinity)).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 578:  should be = Infinity",}, b0, false, false, "GY", null);
+runtime.ext_scratch3_looks._say("fail 578:  should be = Infinity", target);
 }
 if (!(("" + ("".toLowerCase() > "Infinity".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 579:  should be > Infinity",}, b0, false, false, "G0", null);
+runtime.ext_scratch3_looks._say("fail 579:  should be > Infinity", target);
 }
 if (!(("" + ("".toLowerCase() < "banana".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 580:  should be < banana",}, b0, false, false, "G2", null);
+runtime.ext_scratch3_looks._say("fail 580:  should be < banana", target);
 }
 if (!(("" + ("".toLowerCase() === "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 581:  should be = banana",}, b0, false, false, "G4", null);
+runtime.ext_scratch3_looks._say("fail 581:  should be = banana", target);
 }
 if (!(("" + ("".toLowerCase() > "banana".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 582:  should be > banana",}, b0, false, false, "G6", null);
+runtime.ext_scratch3_looks._say("fail 582:  should be > banana", target);
 }
 if (!(("" + ("".toLowerCase() < "🎉".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 583:  should be < 🎉",}, b0, false, false, "G8", null);
+runtime.ext_scratch3_looks._say("fail 583:  should be < 🎉", target);
 }
 if (!(("" + ("".toLowerCase() === "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 584:  should be = 🎉",}, b0, false, false, "G!", null);
+runtime.ext_scratch3_looks._say("fail 584:  should be = 🎉", target);
 }
 if (!(("" + ("".toLowerCase() > "🎉".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 585:  should be > 🎉",}, b0, false, false, "G%", null);
+runtime.ext_scratch3_looks._say("fail 585:  should be > 🎉", target);
 }
 if (!(("" + ("".toLowerCase() < "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 586:  should be < ",}, b0, false, false, "G)", null);
+runtime.ext_scratch3_looks._say("fail 586:  should be < ", target);
 }
 if (!(("" + ("".toLowerCase() === "".toLowerCase())).toLowerCase() === "true".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 587:  should be = ",}, b0, false, false, "G+", null);
+runtime.ext_scratch3_looks._say("fail 587:  should be = ", target);
 }
 if (!(("" + ("".toLowerCase() > "".toLowerCase())).toLowerCase() === "false".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail 588:  should be > ",}, b0, false, false, "G.", null);
+runtime.ext_scratch3_looks._say("fail 588:  should be > ", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "G-", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-comparison-matrix-runtime.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-comparison-matrix-runtime.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "ae", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 yield* thread.procedures["Wrun test"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "aZ", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -18,7 +17,6 @@ const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 const b2 = stage.variables["n^wm8jw#b24sggt.S^tD"];
 const b3 = stage.variables["_]6^lq+-%H0{ov`tKt7$"];
 const b4 = stage.variables["3lyKRepBc$tx)EWlpr!y"];
-const b5 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_run_test () {
 thread.procedures["Wsetup values"]();
 b0.value = 0;
@@ -30,16 +28,15 @@ for (var a1 = b2.value.length; a1 > 0; a1--) {
 b3.value = (toNotNaN(+b3.value) + 1);
 b0.value = (toNotNaN(+b0.value) + 1);
 if (!compareEqual(compareGreaterThan(listGet(b2.value, b1.value), (b2.value[(b3.value | 0) - 1] ?? "")), (b4.value[(b0.value | 0) - 1] ?? ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be > " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))),}, b5, true, false, "]", null);
+runtime.ext_scratch3_looks._say(("fail " + (("" + listGet(b2.value, b1.value)) + (" should be > " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))), target);
 }
-b0.value = (toNotNaN(+b0.value) + 1);
-if (!compareEqual(compareEqual(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be = " + ("" + listGet(b2.value, b3.value))))),}, b5, true, false, "|", null);
+b0.value = (b0.value + 1);
+if (!compareEqual(compareEqual(listGet(b2.value, b1.value), (b2.value[(b3.value | 0) - 1] ?? "")), (b4.value[(b0.value | 0) - 1] ?? ""))) {
+runtime.ext_scratch3_looks._say(("fail " + (("" + listGet(b2.value, b1.value)) + (" should be = " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))), target);
 }
-b0.value = (toNotNaN(+b0.value) + 1);
-if (!compareEqual(compareLessThan(listGet(b2.value, b1.value), listGet(b2.value, b3.value)), (b4.value[(b0.value | 0) - 1] ?? ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail " + (("" + listGet(b2.value, b1.value)) + (" should be < " + ("" + listGet(b2.value, b3.value))))),}, b5, true, true, "ab", null);
-if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+b0.value = (b0.value + 1);
+if (!compareEqual(compareLessThan(listGet(b2.value, b1.value), (b2.value[(b3.value | 0) - 1] ?? "")), (b4.value[(b0.value | 0) - 1] ?? ""))) {
+runtime.ext_scratch3_looks._say(("fail " + (("" + listGet(b2.value, b1.value)) + (" should be < " + ("" + (b2.value[(b3.value | 0) - 1] ?? ""))))), target);
 }
 if (isStuck()) yield;
 }

--- a/test/snapshot/__snapshots__/warp-timer/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-compatibility-layer-type-barrier.sb3.tw-snapshot
@@ -3,17 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("looks_sayforsecs");
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = runtime.getOpcodeFunction("looks_sayforsecs");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
-b1.value = (0 + 0);
-yield* executeInCompatibilityLayer({"MESSAGE":"Hello!","SECS":0.1,}, b2, false, false, "d", null);
-if (((toNotNaN(+b1.value) + 2) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "i", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (0 + 0);
+yield* executeInCompatibilityLayer({"MESSAGE":"Hello!","SECS":0.1,}, b1, false, false, "d", null);
+if (((toNotNaN(+b0.value) + 2) === 2)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-coordinate-precision.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-coordinate-precision.sb3.tw-snapshot
@@ -3,34 +3,33 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = runtime.getSpriteTargetByName("Sprite1");
+const b0 = runtime.getSpriteTargetByName("Sprite1");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, "`f)8`e7_V%]cmRy7eZ?*", null);
+runtime.ext_scratch3_looks._say("plan 6", target);
 target.setXY(1e-9, target.y);
 if ((limitPrecision(target.x) === 1e-9)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass much above x does not round",}, b0, false, false, "wnAyae772?^VZ]bq?#*p", null);
+runtime.ext_scratch3_looks._say("pass much above x does not round", target);
 }
-if (((b1 ? b1.x : 0) === 1e-9)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass initial 'of' test",}, b0, false, false, "${qf}t3_Wf_/sqC#i0WN", null);
+if (((b0 ? b0.x : 0) === 1e-9)) {
+runtime.ext_scratch3_looks._say("pass initial 'of' test", target);
 }
 target.setXY(target.x + 0, target.y);
 runtime.ext_scratch3_motion._moveSteps(0, target);
 target.setXY(target.x + -9e-10, target.y);
-if (((b1 ? b1.x : 0) === 1.0000000000000007e-10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 'of' never rounds - positive x",}, b0, false, false, "zt/Fd,i768/rohNq-OU/", null);
+if (((b0 ? b0.x : 0) === 1.0000000000000007e-10)) {
+runtime.ext_scratch3_looks._say("pass 'of' never rounds - positive x", target);
 }
 if ((limitPrecision(target.x) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass x slightly above 0 rounds",}, b0, false, false, "p5a6(?e#B|B(d.fe;b6F", null);
+runtime.ext_scratch3_looks._say("pass x slightly above 0 rounds", target);
 }
 target.setXY(target.x + -9e-10, target.y);
 target.setXY(target.x, target.y + 0);
-if (((b1 ? b1.x : 0) === -7.999999999999999e-10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 'of' never rounds and change x - negative x",}, b0, false, false, "![=|9E8]xp_9QR]fu}4M", null);
+if (((b0 ? b0.x : 0) === -7.999999999999999e-10)) {
+runtime.ext_scratch3_looks._say("pass 'of' never rounds and change x - negative x", target);
 }
 if ((limitPrecision(target.x) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass x slightly below 0 rounds",}, b0, false, false, "4o-vB]D}HJ1/*qW~k3Cd", null);
+runtime.ext_scratch3_looks._say("pass x slightly below 0 rounds", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "8We]d__[]7X;@+e*x~^@", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-counter.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-counter.sb3.tw-snapshot
@@ -3,34 +3,32 @@
 
 // 2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((runtime.ext_scratch3_control._counter === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass global",}, b0, false, false, "C", null);
+runtime.ext_scratch3_looks._say("pass global", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "B", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // 1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 5",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 5", target);
 if ((runtime.ext_scratch3_control._counter === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass initial value = 0",}, b0, false, false, "q", null);
+runtime.ext_scratch3_looks._say("pass initial value = 0", target);
 }
 runtime.ext_scratch3_control._counter++;
 if ((runtime.ext_scratch3_control._counter === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass incr 1",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("pass incr 1", target);
 }
 runtime.ext_scratch3_control._counter++;
 if ((runtime.ext_scratch3_control._counter === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass incr 2",}, b0, false, false, "u", null);
+runtime.ext_scratch3_looks._say("pass incr 2", target);
 }
 runtime.ext_scratch3_control._counter = 0;
 if ((runtime.ext_scratch3_control._counter === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass clear = 0",}, b0, false, false, "w", null);
+runtime.ext_scratch3_looks._say("pass clear = 0", target);
 }
 for (var a0 = 10; a0 > 0; a0--) {
 runtime.ext_scratch3_control._counter++;

--- a/test/snapshot/__snapshots__/warp-timer/tw-custom-report-repeat.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-custom-report-repeat.sb3.tw-snapshot
@@ -3,19 +3,18 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
-b1.value = 0;
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
 for (var a0 = toNotNaN(+thread.procedures["Zblock name"]()); a0 >= 0.5; a0--) {
-b1.value = (toNotNaN(+b1.value) + 1);
+b0.value = (toNotNaN(+b0.value) + 1);
 yield;
 }
-if ((toNotNaN(+b1.value) === 40)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "n", null);
+if ((toNotNaN(+b0.value) === 40)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-exit-state-accounts-for-yields-in-procedures.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-exit-state-accounts-for-yields-in-procedures.sb3.tw-snapshot
@@ -3,17 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = stage.variables["FpLI$ida6)qR,q~y`1|*"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
-b1.value = (1 + 2);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (1 + 2);
 yield* thread.procedures["Zsomething that yields"]();
-if ((("" + listGet(b2.value, b1.value)).toLowerCase() === "the only thing".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "o", null);
+if ((("" + listGet(b1.value, b0.value)).toLowerCase() === "the only thing".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-boolean-number-comparison.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-boolean-number-comparison.sb3.tw-snapshot
@@ -3,21 +3,20 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 4",}, b0, false, false, "i", null);
+runtime.ext_scratch3_looks._say("plan 4", target);
 if (compareGreaterThan(("something".toLowerCase() === "something".toLowerCase()), ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (compareLessThan(("something".toLowerCase() === "else".toLowerCase()), ("1" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((+("something".toLowerCase() === "something".toLowerCase())) > (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 if (((+("something".toLowerCase() === "else".toLowerCase())) < (1 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-non-finite-direction.sb3.tw-snapshot
@@ -3,26 +3,25 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = runtime.getOpcodeFunction("motion_pointtowards");
+const b0 = runtime.getOpcodeFunction("motion_pointtowards");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 4",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("plan 4", target);
 target.setDirection(95);
 if ((target.direction === 95)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 1",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("pass 1", target);
 }
 target.setDirection((1 / 0));
 if ((target.direction === 95)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, "r", null);
+runtime.ext_scratch3_looks._say("pass 2", target);
 }
 target.setDirection(toNotNaN((0 / 0)));
 if ((target.direction === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "u", null);
+runtime.ext_scratch3_looks._say("pass 3", target);
 }
-yield* executeInCompatibilityLayer({"TOWARDS":"Sprite2",}, b1, false, false, "g", null);
+yield* executeInCompatibilityLayer({"TOWARDS":"Sprite2",}, b0, false, false, "g", null);
 if ((target.direction === 90)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, "y", null);
+runtime.ext_scratch3_looks._say("pass 4", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "w", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-random-with-invalid-number-with-period.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-random-with-invalid-number-with-period.sb3.tw-snapshot
@@ -3,30 +3,29 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, "j", null);
-b1.value = runtime.ext_scratch3_operators._random(("an invalid number" + "."), 1);
-if (!(b1.value <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("plan 6", target);
+b0.value = runtime.ext_scratch3_operators._random(("an invalid number" + "."), 1);
+if (!(b0.value <= 0)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (compareLessThan(b1.value, 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "r", null);
+if ((b0.value < 1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + b1.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "s", null);
+if ((("" + b0.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-b1.value = runtime.ext_scratch3_operators._random(1, ("an invalid number" + "."));
-if (!(b1.value <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "v", null);
+b0.value = runtime.ext_scratch3_operators._random(1, ("an invalid number" + "."));
+if (!(b0.value <= 0)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (compareLessThan(b1.value, 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "x", null);
+if ((b0.value < 1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + b1.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "A", null);
+if ((("" + b0.value).toLowerCase().indexOf(".".toLowerCase()) !== -1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "y", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-variable-id-name-desync-name-fallback.sb3.tw-snapshot
@@ -3,21 +3,20 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = target.variables["gTtSj;o_E;Snkn620KF."];
-const b2 = target.variables["zShM`!CD?d_|Z,]5X}N6"];
+const b0 = target.variables["gTtSj;o_E;Snkn620KF."];
+const b1 = target.variables["zShM`!CD?d_|Z,]5X}N6"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "d", null);
-b1.value = 2;
-if ((b1.value === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass variable",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = 2;
+if ((b0.value === 2)) {
+runtime.ext_scratch3_looks._say("pass variable", target);
 }
-b2.value = [];
-b2.value.push(3);
-b2._monitorUpToDate = false;
-if ((toNotNaN(+(b2.value[1 - 1] ?? "")) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass list",}, b0, false, false, "m", null);
+b1.value = [];
+b1.value.push(3);
+b1._monitorUpToDate = false;
+if ((toNotNaN(+(b1.value[1 - 1] ?? "")) === 3)) {
+runtime.ext_scratch3_looks._say("pass list", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-forkphorus-515-wait-zero-seconds-in-warp-mode.sb3.tw-snapshot
@@ -5,17 +5,16 @@
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = runtime.getOpcodeFunction("sound_setvolumeto");
 const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 yield* executeInCompatibilityLayer({"VOLUME":0,}, b0, false, false, "d", null);
 b1.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b2, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wno refresh"]();
 yield* thread.procedures["Wruns below with no refresh"]();
 if (compareEqual(b1.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "v", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, "f", null);
+runtime.ext_scratch3_looks._say("end", target);
 runtime.stopAll();
 retire(); return;
 retire(); return;

--- a/test/snapshot/__snapshots__/warp-timer/tw-gh-201-stop-script-does-not-reevaluate-arguments.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-gh-201-stop-script-does-not-reevaluate-arguments.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 thread.procedures["Zfoo %s"]("");
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-gh-249-quicksort.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-gh-249-quicksort.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "Z", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wrun"]();
 yield* thread.procedures["Wvalidate"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "aw", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -33,20 +32,19 @@ const b0 = stage.variables["7AH{dO^X;}C[{[l~g-7m"];
 const b1 = stage.variables["gPJ}c-PZz?Y+_L][iMU_"];
 const b2 = stage.variables["EF^k=u-t@S)w60;RP?dZ-list-list"];
 const b3 = stage.variables["FsKqV/2kid0gw0J+Jj(c"];
-const b4 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_validate () {
 b0.value = 1;
 b1.value = 1;
 for (var a0 = b2.value.length; a0 > 0; a0--) {
 if (!compareEqual(listGet(b2.value, b1.value), listGet(b3.value, b1.value))) {
 b0.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":("fail mismatch at index " + ("" + b1.value)),}, b4, true, false, ",", null);
+runtime.ext_scratch3_looks._say(("fail mismatch at index " + ("" + b1.value)), target);
 }
 b1.value = (toNotNaN(+b1.value) + 1);
 if (isStuck()) yield;
 }
 if ((toNotNaN(+b0.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass sorted",}, b4, true, false, "aE", null);
+runtime.ext_scratch3_looks._say("pass sorted", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-list-any.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-list-any.sb3.tw-snapshot
@@ -3,36 +3,35 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["eFlmP1{XC+I1:h0Yln.K"];
+const b0 = stage.variables["eFlmP1{XC+I1:h0Yln.K"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 7",}, b0, false, false, "h", null);
-b1.value = [];
-listInsert(b1, "any", "a");
-listInsert(b1, "any", "b");
-listInsert(b1, "any", "c");
-if ((b1.value.length === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("plan 7", target);
+b0.value = [];
+listInsert(b0, "any", "a");
+listInsert(b0, "any", "b");
+listInsert(b0, "any", "c");
+if ((b0.value.length === 3)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, "a")) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "v", null);
+if (listContains(b0, "a")) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, "b")) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "x", null);
+if (listContains(b0, "b")) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, "c")) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "z", null);
+if (listContains(b0, "c")) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if (listContains(b1, listGet(b1.value, "any"))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "A", null);
+if (listContains(b0, listGet(b0.value, "any"))) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-listDelete(b1, "any");
-if ((b1.value.length === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "C", null);
+listDelete(b0, "any");
+if ((b0.value.length === 2)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + listGet(b1.value, "*")).toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "F", null);
+if ((("" + listGet(b0.value, "*")).toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "E", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-loop-condition-optimization-gh-276.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wtest %s"]("random");
-if ((("" + b1.value).toLowerCase() === "random".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "p", null);
+if ((("" + b0.value).toLowerCase() === "random".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "n", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-non-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -3,27 +3,26 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["%ehs:~!Y0l-5=!mnd-B?"];
-const b2 = stage.variables["=3aHfv[mKa)v,Wfpy:y?"];
-const b3 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["%ehs:~!Y0l-5=!mnd-B?"];
+const b1 = stage.variables["=3aHfv[mKa)v,Wfpy:y?"];
+const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
-b1.value = [];
-b1.value.push((1 + 2));
-b1._monitorUpToDate = false;
-b1.value.push("eof");
-b1._monitorUpToDate = false;
-b2.value = 0;
-b3.value = "bwah";
-while (!(("" + b3.value).toLowerCase() === "eof".toLowerCase())) {
-b2.value = (toNotNaN(+b2.value) + 1);
-b3.value = (b1.value[(b2.value | 0) - 1] ?? "");
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = [];
+b0.value.push((1 + 2));
+b0._monitorUpToDate = false;
+b0.value.push("eof");
+b0._monitorUpToDate = false;
+b1.value = 0;
+b2.value = "bwah";
+while (!(("" + b2.value).toLowerCase() === "eof".toLowerCase())) {
+b1.value = (toNotNaN(+b1.value) + 1);
+b2.value = (b0.value[(b1.value | 0) - 1] ?? "");
 yield;
 }
-if ((toNotNaN(+b2.value) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "q", null);
+if ((toNotNaN(+b1.value) === 2)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-obsolete-blocks.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-obsolete-blocks.sb3.tw-snapshot
@@ -3,31 +3,30 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("sensing_userid");
-const b3 = runtime.getOpcodeFunction("motion_xscroll");
-const b4 = runtime.getOpcodeFunction("motion_yscroll");
-const b5 = runtime.getOpcodeFunction("motion_scroll_right");
-const b6 = runtime.getOpcodeFunction("motion_scroll_up");
-const b7 = runtime.getOpcodeFunction("motion_align_scene");
-const b8 = runtime.getOpcodeFunction("looks_setstretchto");
-const b9 = runtime.getOpcodeFunction("looks_changestretchby");
-const b10 = runtime.getOpcodeFunction("looks_hideallsprites");
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b1 = runtime.getOpcodeFunction("sensing_userid");
+const b2 = runtime.getOpcodeFunction("motion_xscroll");
+const b3 = runtime.getOpcodeFunction("motion_yscroll");
+const b4 = runtime.getOpcodeFunction("motion_scroll_right");
+const b5 = runtime.getOpcodeFunction("motion_scroll_up");
+const b6 = runtime.getOpcodeFunction("motion_align_scene");
+const b7 = runtime.getOpcodeFunction("looks_setstretchto");
+const b8 = runtime.getOpcodeFunction("looks_changestretchby");
+const b9 = runtime.getOpcodeFunction("looks_hideallsprites");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "pW2KnJW$%KXFoppMJBAi", null);
-b1.value = (yield* executeInCompatibilityLayer({}, b2, false, false, "X[|X;C.(v[|^i|@0Eqy4", null));
-b1.value = (yield* executeInCompatibilityLayer({}, b3, false, false, "z;H$hVK7X;MZSyO9U/#1", null));
-b1.value = (yield* executeInCompatibilityLayer({}, b4, false, false, ";Q94_J}Jv36TqTll;ji*", null));
-yield* executeInCompatibilityLayer({"DISTANCE":10,}, b5, false, false, "_TLJeW5hG9gAtYO2c*D9", null);
-yield* executeInCompatibilityLayer({"DISTANCE":10,}, b6, false, false, "o=l#1WJR!L37RN`q:`8E", null);
-yield* executeInCompatibilityLayer({"ALIGNMENT":"bottom-left",}, b7, false, false, "idkZ9I+=Q:@xXm;N-2Oy", null);
-yield* executeInCompatibilityLayer({"STRETCH":100,}, b8, false, false, "AMs-%pRGK*v6a[.XifN1", null);
-yield* executeInCompatibilityLayer({"STRETCH":100,}, b8, false, false, "g+bBVCHp+A[-X2E7-7#|", null);
-yield* executeInCompatibilityLayer({"CHANGE":10,}, b9, false, false, "ZN24~,cX56Dc2k4vt}HB", null);
-yield* executeInCompatibilityLayer({"CHANGE":10,}, b9, false, false, "Zjds+5Is*:nb7wnX{rYN", null);
-yield* executeInCompatibilityLayer({}, b10, false, false, "8X_d`@6,B7%wzr7.xE}t", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "C/%^M/1/S`iX8*M~Q;!3", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "(C;YJ2L~?zR[Y)Wti?3m", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = (yield* executeInCompatibilityLayer({}, b1, false, false, "X[|X;C.(v[|^i|@0Eqy4", null));
+b0.value = (yield* executeInCompatibilityLayer({}, b2, false, false, "z;H$hVK7X;MZSyO9U/#1", null));
+b0.value = (yield* executeInCompatibilityLayer({}, b3, false, false, ";Q94_J}Jv36TqTll;ji*", null));
+yield* executeInCompatibilityLayer({"DISTANCE":10,}, b4, false, false, "_TLJeW5hG9gAtYO2c*D9", null);
+yield* executeInCompatibilityLayer({"DISTANCE":10,}, b5, false, false, "o=l#1WJR!L37RN`q:`8E", null);
+yield* executeInCompatibilityLayer({"ALIGNMENT":"bottom-left",}, b6, false, false, "idkZ9I+=Q:@xXm;N-2Oy", null);
+yield* executeInCompatibilityLayer({"STRETCH":100,}, b7, false, false, "AMs-%pRGK*v6a[.XifN1", null);
+yield* executeInCompatibilityLayer({"STRETCH":100,}, b7, false, false, "g+bBVCHp+A[-X2E7-7#|", null);
+yield* executeInCompatibilityLayer({"CHANGE":10,}, b8, false, false, "ZN24~,cX56Dc2k4vt}HB", null);
+yield* executeInCompatibilityLayer({"CHANGE":10,}, b8, false, false, "Zjds+5Is*:nb7wnX{rYN", null);
+yield* executeInCompatibilityLayer({}, b9, false, false, "8X_d`@6,B7%wzr7.xE}t", null);
+runtime.ext_scratch3_looks._say("pass", target);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-one-divide-negative-zero.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-one-divide-negative-zero.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "@|B*yJ0zKh!acN`7L-N5", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (((1 / -0) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "=enYDFG11Nj/0BL:y56w", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ",Cpv8W0RH0RgNky[1xb:", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-preciseProjectTimer-drift-453118719.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-preciseProjectTimer-drift-453118719.sb3.tw-snapshot
@@ -4,13 +4,12 @@
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["PsY$$vp$IVH;dDAr[q2h"];
-const b1 = runtime.getOpcodeFunction("looks_say");
-const b2 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
+const b1 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
 return function* genXYZ () {
 b0.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b1, false, false, "}fY]VN(X|v/[G`P0?@s2", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 for (var a0 = 30; a0 > 0; a0--) {
-b2.value = runtime.ioDevices.clock.projectTimer();
+b1.value = runtime.ioDevices.clock.projectTimer();
 thread.timer = timer();
 var a1 = Math.max(0, 1000 * 0);
 runtime.requestRedraw();
@@ -22,7 +21,7 @@ thread.timer = null;
 yield;
 }
 b0.value = 1;
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, "mDG0BTTG/wwr;/Uz~u^c", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -31,7 +30,6 @@ retire(); return;
 const b0 = stage.variables["l^q!%fq]Bv;72dlGf}^Z"];
 const b1 = runtime.getOpcodeFunction("event_whengreaterthan");
 const b2 = stage.variables["PsY$$vp$IVH;dDAr[q2h"];
-const b3 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 {
 const resolvedValue = toBoolean((yield* executeInCompatibilityLayer({"VALUE":b0.value,"WHENGREATERTHANMENU":"TIMER",}, b1, false, false, "iNmua~6veGey6O-_UB9.", null)));
@@ -45,7 +43,7 @@ retire(); return;
 yield;
 }
 if (compareEqual(b2.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b3, false, false, "JE9*Ms@I!EKJ-|Bcga#W", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-prefers-first-occurence-of-procedure-387608267.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-prefers-first-occurence-of-procedure-387608267.sb3.tw-snapshot
@@ -3,18 +3,16 @@
 
 // Player script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "#0F2+kcgu;or|hdwuT9{", null);
-yield* thread.procedures["ZSet Costume"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "Q^(MKge)QH2e:WH6b6g@", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+thread.procedures["ZSet Costume"]();
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Player ZSet Costume
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_Set_Costume () {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "Z$W^@c(f)rHu:DL/SGuQ", null);
+return function funXYZ_Set_Costume () {
+runtime.ext_scratch3_looks._say("pass", target);
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-arguments-with-same-name.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-arguments-with-same-name.sb3.tw-snapshot
@@ -3,31 +3,28 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "J#qm1yA(@Z6mj%Mgh;0X", null);
-yield* thread.procedures["Znumber or text %s %s"]("bad","ok");
-yield* thread.procedures["Zboolean %b %b"]("false",!false);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "$R-1lb(Mu?gdTIH^;kC_", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
+thread.procedures["Znumber or text %s %s"]("bad","ok");
+thread.procedures["Zboolean %b %b"]("false",!false);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Znumber or text %s %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_number_or_text__ (p0,p1) {
+return function funXYZ_number_or_text__ (p0,p1) {
 if ((("" + p1).toLowerCase() === "ok".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "HH`yRe9(x5%D:eV@EmkE", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 return "";
 }; })
 
 // Sprite1 Zboolean %b %b
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-return function* genXYZ_boolean__ (p0,p1) {
+return function funXYZ_boolean__ (p0,p1) {
 if (toBoolean(p1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "M^!cgco]B(V)je$a6lF7", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-call-resets-variable-input-types-430811055.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-call-resets-variable-input-types-430811055.sb3.tw-snapshot
@@ -3,16 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "qf{MD}-f+l?U+)KA#Vnm", null);
-b1.value = "";
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "";
 thread.procedures["Zdo something"]();
-if (!(b1.value.toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "Sgf_#7|GOpx!R]?Q3]$s", null);
+if (!(b0.value.toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, ",vD-ZG7f{]FoJ`,))JWh", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-prototype-exists-but-not-definition-549160843.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-prototype-exists-but-not-definition-549160843.sb3.tw-snapshot
@@ -3,9 +3,8 @@
 
 // Apple script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "a", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "f", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-non-existant.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-non-existant.sb3.tw-snapshot
@@ -23,19 +23,18 @@ retire(); return;
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
+const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "o", null);
-b1.value = 0;
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = 0;
 if (compareEqual(thread.procedures["Zinvalid params - reporter"](), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass invalid params reporter",}, b0, false, false, "L", null);
+runtime.ext_scratch3_looks._say("pass invalid params reporter", target);
 }
 if (compareEqual(thread.procedures["Zinvalid params - boolean"](), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass invalid params boolean",}, b0, false, false, "N", null);
+runtime.ext_scratch3_looks._say("pass invalid params boolean", target);
 }
 runtime.stopForTarget(target, thread);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "P", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-non-existent.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-non-existent.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
-b1.value = "discard me";
-b1.value = "";
-if ((("" + b1.value).toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent procedure returned empty string",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "discard me";
+b0.value = "";
+if ((("" + b0.value).toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass non existent procedure returned empty string", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-recursion.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-recursion.sb3.tw-snapshot
@@ -3,30 +3,29 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 18",}, b0, false, false, "G", null);
-b1.value = 0;
-b2.value = (yield* thread.procedures["Znon warp recursion should yield %s"](8));
-if ((toNotNaN(+b1.value) === 4)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp recursion yields",}, b0, false, false, "ao", null);
+runtime.ext_scratch3_looks._say("plan 18", target);
+b0.value = 0;
+b1.value = (yield* thread.procedures["Znon warp recursion should yield %s"](8));
+if ((toNotNaN(+b0.value) === 4)) {
+runtime.ext_scratch3_looks._say("pass non warp recursion yields", target);
 }
-b1.value = 0;
-b2.value = thread.procedures["Wwarp recursion should not yield %s"](8);
-if ((b1.value === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass warp recursion does not yield",}, b0, false, false, "ar", null);
+b0.value = 0;
+b1.value = thread.procedures["Wwarp recursion should not yield %s"](8);
+if ((b0.value === 0)) {
+runtime.ext_scratch3_looks._say("pass warp recursion does not yield", target);
 }
-b1.value = 0;
-b2.value = (yield* thread.procedures["Zfib %s"](7));
-if ((toNotNaN(+b1.value) === 20)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp fib yielded",}, b0, false, false, "au", null);
+b0.value = 0;
+b1.value = (yield* thread.procedures["Zfib %s"](7));
+if ((toNotNaN(+b0.value) === 20)) {
+runtime.ext_scratch3_looks._say("pass non warp fib yielded", target);
 }
 yield* thread.procedures["Zrecursing yields between each %s"]("initial");
 yield* thread.procedures["Zrecursing arguments eval order %s %s %s %s"]("initial","","","");
 runtime.stopForTarget(target, thread);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "av", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -63,21 +62,20 @@ return "";
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_recursing_yields_bet (p0) {
 if ((("" + p0).toLowerCase() === "initial".toLowerCase())) {
 b0.value = 0;
 b1.value = (toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 1))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 2))) + toNotNaN((toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))) + toNotNaN(+(yield* yieldThenCallGenerator(thread.procedures["Zrecursing yields between each %s"], 3))))))))))));
 if ((toNotNaN(+b0.value) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recursing between calls yields final",}, b2, false, false, "aK", null);
+runtime.ext_scratch3_looks._say("pass recursing between calls yields final", target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail recursing between calls yields final",}, b2, false, false, "aL", null);
+runtime.ext_scratch3_looks._say("fail recursing between calls yields final", target);
 }
 } else {
 if (compareEqual(b0.value, p0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":("pass recursing between calls yields " + ("" + p0)),}, b2, false, false, "#", null);
+runtime.ext_scratch3_looks._say(("pass recursing between calls yields " + ("" + p0)), target);
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":("fail recursing between calls yields " + ("" + p0)),}, b2, false, false, "%", null);
+runtime.ext_scratch3_looks._say(("fail recursing between calls yields " + ("" + p0)), target);
 }
 }
 return "";
@@ -88,35 +86,34 @@ return "";
 const b0 = stage.variables["4HH82mPlVMOONdl(Ot*7"];
 const b1 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
 const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b3 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_recursing_arguments_ (p0,p1,p2,p3) {
 if ((("" + p0).toLowerCase() === "initial".toLowerCase())) {
 b0.value = [];
 b1.value = 0;
 b2.value = (yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 1",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 2",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 3",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 4","","","")),(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 5","","","")),(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 6","","","")))),"","")),"",(yield* yieldThenCallGenerator(thread.procedures["Zrecursing arguments eval order %s %s %s %s"], "child 7","","",""))));
 if ((("" + (b0.value[1 - 1] ?? "")).toLowerCase() === "1/child 4".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 1",}, b3, false, false, "aZ", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 1", target);
 }
 if ((("" + (b0.value[2 - 1] ?? "")).toLowerCase() === "1/child 5".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 2",}, b3, false, false, "a#", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 2", target);
 }
 if ((("" + (b0.value[3 - 1] ?? "")).toLowerCase() === "2/child 6".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 3",}, b3, false, false, "a(", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 3", target);
 }
 if ((("" + (b0.value[4 - 1] ?? "")).toLowerCase() === "2/child 3".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 4",}, b3, false, false, "a*", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 4", target);
 }
 if ((("" + (b0.value[5 - 1] ?? "")).toLowerCase() === "3/child 2".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 5",}, b3, false, false, "a,", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 5", target);
 }
 if ((("" + (b0.value[6 - 1] ?? "")).toLowerCase() === "3/child 7".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 6",}, b3, false, false, "a.", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 6", target);
 }
 if ((("" + (b0.value[7 - 1] ?? "")).toLowerCase() === "4/child 1".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - 7",}, b3, false, false, "a:", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - 7", target);
 }
 if ((b0.value.length === 7)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass recurse arg order - length is correct",}, b3, false, false, "a=", null);
+runtime.ext_scratch3_looks._say("pass recurse arg order - length is correct", target);
 }
 } else {
 b0.value.push((("" + b1.value) + ("/" + ("" + p0))));

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-simple.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-simple.sb3.tw-snapshot
@@ -3,27 +3,26 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 8",}, b0, false, false, "x", null);
+runtime.ext_scratch3_looks._say("plan 8", target);
 if ((("" + thread.procedures["Zsimplest"]()).toLowerCase() === "It works!".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass simplest",}, b0, false, false, ":", null);
+runtime.ext_scratch3_looks._say("pass simplest", target);
 }
 if ((("" + thread.procedures["Znesting 1"]()).toLowerCase() === "42-54".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass nesting1",}, b0, false, false, "=", null);
+runtime.ext_scratch3_looks._say("pass nesting1", target);
 }
 if ((toNotNaN(+thread.procedures["Wwarp fib %s"](12)) === 144)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass fib 12",}, b0, false, false, "@", null);
+runtime.ext_scratch3_looks._say("pass fib 12", target);
 }
 if ((toNotNaN(+thread.procedures["Wfactorial %s"](12)) === 479001600)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass factorial 12",}, b0, false, false, "]", null);
+runtime.ext_scratch3_looks._say("pass factorial 12", target);
 }
-b1.value = (yield* thread.procedures["Zno shadowing 1 %s %s"]("f","g"));
-if ((("" + b1.value).toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass default return value",}, b0, false, false, "|", null);
+b0.value = thread.procedures["Zno shadowing 1 %s %s"]("f","g");
+if ((("" + b0.value).toLowerCase() === "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass default return value", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "`", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
@@ -61,19 +60,18 @@ return "";
 
 // Sprite1 Zno shadowing 1 %s %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-return function* genXYZ_no_shadowing_1__ (p0,p1) {
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+return function funXYZ_no_shadowing_1__ (p0,p1) {
 if (((("" + p0).toLowerCase() === "f".toLowerCase()) && (("" + p1).toLowerCase() === "g".toLowerCase()))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass shadow check 1",}, b0, false, false, "aq", null);
+runtime.ext_scratch3_looks._say("pass shadow check 1", target);
 }
-b1.value = thread.procedures["Zno shadowing 2 %s %s"](1,2);
+b0.value = thread.procedures["Zno shadowing 2 %s %s"](1,2);
 if (((("" + p0).toLowerCase() === "f".toLowerCase()) && (("" + p1).toLowerCase() === "g".toLowerCase()))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass shadow check 2",}, b0, false, false, "au", null);
+runtime.ext_scratch3_looks._say("pass shadow check 2", target);
 }
-b1.value = thread.procedures["Zno shadowing 2 %s %s"](3,4);
+b0.value = thread.procedures["Zno shadowing 2 %s %s"](3,4);
 if (((("" + p0).toLowerCase() === "f".toLowerCase()) && (("" + p1).toLowerCase() === "g".toLowerCase()))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass shadow check 3",}, b0, false, false, "ax", null);
+runtime.ext_scratch3_looks._say("pass shadow check 3", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-stops-scripts.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-stops-scripts.sb3.tw-snapshot
@@ -3,26 +3,24 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
+const b0 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "f", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 yield* thread.procedures["Wreturn stops the script immediately"]();
-if ((toNotNaN(+b1.value) === 25)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass return stopped the script immediately",}, b0, false, false, "u", null);
+if ((toNotNaN(+b0.value) === 25)) {
+runtime.ext_scratch3_looks._say("pass return stopped the script immediately", target);
 }
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test return outside of custom block" }));
-if ((toNotNaN(+b1.value) === 18)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass return worked to stop outside of custom block",}, b0, false, false, "x", null);
+if ((toNotNaN(+b0.value) === 18)) {
+runtime.ext_scratch3_looks._say("pass return worked to stop outside of custom block", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "v", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Wreturn stops the script immediately
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["PsAI*C{QHI3*4?O8p#TM"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_return_stops_the_scr () {
 b0.value = 0;
 for (var a0 = 100; a0 > 0; a0--) {
@@ -32,7 +30,7 @@ return "stopped!";
 }
 if (isStuck()) yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"fail return did not stop the script immediately",}, b1, true, false, "z", null);
+runtime.ext_scratch3_looks._say("fail return did not stop the script immediately", target);
 return "";
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-warp.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-procedure-return-warp.sb3.tw-snapshot
@@ -23,19 +23,17 @@ retire(); return;
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 3",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("plan 3", target);
 yield* thread.procedures["Znon warp"]();
 runtime.stopForTarget(target, thread);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "N", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Znon warp
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_non_warp () {
 b0.value = 0;
 for (var a0 = 5; a0 > 0; a0--) {
@@ -50,10 +48,10 @@ thread.timer = null;
 yield;
 }
 if ((toNotNaN(+b0.value) === 5)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 1",}, b1, false, false, "R", null);
+runtime.ext_scratch3_looks._say("pass non warp 1", target);
 }
 if ((("" + (yield* thread.procedures["Wverify runs warp %s"]((yield* thread.procedures["Zverify runs non warp %s"]((yield* thread.procedures["Wverify runs warp %s"]("abc"))))))).toLowerCase() === "warp: non warp: warp: abc".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp and warp mix",}, b1, false, false, "S", null);
+runtime.ext_scratch3_looks._say("pass non warp and warp mix", target);
 }
 b0.value = 0;
 for (var a2 = 5; a2 > 0; a2--) {
@@ -68,7 +66,7 @@ thread.timer = null;
 yield;
 }
 if ((toNotNaN(+b0.value) === 5)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non warp 2",}, b1, false, false, "W", null);
+runtime.ext_scratch3_looks._say("pass non warp 2", target);
 }
 return "";
 }; })
@@ -76,7 +74,6 @@ return "";
 // Sprite1 Wverify runs warp %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_verify_runs_warp_ (p0) {
 b0.value = 0;
 for (var a0 = 5; a0 > 0; a0--) {
@@ -90,7 +87,7 @@ thread.timer = null;
 if (isStuck()) yield;
 }
 if (!compareEqual(b0.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail did not run warp",}, b1, true, false, "Z", null);
+runtime.ext_scratch3_looks._say("fail did not run warp", target);
 }
 return ("warp: " + ("" + p0));
 return "";
@@ -99,7 +96,6 @@ return "";
 // Sprite1 Zverify runs non warp %s
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Go=PJS7BFXYo_qi2S:kQ"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_verify_runs_non_warp (p0) {
 b0.value = 0;
 for (var a0 = 5; a0 > 0; a0--) {
@@ -114,7 +110,7 @@ thread.timer = null;
 yield;
 }
 if (compareEqual(b0.value, 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail ran warp",}, b1, false, false, "L", null);
+runtime.ext_scratch3_looks._say("fail ran warp", target);
 }
 return ("non warp: " + ("" + p0));
 return "";

--- a/test/snapshot/__snapshots__/warp-timer/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-promise-loop-double-yield-kouzeru.sb3.tw-snapshot
@@ -5,15 +5,14 @@
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["JbF5exWEi*m?-UEmkASS"];
 const b1 = stage.variables["[G/@.KGc-4y[(GZ(bt7o"];
-const b2 = runtime.getOpcodeFunction("looks_say");
-const b3 = runtime.getOpcodeFunction("sound_seteffectto");
+const b2 = runtime.getOpcodeFunction("sound_seteffectto");
 return function* genXYZ () {
 while (true) {
 if (compareEqual(b0.value, b1.value)) {
 } else {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "89/dl$1dp$~nj81:jj@H", null);
+runtime.ext_scratch3_looks._say("pass", target);
 b1.value = b0.value;
-yield* executeInCompatibilityLayer({"VALUE":b0.value,"EFFECT":"pitch",}, b3, false, true, "*=8r,g4Pzvxo?aSMcpfX", null);
+yield* executeInCompatibilityLayer({"VALUE":b0.value,"EFFECT":"pitch",}, b2, false, true, "*=8r,g4Pzvxo?aSMcpfX", null);
 if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
 }
 yield;
@@ -24,16 +23,15 @@ retire(); return;
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["[G/@.KGc-4y[(GZ(bt7o"];
-const b1 = runtime.getOpcodeFunction("looks_say");
-const b2 = stage.variables["JbF5exWEi*m?-UEmkASS"];
+const b1 = stage.variables["JbF5exWEi*m?-UEmkASS"];
 return function* genXYZ () {
 b0.value = 0;
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b1, false, false, "0/2-)Gp^^=haQ1OMD.xb", null);
+runtime.ext_scratch3_looks._say("plan 15", target);
 for (var a0 = 15; a0 > 0; a0--) {
-if ((toNotNaN(+b2.value) === 200)) {
-b2.value = 50;
+if ((toNotNaN(+b1.value) === 200)) {
+b1.value = 50;
 } else {
-b2.value = 200;
+b1.value = 200;
 }
 thread.timer = timer();
 var a1 = Math.max(0, 1000 * 0);
@@ -45,7 +43,7 @@ yield;
 thread.timer = null;
 yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, "--nBRXyJfqS0MM9`#S3}", null);
+runtime.ext_scratch3_looks._say("end", target);
 runtime.stopAll();
 retire(); return;
 retire(); return;

--- a/test/snapshot/__snapshots__/warp-timer/tw-repeat-analysis-doesnt-reanalyze.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-repeat-analysis-doesnt-reanalyze.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wa"]();
-if ((("" + b1.value).toLowerCase() === "bwah".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "l", null);
+if ((("" + b0.value).toLowerCase() === "bwah".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "k", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-repeat-procedure-reporter-infinite-analyzer-loop.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Text script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "a~", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 yield* thread.procedures["Wtest 1"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "dh", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-restart-broadcast-threads.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-restart-broadcast-threads.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "aQ(Y!Bs3;[rV^Q%AQ,NX", null);
-b1.value = 0;
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 thread.timer = timer();
@@ -18,10 +17,10 @@ while (thread.timer.timeElapsed() < a0) {
 yield;
 }
 thread.timer = null;
-if ((toNotNaN(+b1.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "`SX*FG*Lwo*0_T=box-@", null);
+if ((toNotNaN(+b0.value) === 1)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "|#`zzPA_x%{`FyIAQhb4", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-rotate-by-decimal-without-leading-zero.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-rotate-by-decimal-without-leading-zero.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 target.setDirection(90);
 target.setDirection((target.direction + 0.25));
 target.setDirection((target.direction + 0.25));
 if ((target.direction === 90.5)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "i", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-safe-procedure-argument-casting.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-safe-procedure-argument-casting.sb3.tw-snapshot
@@ -3,18 +3,17 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "J#qm1yA(@Z6mj%Mgh;0X", null);
+runtime.ext_scratch3_looks._say("plan 2", target);
 thread.procedures["Zswitch %s"]("1");
 if ((((target.currentCostume + 1) === 2) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 1))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ";DM$.QW6o-O+T/oBdqt!", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 thread.procedures["Zswitch %s"]("2");
 if ((((target.currentCostume + 1) === 1) && (toNotNaN(+target.getCostumes()[target.currentCostume].name) === 2))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "71a9Slk0w=^~x;5T@nw,", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "$R-1lb(Mu?gdTIH^;kC_", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-self-restarting-script-keeps-running-until-yield.sb3.tw-snapshot
@@ -3,13 +3,12 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["G{NQ*NXG*qzywe1Q3?FM"];
-const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["G{NQ*NXG*qzywe1Q3?FM"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "c", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
 b1.value = 0;
-b2.value = 0;
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 retire(); return;
 }; })
@@ -18,7 +17,6 @@ retire(); return;
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 const b1 = stage.variables["G{NQ*NXG*qzywe1Q3?FM"];
-const b2 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if (compareEqual(b0.value, 0)) {
 b0.value = 1;
@@ -30,9 +28,9 @@ yield;
 b1.value = 2;
 } else {
 if ((toNotNaN(+b1.value) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b2, false, false, "p", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b2, false, false, "n", null);
+runtime.ext_scratch3_looks._say("end", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-sensing-of.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-sensing-of.sb3.tw-snapshot
@@ -3,112 +3,111 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage && stage.lookupVariableByNameAndType("Stage variable", "", true);
-const b2 = runtime.getSpriteTargetByName("Test sprite");
-const b3 = b2 && b2.lookupVariableByNameAndType("Private variable", "", true);
-const b4 = stage && stage.lookupVariableByNameAndType("This variable used to exist", "", true);
-const b5 = stage.variables["GTmK+*w8mNQP,z`4WG8#"];
-const b6 = runtime.getSpriteTargetByName("Sprite that doesn't exist");
+const b0 = stage && stage.lookupVariableByNameAndType("Stage variable", "", true);
+const b1 = runtime.getSpriteTargetByName("Test sprite");
+const b2 = b1 && b1.lookupVariableByNameAndType("Private variable", "", true);
+const b3 = stage && stage.lookupVariableByNameAndType("This variable used to exist", "", true);
+const b4 = stage.variables["GTmK+*w8mNQP,z`4WG8#"];
+const b5 = runtime.getSpriteTargetByName("Sprite that doesn't exist");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 32",}, b0, false, false, "oX(r}qUQo7fd[u~D_4@T", null);
+runtime.ext_scratch3_looks._say("plan 32", target);
 if (((stage.currentCostume + 1) === 2)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass backdrop #",}, b0, false, false, "T9..K[5LEO1f~{%eoPU;", null);
+runtime.ext_scratch3_looks._say("pass backdrop #", target);
 }
 if ((stage.getCostumes()[stage.currentCostume].name.toLowerCase() === "Backdrop name test".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass backdrop name",}, b0, false, false, "q63|^NKAu?OMK%W-s}+~", null);
+runtime.ext_scratch3_looks._say("pass backdrop name", target);
 }
 if (((stage ? stage.volume : 0) === 45)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass stage volume",}, b0, false, false, "9Coi(uM:DG!WPZ($,SnY", null);
+runtime.ext_scratch3_looks._say("pass stage volume", target);
 }
-if ((("" + (b1 ? b1.value : 0)).toLowerCase() === "Variable in stage".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass stage variable",}, b0, false, false, "D_EA]xN%|[NsTKqc4up9", null);
+if ((("" + (b0 ? b0.value : 0)).toLowerCase() === "Variable in stage".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass stage variable", target);
 }
-if (((b2 ? b2.x : 0) === 19)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass x",}, b0, false, false, "ek^n,6zjHyX;YOW;H@]?", null);
+if (((b1 ? b1.x : 0) === 19)) {
+runtime.ext_scratch3_looks._say("pass x", target);
 }
-if (((b2 ? b2.y : 0) === 20)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass y",}, b0, false, false, "-DZ%ny~~x.m12l9I64~W", null);
+if (((b1 ? b1.y : 0) === 20)) {
+runtime.ext_scratch3_looks._say("pass y", target);
 }
-if (((b2 ? b2.direction : 0) === 89)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass direction",}, b0, false, false, "$Y=E2o@3oa-^OHt5v:-b", null);
+if (((b1 ? b1.direction : 0) === 89)) {
+runtime.ext_scratch3_looks._say("pass direction", target);
 }
-if (((b2 ? b2.currentCostume + 1 : 0) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass costume #",}, b0, false, false, "+zO[+f?c7F`ZGTbD.oqI", null);
+if (((b1 ? b1.currentCostume + 1 : 0) === 3)) {
+runtime.ext_scratch3_looks._say("pass costume #", target);
 }
-if (((b2 ? b2.getCostumes()[b2.currentCostume].name : 0).toLowerCase() === "Costume name test".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass costume name",}, b0, false, false, "Y6L|T0Pvwsct2gq+HGvv", null);
+if (((b1 ? b1.getCostumes()[b1.currentCostume].name : 0).toLowerCase() === "Costume name test".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass costume name", target);
 }
-if (((b2 ? b2.size : 0) === 76.01)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass size",}, b0, false, false, "IBZv@o)qX~r6)!;hqaWa", null);
+if (((b1 ? b1.size : 0) === 76.01)) {
+runtime.ext_scratch3_looks._say("pass size", target);
 }
-if (((b2 ? b2.volume : 0) === 14.3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass volume",}, b0, false, false, "JBHJ,)N)@]~;;yFTY`RG", null);
+if (((b1 ? b1.volume : 0) === 14.3)) {
+runtime.ext_scratch3_looks._say("pass volume", target);
 }
-if ((("" + (b3 ? b3.value : 0)).toLowerCase() === "Private variable value".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass private variable",}, b0, false, false, "#jYbx])r8^`95~ZgPtZD", null);
+if ((("" + (b2 ? b2.value : 0)).toLowerCase() === "Private variable value".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass private variable", target);
 }
-if (compareEqual((b4 ? b4.value : 0), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass non existent variable",}, b0, false, false, ")nnN?*l+E)dC(fT5(_@q", null);
+if (compareEqual((b3 ? b3.value : 0), 0)) {
+runtime.ext_scratch3_looks._say("pass non existent variable", target);
 }
-b5.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b5.value, PROPERTY: "backdrop #" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, "UFr{fbR3@a.u_paq:r]F", null);
+b4.value = (("" + randomInt(1, 9)) + ("" + randomInt(1, 9)));
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "backdrop #" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop #", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "backdrop name" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop name",}, b0, false, false, "wzVsIitt0^t(wDS-V3?Z", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "backdrop name" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop name", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "volume" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, ":SZx%]xR5t`;;@M~:jT:", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "volume" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE volume", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "Stage variable" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE stage variable",}, b0, false, false, "!eEjdEJj!yYb{buag^M[", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "Stage variable" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE stage variable", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "x position" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE x",}, b0, false, false, "!6!o,FiLV=w2bS~{R|AK", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "x position" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE x", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "y position" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE y",}, b0, false, false, "5K7_7*adzRDbfFjxanQF", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "y position" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE y", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "direction" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE direction",}, b0, false, false, "D{z)e;(*H|.gAykbuSkE", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "direction" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE direction", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "costume #" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE costume #",}, b0, false, false, "WgCH3j9ObHA,;P3T=now", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "costume #" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE costume #", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "costume name" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE costume name",}, b0, false, false, "qhxQy$^wiOTOEu.=2^i)", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "costume name" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE costume name", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "size" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE size",}, b0, false, false, "+6V.t=]xZ=Gl?%-OWbFy", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "size" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE size", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "volume" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, "*E:B}?C@H2ce2uRr9.9=", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "volume" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE volume", target);
 }
-if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: ("" + b5.value), PROPERTY: "Private variable" }), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE private variable",}, b0, false, false, "B6r;3{7R7g4Z.pzeGiCM", null);
+if (compareEqual(runtime.ext_scratch3_sensing.getAttributeOf({OBJECT: b4.value, PROPERTY: "Private variable" }), 0)) {
+runtime.ext_scratch3_looks._say("pass NE private variable", target);
 }
-if (((b6 ? b6.x : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop #",}, b0, false, false, "q[X%xv.u6==Riu20?y{I", null);
+if (((b5 ? b5.x : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop #", target);
 }
-if (((b6 ? b6.y : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE backdrop name",}, b0, false, false, "?M4CH@e3~]30+$4[brH[", null);
+if (((b5 ? b5.y : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE backdrop name", target);
 }
-if (((b6 ? b6.direction : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE volume",}, b0, false, false, "H:D~v_)nZ?oJ8X|qHag#", null);
+if (((b5 ? b5.direction : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE volume", target);
 }
-if (((b6 ? b6.currentCostume + 1 : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE stage variable",}, b0, false, false, "lqwZ[26e,$PwYz,OlO0X", null);
+if (((b5 ? b5.currentCostume + 1 : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE stage variable", target);
 }
-if (compareEqual((b6 ? b6.getCostumes()[b6.currentCostume].name : 0), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE x",}, b0, false, false, "I@zdHi0kl|{:ze_J.}S_", null);
+if (compareEqual((b5 ? b5.getCostumes()[b5.currentCostume].name : 0), 0)) {
+runtime.ext_scratch3_looks._say("pass NE x", target);
 }
-if (((b6 ? b6.size : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE y",}, b0, false, false, "qD{Ni|{SL:`04:Gj/A7B", null);
+if (((b5 ? b5.size : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE y", target);
 }
-if (((b6 ? b6.volume : 0) === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass NE direction",}, b0, false, false, "vvB(iq@jjvj{=_{:6DXZ", null);
+if (((b5 ? b5.volume : 0) === 0)) {
+runtime.ext_scratch3_looks._say("pass NE direction", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "dJRK.)mKX6,r26Jy]5qr", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-simple-string-operations.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-simple-string-operations.sb3.tw-snapshot
@@ -3,15 +3,14 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["PJl9-2GypE.OstQk*B_*"];
+const b0 = stage.variables["PJl9-2GypE.OstQk*B_*"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "d", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wa"]();
-if ((("" + b1.value).toLowerCase() === "babab".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "s", null);
+if ((("" + b0.value).toLowerCase() === "babab".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "q", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-sound-menu-avoids-number-literal-if-name-conflict.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-sound-menu-avoids-number-literal-if-name-conflict.sb3.tw-snapshot
@@ -3,19 +3,18 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 2",}, b0, false, false, "f", null);
-b1.value = "5";
+runtime.ext_scratch3_looks._say("plan 2", target);
+b0.value = "5";
 runtime.ext_scratch3_looks._setCostume(target, "costume1");
 if (((target.currentCostume + 1) === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass initial costume",}, b0, false, false, "p", null);
+runtime.ext_scratch3_looks._say("pass initial costume", target);
 }
-runtime.ext_scratch3_looks._setCostume(target, b1.value);
+runtime.ext_scratch3_looks._setCostume(target, b0.value);
 if (((target.currentCostume + 1) === 3)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass costume \"5\"",}, b0, false, false, "m", null);
+runtime.ext_scratch3_looks._say("pass costume \"5\"", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "l", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-stage-cannot-move-layers.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-stage-cannot-move-layers.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "5,snC%48IW(1ZVM(k0l2", null);
-b1.value = "Initial";
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = "Initial";
 thread.timer = timer();
 var a0 = Math.max(0, 1000 * 0);
 runtime.requestRedraw();
@@ -17,17 +16,16 @@ yield;
 }
 thread.timer = null;
 yield* waitThreads(startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "Test 1" }));
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "5.$W?rkoLYkKo1qX@%@?", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if ((("" + b0.value).toLowerCase() === "Initial".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b1, false, false, "eR%8T)3MQjkbQkAh~L0%", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-state-analysis-understands-stop-this-script.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-state-analysis-understands-stop-this-script.sb3.tw-snapshot
@@ -3,16 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["KMKx1gRubgLz,!L]^TBS"];
-const b2 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["KMKx1gRubgLz,!L]^TBS"];
+const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "g", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 thread.procedures["Wtest"]();
-if ((("" + listGet(b1.value, b2.value)).toLowerCase() === "thing".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "m", null);
+if ((("" + listGet(b0.value, b1.value)).toLowerCase() === "thing".toLowerCase())) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "o", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-subtract-can-return-nan.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-subtract-can-return-nan.sb3.tw-snapshot
@@ -3,12 +3,11 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "6_?4sPB-|g:DtjdOm5Q-", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 if (!((Infinity - Infinity) <= 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, ")-u2YbbMb;gXMPOidjPj", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "zqE}hdaes.b)@mO1{R;X", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-tab-equals-zero.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-tab-equals-zero.sb3.tw-snapshot
@@ -3,11 +3,10 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["Kl,Own0m6{^v3$E{Wsc="];
+const b0 = stage.variables["Kl,Own0m6{^v3$E{Wsc="];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 6",}, b0, false, false, "i", null);
-b1.value = "\t";
+runtime.ext_scratch3_looks._say("plan 6", target);
+b0.value = "\t";
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
 retire(); return;
 }; })
@@ -15,26 +14,25 @@ retire(); return;
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["Kl,Own0m6{^v3$E{Wsc="];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
 if (compareEqual(b0.value, ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t in a variable = string 0",}, b1, false, false, "q", null);
+runtime.ext_scratch3_looks._say("pass \\t in a variable = string 0", target);
 }
 if (compareEqual("\t", ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass literal \\t = string 0",}, b1, false, false, "u", null);
+runtime.ext_scratch3_looks._say("pass literal \\t = string 0", target);
 }
 if (compareEqual(("    " + ("" + b0.value)), ("0" + ""))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t and other spaces = string 0",}, b1, false, false, "w", null);
+runtime.ext_scratch3_looks._say("pass \\t and other spaces = string 0", target);
 }
 if (compareEqual(b0.value, (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t in a variable = number 0",}, b1, false, false, "z", null);
+runtime.ext_scratch3_looks._say("pass \\t in a variable = number 0", target);
 }
 if ((0 === (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass literal \\t = number 0",}, b1, false, false, "B", null);
+runtime.ext_scratch3_looks._say("pass literal \\t = number 0", target);
 }
 if (compareEqual(("    " + ("" + b0.value)), (0 + 0))) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass \\t and other spaces = number 0",}, b1, false, false, "E", null);
+runtime.ext_scratch3_looks._say("pass \\t and other spaces = number 0", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b1, false, false, "D", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-tangent.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-tangent.sb3.tw-snapshot
@@ -3,54 +3,53 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 15",}, b0, false, false, "p", null);
+runtime.ext_scratch3_looks._say("plan 15", target);
 if (compareEqual(tan(0), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 0",}, b0, false, false, "O", null);
+runtime.ext_scratch3_looks._say("pass 0", target);
 }
 if ((toNotNaN(tan(90)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 90",}, b0, false, false, "G", null);
+runtime.ext_scratch3_looks._say("pass 90", target);
 }
 if (compareEqual(tan(180), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 180",}, b0, false, false, "I", null);
+runtime.ext_scratch3_looks._say("pass 180", target);
 }
 if ((toNotNaN(tan(270)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 270",}, b0, false, false, "K", null);
+runtime.ext_scratch3_looks._say("pass 270", target);
 }
 if (compareEqual(tan(360), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 360",}, b0, false, false, "M", null);
+runtime.ext_scratch3_looks._say("pass 360", target);
 }
 if ((toNotNaN(tan(450)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 450",}, b0, false, false, "Q", null);
+runtime.ext_scratch3_looks._say("pass 450", target);
 }
 if (compareEqual(tan(540), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 540",}, b0, false, false, "S", null);
+runtime.ext_scratch3_looks._say("pass 540", target);
 }
 if ((toNotNaN(tan(630)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 630",}, b0, false, false, "U", null);
+runtime.ext_scratch3_looks._say("pass 630", target);
 }
 if (compareEqual(tan(720), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 720",}, b0, false, false, "W", null);
+runtime.ext_scratch3_looks._say("pass 720", target);
 }
 if ((toNotNaN(tan(810)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 810",}, b0, false, false, "Y", null);
+runtime.ext_scratch3_looks._say("pass 810", target);
 }
 if ((toNotNaN(tan(-90)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -90",}, b0, false, false, "0", null);
+runtime.ext_scratch3_looks._say("pass -90", target);
 }
 if (compareEqual(tan(-180), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -180",}, b0, false, false, "2", null);
+runtime.ext_scratch3_looks._say("pass -180", target);
 }
 if ((toNotNaN(tan(-270)) === Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -270",}, b0, false, false, "4", null);
+runtime.ext_scratch3_looks._say("pass -270", target);
 }
 if (compareEqual(tan(-360), 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -360",}, b0, false, false, "6", null);
+runtime.ext_scratch3_looks._say("pass -360", target);
 }
 if ((toNotNaN(tan(-450)) === -Infinity)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass -450",}, b0, false, false, "9", null);
+runtime.ext_scratch3_looks._say("pass -450", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "8", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-unsafe-equals.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-unsafe-equals.sb3.tw-snapshot
@@ -3,84 +3,81 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables[",OktMIwz{~bdgWnPEa8u"];
-const b2 = stage.variables["yfy(G`K5K^fJcXAfiN4i"];
+const b0 = stage.variables[",OktMIwz{~bdgWnPEa8u"];
+const b1 = stage.variables["yfy(G`K5K^fJcXAfiN4i"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 14",}, b0, false, false, "S8W[CSRh5A:[y8s/Ridj", null);
+runtime.ext_scratch3_looks._say("plan 14", target);
 if ((10 === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 1",}, b0, false, false, "1ove2a-$DQw7qy5PGdgq", null);
+runtime.ext_scratch3_looks._say("pass 1", target);
 }
 if ((10 === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 2",}, b0, false, false, "@A5}x{mm-Gk?CVz3o0Yn", null);
+runtime.ext_scratch3_looks._say("pass 2", target);
 }
-b1.value = 10;
-if ((b1.value === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 3",}, b0, false, false, "Ul:BCck-}Fvdux~x#$${", null);
+b0.value = 10;
+if ((b0.value === 10)) {
+runtime.ext_scratch3_looks._say("pass 3", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 4",}, b0, false, false, "8]2$7P)o#+#Lo]mFSBbx", null);
+if ((b0.value === 10)) {
+runtime.ext_scratch3_looks._say("pass 4", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 5",}, b0, false, false, "ZU^{OfKTg|+Au$$q0[]u", null);
+if ((b0.value === 10)) {
+runtime.ext_scratch3_looks._say("pass 5", target);
 }
 for (var a0 = 1; a0 > 0; a0--) {
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 6",}, b0, false, false, "HB+_IN}6=K[*ksxKXH0`", null);
+if ((toNotNaN(+b0.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 6", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 7",}, b0, false, false, ";73ODiwcp8IthYURTX;S", null);
+if ((toNotNaN(+b0.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 7", target);
 }
-if ((toNotNaN(+b1.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 8",}, b0, false, true, "${[MFmBL-D*1rbas9Q89", null);
-if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+if ((toNotNaN(+b0.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 8", target);
 }
 yield;
 }
-b2.value = "010";
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 9",}, b0, false, false, "#.`@SBj!g-c0:_q/tMZo", null);
+b1.value = "010";
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 9", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 10",}, b0, false, false, "B`o?V6/q6g),/2w};a#y", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 10", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 11",}, b0, false, false, "TJ:#TkYBys*!RYiKLXb)", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 11", target);
 }
 for (var a1 = 1; a1 > 0; a1--) {
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 12",}, b0, false, false, ",Z,~10Qo~j;(+VL+I3q:", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 12", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 13",}, b0, false, false, "|Mqx([(26M%#ggW9)U0s", null);
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 13", target);
 }
-if ((toNotNaN(+b2.value) === 10)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass 14",}, b0, false, true, "YvtiKF231lU8p5Qd97RP", null);
-if (hasResumedFromPromise) {hasResumedFromPromise = false;continue;}
+if ((toNotNaN(+b1.value) === 10)) {
+runtime.ext_scratch3_looks._say("pass 14", target);
 }
 yield;
 }
 if ((0 === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "yO!,nQodLC}uqIc?212+", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if ((1 === 0)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "XzQt!.^A,SV?q0`Ui)wG", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if ((0 === 1)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "rxZqw7cv8g;PDM4B%{`?", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if ((" ".toLowerCase() === "0".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "3G|)eVw1mQm;O~cRy`}0", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if (("0".toLowerCase() === " ".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "sd5xXX*tsW/~A_Q!0;^w", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if (("".toLowerCase() === "0".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "7**baE=].WD9OoY1+IEu", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
 if (("0".toLowerCase() === "".toLowerCase())) {
-yield* executeInCompatibilityLayer({"MESSAGE":"fail",}, b0, false, false, "7!IB!=o/2H.Jqj-8Vwhz", null);
+runtime.ext_scratch3_looks._say("fail", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "df{tf!WhfRwXgQ?SN_dj", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-wait-until-condition-gh-277.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-wait-until-condition-gh-277.sb3.tw-snapshot
@@ -3,16 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
+const b0 = stage.variables["`jEk@4|i[#Fk?(8x)AV.-my variable"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "message1" });
-b1.value = "bwah";
-while (!(("" + b1.value).toLowerCase() === "bleh".toLowerCase())) {
+b0.value = "bwah";
+while (!(("" + b0.value).toLowerCase() === "bleh".toLowerCase())) {
 yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "h", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-warp-loop-condition-analysis.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-warp-loop-condition-analysis.sb3.tw-snapshot
@@ -3,23 +3,22 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables[";~q(!vt3c.Jrz2M]ZMy]"];
-const b2 = stage.variables[",23fjp~KN1aMG|;66K@Z"];
+const b0 = stage.variables[";~q(!vt3c.Jrz2M]ZMy]"];
+const b1 = stage.variables[",23fjp~KN1aMG|;66K@Z"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "j", null);
-b1.value = [];
-b1.value.push((1 + 2));
-b1._monitorUpToDate = false;
-b1.value.push((3 + 4));
-b1._monitorUpToDate = false;
-b1.value.push("final");
-b1._monitorUpToDate = false;
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = [];
+b0.value.push((1 + 2));
+b0._monitorUpToDate = false;
+b0.value.push((3 + 4));
+b0._monitorUpToDate = false;
+b0.value.push("final");
+b0._monitorUpToDate = false;
 yield* thread.procedures["Wtest"]();
-if ((toNotNaN(+b2.value) === 4)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "u", null);
+if ((toNotNaN(+b1.value) === 4)) {
+runtime.ext_scratch3_looks._say("pass", target);
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "t", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 

--- a/test/snapshot/__snapshots__/warp-timer/tw-warp-repeat-until-timer-greater-than.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-warp-repeat-until-timer-greater-than.sb3.tw-snapshot
@@ -3,18 +3,16 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, "e", null);
+runtime.ext_scratch3_looks._say("plan 1", target);
 yield* thread.procedures["Wrun without screen refresh"]();
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "s", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 Wrun without screen refresh
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
 const b0 = stage.variables["F?*}X,`9XBpN_[piGRrz"];
-const b1 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ_run_without_screen_r () {
 b0.value = ((daysSince2000() * 86400) + 3);
 runtime.ioDevices.clock.resetProjectTimer();
@@ -22,7 +20,7 @@ while (!((runtime.ioDevices.clock.projectTimer() > 0.1) || compareGreaterThan((d
 if (isStuck()) yield;
 }
 if (compareLessThan((daysSince2000() * 86400), b0.value)) {
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b1, true, false, "u", null);
+runtime.ext_scratch3_looks._say("pass", target);
 }
 return "";
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-when-backdrop-switches-to-next-backdrop.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-when-backdrop-switches-to-next-backdrop.sb3.tw-snapshot
@@ -3,17 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "Ny4npe`j3|CTeaIS.:6O", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "2T.vCF,K}vA=XNZ=kY+v", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 runtime.ext_scratch3_looks._setBackdrop(stage, stage.currentCostume + 1, true);
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-when-backdrop-switches-to-switch-backdrop-to.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-when-backdrop-switches-to-switch-backdrop-to.sb3.tw-snapshot
@@ -3,17 +3,15 @@
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "Ny4npe`j3|CTeaIS.:6O", null);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 
 // Sprite1 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 0",}, b0, false, false, "2T.vCF,K}vA=XNZ=kY+v", null);
+runtime.ext_scratch3_looks._say("plan 0", target);
 runtime.ext_scratch3_looks._setBackdrop(stage, "backdrop2");
 retire(); return;
 }; })

--- a/test/snapshot/__snapshots__/warp-timer/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-zombie-cube-escape-284516654.sb3.tw-snapshot
@@ -3,19 +3,18 @@
 
 // Sprite2 script
 (function factoryXYZ(thread) { const target = thread.target; const runtime = target.runtime; const stage = runtime.getTargetForStage();
-const b0 = runtime.getOpcodeFunction("looks_say");
-const b1 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
-const b2 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
+const b0 = stage.variables["7qur6!bGgvC9I(Nd5.HP"];
+const b1 = stage.variables["sUOp@-6J4y0PqwiXit4!"];
 return function* genXYZ () {
-yield* executeInCompatibilityLayer({"MESSAGE":"plan 1",}, b0, false, false, ",a.euo_AgQTxR+D^x0M0", null);
-b1.value = 0;
-b2.value = "";
-while (!(("" + b2.value).toLowerCase() > "".toLowerCase())) {
+runtime.ext_scratch3_looks._say("plan 1", target);
+b0.value = 0;
+b1.value = "";
+while (!(("" + b1.value).toLowerCase() > "".toLowerCase())) {
 startHats("event_whenbroadcastreceived", { BROADCAST_OPTION: "step" });
 yield;
 }
-yield* executeInCompatibilityLayer({"MESSAGE":"pass",}, b0, false, false, "miAC8JZ$@akv[+}KR*@B", null);
-yield* executeInCompatibilityLayer({"MESSAGE":"end",}, b0, false, false, "gXJU#lhy3A3XA_s[-Xs$", null);
+runtime.ext_scratch3_looks._say("pass", target);
+runtime.ext_scratch3_looks._say("end", target);
 retire(); return;
 }; })
 


### PR DESCRIPTION
Closes https://github.com/TurboWarp/scratch-vm/issues/302

This benefits the internal test suite more than it benefits real projects. tw-comparison-matrix-runtime and tw-forkphorus-515-random-with-invalid-number-with-period both see some optimizations that couldn't before. It would allow putting more assertions in projects without having to worry about breaking the optimizations that a project is trying to test
