### PR TITLE
Slight jsexecute.js improvements

### DIFF
--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -338,7 +338,7 @@ runtimeFunctions.compareLessThan = `const compareLessThanSlow = (v1, v2) => {
     }
     return n1 < n2;
 };
-const compareLessThan = (v1, v2) => typeof v1 === 'number' && typeof v2 === 'number' && !Number.isNaN(v2) ? v1 < v2 : compareLessThanSlow(v1, v2)`;
+const compareLessThan = (v1, v2) => typeof v1 === 'number' && typeof v2 === 'number' && !Number.isNaN(v2) ? v1 < v2 : compareLessThanSlow(v1, v2);`;
 
 /**
  * Generate a random integer.
@@ -411,26 +411,25 @@ runtimeFunctions.distance = `const distance = menu => {
  * @returns {number} 0 based list index, or -1 if invalid.
  */
 baseRuntime += `const listIndexSlow = (index, length) => {
-    if (index === 'last') {
-        return length - 1;
-    } else if (index === 'random' || index === 'any') {
-        if (length > 0) {
-            return (Math.random() * length) | 0;
-        }
-        return -1;
-    }
-    index = (+index || 0) | 0;
-    if (index < 1 || index > length) {
-        return -1;
-    }
-    return index - 1;
+    switch(index) {
+        case 'last':
+            return length - 1;
+        case 'any':
+        case 'random':
+            return (length > 0) ? ((Math.random() * length) | 0) : -1;
+        default:
+            index = (+index || 0) | 0;
+            return (index < 1 || index > length) ? -1: index - 1;
+    }    
 };
+
 const listIndex = (index, length) => {
-    if (typeof index !== 'number') {
-      return listIndexSlow(index, length);
+    /* expect best case since 'random', 'last', and 'any' are never usually used by people */
+    if (typeof index === 'number') {
+        index = index | 0;
+        return index < 1 || index > length ? -1 : index - 1;
     }
-    index = index | 0;
-    return index < 1 || index > length ? -1 : index - 1;
+    return listIndexSlow(index, length);
 };`;
 
 /**

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -501,7 +501,10 @@ runtimeFunctions.listDelete = `const listDelete = (list, idx) => {
  * @returns {boolean} True if the list contains the item
  */
 runtimeFunctions.listContains = `const listContains = (list, item) => {
-    /* using indexOf then checking using compareEqual is terrible for performance. indexOf isn't reliable anyways */
+    if (list.value.indexOf(item) !== -1) {
+        return true;
+    }
+    /* i stand corrected */
     for (let i = 0; i < list.value.length; i++) {
         if (compareEqual(list.value[i], item)) {
             return true;

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -424,7 +424,7 @@ baseRuntime += `const listIndexSlow = (index, length) => {
 };
 
 const listIndex = (index, length) => {
-    /* expect best case since 'random', 'last', and 'any' are never usually used by people */
+    /* expect a number instead since barely anyone uses a string */
     if (typeof index === 'number') {
         index = index | 0;
         return index < 1 || index > length ? -1 : index - 1;
@@ -501,10 +501,7 @@ runtimeFunctions.listDelete = `const listDelete = (list, idx) => {
  * @returns {boolean} True if the list contains the item
  */
 runtimeFunctions.listContains = `const listContains = (list, item) => {
-    // TODO: evaluate whether indexOf is worthwhile here
-    if (list.value.indexOf(item) !== -1) {
-        return true;
-    }
+    /* using indexOf then checking using compareEqual is terrible for performance. indexOf isn't reliable anyways */
     for (let i = 0; i < list.value.length; i++) {
         if (compareEqual(list.value[i], item)) {
             return true;


### PR DESCRIPTION
I made super small improvements to ``listIndex()``, and ``listIndexSlow()``.

``listIndex()`` no longer expects a string index first because numbers are more usually passed than 'last', or anything similar.
``listIndexSlow()`` is more concise.

Also, checking with ``indexOf()`` first in ``listContains()`` *is* faster than only using ``compareEqual()``. I was clearly on *something* last night..