### PR TITLE
Update scratch-translate-extension-languages to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "immutable": "3.8.2",
         "scratch-parser": "github:TurboWarp/scratch-parser#master",
         "scratch-sb1-converter": "0.2.7",
-        "scratch-translate-extension-languages": "0.0.20191118205314",
+        "scratch-translate-extension-languages": "^1.0.7",
         "text-encoding": "0.7.0",
         "uuid": "8.3.2",
         "worker-loader": "^1.1.1"
@@ -13782,9 +13782,10 @@
       }
     },
     "node_modules/scratch-translate-extension-languages": {
-      "version": "0.0.20191118205314",
-      "resolved": "https://registry.npmjs.org/scratch-translate-extension-languages/-/scratch-translate-extension-languages-0.0.20191118205314.tgz",
-      "integrity": "sha512-r0lvpgQjPMjbhI2wROrgoXzBhCvWJdkbAqJMfl2CdNqrwBpUXqLvNNtI3VtNLPJAcp9VfxEylkU9lVZ0gvU46Q=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/scratch-translate-extension-languages/-/scratch-translate-extension-languages-1.0.7.tgz",
+      "integrity": "sha512-6+bQU9iVYv23T8J0SjpV6MTugm0y8myh/4DPgu1BGfccysdkaWzu3MkNGQyQRUlbqAiW9wM7ctfv3USPEkzTgg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/script-loader": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "immutable": "3.8.2",
     "scratch-parser": "github:TurboWarp/scratch-parser#master",
     "scratch-sb1-converter": "0.2.7",
-    "scratch-translate-extension-languages": "0.0.20191118205314",
+    "scratch-translate-extension-languages": "^1.0.7",
     "text-encoding": "0.7.0",
     "uuid": "8.3.2",
     "worker-loader": "^1.1.1"

--- a/test/unit/extension_text_to_speech.js
+++ b/test/unit/extension_text_to_speech.js
@@ -39,6 +39,6 @@ test('use localized spoken language name in place of localized written language 
     ext.getEditorLanguage = () => 'es';
     const languageMenu = ext.getLanguageMenu();
     const localizedNameForChineseInSpanish = languageMenu.find(el => el.value === 'zh-cn').text;
-    t.strictEqual(localizedNameForChineseInSpanish, 'Chino (Mandarín)'); // i.e. should not be 'Chino (simplificado)'
+    t.strictEqual(localizedNameForChineseInSpanish, 'Chino (mandarín)'); // i.e. should not be 'Chino (simplificado)'
     t.end();
 });


### PR DESCRIPTION
Fixes https://github.com/TurboWarp/scratch-vm/issues/312 probably

Diff: https://github.com/TurboWarp/scratch-translate-extension-languages-mirror/compare/2a577c9924fd74e48a7434cd87e495b1be4560a9...7302daf7d73a775d12322216ea3de130d811b226