### PR TITLE
Use inline modulo calculation when modulus is known

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ npm-*
 # Editor
 /.idea
 /.vscode
+/.zed
 
 # Build
 /dist

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -121,10 +121,8 @@ class Scratch3OperatorsBlocks {
     mod (args) {
         const n = Cast.toNumber(args.NUM1);
         const modulus = Cast.toNumber(args.NUM2);
-        let result = n % modulus;
         // Scratch mod uses floored division instead of truncated division.
-        if (result / modulus < 0) result += modulus;
-        return result;
+        return ((n % modulus) + modulus) % modulus;
     }
 
     round (args) {

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -560,9 +560,7 @@ runtimeFunctions.colorToList = `const colorToList = color => globalState.Cast.to
  * @returns {number} n % modulus (floored division)
  */
 runtimeFunctions.mod = `const mod = (n, modulus) => {
-    let result = n % modulus;
-    if (result / modulus < 0) result += modulus;
-    return result;
+    return (n % modulus + modulus) % modulus;
 }`;
 
 /**

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -364,6 +364,13 @@ class JSGenerator {
             return `(Math.log(${this.descendInput(node.value)}) / Math.LN10)`;
         case InputOpcode.OP_MOD:
             this.descendedIntoModulo = true;
+            if (node.right.opcode === InputOpcode.CONSTANT) {
+                const modulus = this.descendInput(node.right);
+                // Modulo using remainder operation: (left % modulus + modulus) % modulus
+                // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder
+                // Referencing the modulus multiple times here is fine because it is constant
+                return `((${this.descendInput(node.left)} % ${modulus} + ${modulus}) % ${modulus})`;
+            }
             return `mod(${this.descendInput(node.left)}, ${this.descendInput(node.right)})`;
         case InputOpcode.OP_MULTIPLY:
             return `(${this.descendInput(node.left)} * ${this.descendInput(node.right)})`;

--- a/test/snapshot/__snapshots__/tw-NaN.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/tw-NaN.sb3.tw-snapshot
@@ -38,10 +38,10 @@ runtime.ext_scratch3_looks._say("pass", target);
 if (((toNotNaN(Math.sqrt(-1)) * 1) === 0)) {
 runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
+if ((("" + ((0 % 0 + 0) % 0)).toLowerCase() === "NaN".toLowerCase())) {
 runtime.ext_scratch3_looks._say("pass", target);
 }
-if (((toNotNaN(mod(0, 0)) * 1) === 0)) {
+if (((toNotNaN(((0 % 0 + 0) % 0)) * 1) === 0)) {
 runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {

--- a/test/snapshot/__snapshots__/warp-timer/tw-NaN.sb3.tw-snapshot
+++ b/test/snapshot/__snapshots__/warp-timer/tw-NaN.sb3.tw-snapshot
@@ -38,10 +38,10 @@ runtime.ext_scratch3_looks._say("pass", target);
 if (((toNotNaN(Math.sqrt(-1)) * 1) === 0)) {
 runtime.ext_scratch3_looks._say("pass", target);
 }
-if ((("" + mod(0, 0)).toLowerCase() === "NaN".toLowerCase())) {
+if ((("" + ((0 % 0 + 0) % 0)).toLowerCase() === "NaN".toLowerCase())) {
 runtime.ext_scratch3_looks._say("pass", target);
 }
-if (((toNotNaN(mod(0, 0)) * 1) === 0)) {
+if (((toNotNaN(((0 % 0 + 0) % 0)) * 1) === 0)) {
 runtime.ext_scratch3_looks._say("pass", target);
 }
 if ((("" + Math.log(-1)).toLowerCase() === "NaN".toLowerCase())) {


### PR DESCRIPTION
The modulo reporter internally uses a function call to `mod()`, which is very expensive for a basic math operation.

Per my (very crude) performance test, the modulo operation is very expensive, taking 6.531s in 5,000,000 iterations when JIT is disabled, several times more expensive than other blocks (e.g. floor is 0.843s).

<details>
<summary>Said crude performance test</summary>

```
time (s) per 5,000,000 iterations (JIT + Warp Timer disabled):

set var:   1.307
change vr: 5.719
get var:   0.495 (interesting a lot higher when modifing the same value at 4.203)
get param: 3.796

add:       0.002
sub:       0.002
mul:       0.002
div:       0.002
mod:       6.531 (3.654 when modulus is known with my PR)
rand:      3.599
not:       0.002
and:       0.002
or:        0.002
eq:        0.418
abs:       0.847
floor:     0.843
ceil:      0.844
sqrt:      4.589
sin:       7.505
cos:       7.527
tan:       11.125
asin:      5.656
acos:      5.779
atan:      2.513
ln:        4.981
log:       5.694
e ^:       1.803
10 ^:      0.028
join:      0.006
letter of: 0.679
length of: 0.136
cntin str: 3.853 (changes with contents)
round int: 0.889
round flt: 0.583

get list:  31.636 (changes with contents)
item:      4.388
item #:    35.467  (changes with contents)
length:    0.610

counter:   0.544
incr cnt:  2.020

answer:    0.426

cost num:  0.807
cost name: 3.007
```

</details>

When the modulus is a constant (which is most of the time), there is no additional cost in referencing it multiple times. Therefore we can use the equation `mod(a, b) = rem(rem(a, b) + b, b)` inline and avoid the overhead of making a function call.

This makes it run ~2x as fast (3.654s vs 6.531s before) when modulus is known. My SHA256 implementation compiled from C (which makes heavy use of modulo) now runs at ~2560 Hz (~1790 Hz before).

One side effect of this is now `0 mod -1` returns `-0`, not `0`, which affects the value shown when clicking on the reporter and list displays. Though I take you're not aiming for parity over this with scratch as `0 / -1` has the same problem.

Adding zero to the end of the expression would return `0` as expected, would that be preferred?