### PR TITLE
Fix evalAndReturn with comments at the bottom of a script

### DIFF
--- a/src/extension-support/tw-external.js
+++ b/src/extension-support/tw-external.js
@@ -79,7 +79,7 @@ external.blob = async url => {
 external.evalAndReturn = async (url, returnExpression) => {
     const res = await external.fetch(url);
     const text = await res.text();
-    const js = `${text};return ${returnExpression}`;
+    const js = `${text}\nreturn ${returnExpression};`;
     const fn = new Function(js);
     return fn();
 };

--- a/test/unit/tw_external.js
+++ b/test/unit/tw_external.js
@@ -50,6 +50,13 @@ test('evalAndReturn', t => {
     });
 });
 
+test('evalAndReturn with a trailing comment without newline', t => {
+    external.evalAndReturn('data:text/plain;,var%20x=20 // whatever', 'x').then(result => {
+        t.equal(result, 20);
+        t.end();
+    });
+});
+
 test('relative URL throws', t => {
     external.fetch('./test.js').catch(err => {
         t.equal(err.message, `Unsupported URL: ./test.js`);


### PR DESCRIPTION
This is because beepbox's script:
https://cdn.jsdelivr.net/npm/beepbox@4.2.0/global/beepbox_synth.min.js has a sourceMappingURL comment at the bottom for whatever reason, causing it to become
//# sourceMappingURL=beepbox_synth.min.js.map;return beepbox; This is obviously going to break and might also be the case with other libraries too, hot just beepbox.

So this PR changes it to add a newline before the `return` and also adds a semicolon after the return for compatibility with old js engines that don't support automatic semicolon injection.

Ported from AmpMod:
https://codeberg.org/ampmod/ampmod/commit/0daf1021bdc8e67a1f0d08b91ce500605fcaa711
I mostly made it specifically for AmpMod but it will definitely be useful for others who don't understand why evalAndReturn doesn't work sometimes.