### PR TITLE
Fix indefinite calls to analyzeScript when a large amount of procedures interlink

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -1459,7 +1459,7 @@ class IRGenerator {
         /** @type {Object.<string, IntermediateScript>} */
         this.procedures = {};
 
-        this.analyzedProcedures = [];
+        this.analyzedProcedures = new Set();
     }
 
     addProcedureDependencies (dependencies) {
@@ -1500,12 +1500,11 @@ class IRGenerator {
             const procedureData = this.procedures[procedureCode];
 
             // Analyze newly found procedures.
-            if (!this.analyzedProcedures.includes(procedureCode)) {
-                this.analyzedProcedures.push(procedureCode);
+            if (!this.analyzedProcedures.has(procedureCode)) {
+                this.analyzedProcedures.add(procedureCode);
                 if (this.analyzeScript(procedureData)) {
                     madeChanges = true;
                 }
-                this.analyzedProcedures.pop();
             }
 
             // If a procedure used by a script may yield, the script itself may yield.
@@ -1548,7 +1547,10 @@ class IRGenerator {
         }
 
         // Analyze scripts until no changes are made.
-        while (this.analyzeScript(entry));
+        while (this.analyzeScript(entry)) {
+            // Reset so all procedures get re-examined each pass.
+            this.analyzedProcedures = new Set();
+        }
 
         return new IntermediateRepresentation(entry, this.procedures);
     }


### PR DESCRIPTION
Currently `analyzeScript` in `irgen.js` looks at every possible (non-recursive) path, which for some projects can cause turbowarp to stall indefinitely (such as in the C compiler I am writing which uses procedures for every branch instruction).
<img width="1050" height="482" alt="Screenshot 2026-04-09 at 18 10 46" src="https://github.com/user-attachments/assets/24326041-2b54-4b33-a8d0-2f70092d2fe0" />

In commit 16e749dabf4dd78eab21fdcbbfd23bc585777ede the line `this.analyzedProcedures.pop();` was added as a hotfix to prevent a bug where recursive procedures where analyzed incorrectly (see the comment in that commit). This prevents the bug but has the side effect of causing the function to traverse already explored paths, which for projects where multiple procedures can be called in any order (such as with my function pointer implementation) can give this `O(n!)` complexity, preventing them from compiling in a reasonable amount of time.

The fix is to revert this change and fix the root cause of the bug, which is to reset `analyzedProcedures` before `analyzeScript` is called subsequently.

The code which causes the error is attached (it needs to be renamed to `demo.sprite3` before use). Note that to prevent insane rendering lag, the code uses `shadow: true` on all top level blocks, so no blocks will be visible in the editor.
[demo.zip](https://github.com/user-attachments/files/26614027/demo.zip)