### PR TITLE
Don't allow reading video motion when external communication is possible

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -506,6 +506,12 @@ class Runtime extends EventEmitter {
         this.enforcePrivacy = true;
 
         /**
+         * If true, an external communication method exists and enforcePrivacy is enabled.
+         * Do not update this directly. Must be changed via public functions that call Runtime.updatePrivacy().
+         */
+        this.privacyRestrictionsActive = false;
+
+        /**
          * Internal map of opaque identifiers to the callback to run that function.
          * @type {Map<string, function>}
          */
@@ -3420,12 +3426,12 @@ class Runtime extends EventEmitter {
     }
 
     updatePrivacy () {
-        const enforceRestrictions = (
+        this.privacyRestrictionsActive = (
             this.enforcePrivacy &&
             Object.values(this.externalCommunicationMethods).some(i => i)
         );
         if (this.renderer && this.renderer.setPrivateSkinAccess) {
-            this.renderer.setPrivateSkinAccess(!enforceRestrictions);
+            this.renderer.setPrivateSkinAccess(!this.privacyRestrictionsActive);
         }
     }
 

--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -531,6 +531,10 @@ class Scratch3VideoSensingBlocks {
      * @returns {number} the motion amount or direction of the stage or sprite
      */
     videoOn (args, util) {
+        if (this.runtime.privacyRestrictionsActive) {
+            return -1;
+        }
+
         this.detect.analyzeFrame();
 
         let state = this.detect;
@@ -554,6 +558,10 @@ class Scratch3VideoSensingBlocks {
      *   reference
      */
     whenMotionGreaterThan (args, util) {
+        if (this.runtime.privacyRestrictionsActive) {
+            return false;
+        }
+
         this.detect.analyzeFrame();
         const state = this._analyzeLocalMotion(util.target);
         return state.motionAmount > Number(args.REFERENCE);

--- a/test/integration/tw_privacy.js
+++ b/test/integration/tw_privacy.js
@@ -114,3 +114,17 @@ test('custom extensions', async t => {
     t.equal(vm.renderer.privateSkinAccess, false);
     t.end();
 });
+
+test('hasExternalCommunicationMethod', t => {
+    const vm = new VM();
+    t.equal(vm.runtime.privacyRestrictionsActive, false);
+    vm.runtime.setExternalCommunicationMethod('cloudVariables', true);
+    t.equal(vm.runtime.privacyRestrictionsActive, true);
+    vm.runtime.setExternalCommunicationMethod('customExtensions', true);
+    t.equal(vm.runtime.privacyRestrictionsActive, true);
+    vm.runtime.setExternalCommunicationMethod('cloudVariables', false);
+    t.equal(vm.runtime.privacyRestrictionsActive, true);
+    vm.runtime.setExternalCommunicationMethod('customExtensions', false);
+    t.equal(vm.runtime.privacyRestrictionsActive, false);
+    t.end();
+});


### PR DESCRIPTION
Can't have nice things.

This is consistent with us making the webcam images exempted from `touching color`. Now we're just removing the last side channel that lets people read silhouettes out. From the project's perspective it'll just look like there isn't a webcam connected.

The blocks would still work in the packager.